### PR TITLE
Fix Windows review issue #1

### DIFF
--- a/crates/codex-win-engine/src/authenticode.rs
+++ b/crates/codex-win-engine/src/authenticode.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::EngineError;
 
+// The mirror currently serves Store-re-signed MSIX packages; add a separate
+// exact direct-signing anchor here if the Windows source changes in the future.
 pub const OPENAI_MARKETPLACE_PUBLISHER_SUBJECT: &str =
     "cn=50bdfd77-8903-4850-9ffe-6e8522f64d5b";
 #[cfg(any(windows, test))]

--- a/crates/codex-win-engine/src/authenticode.rs
+++ b/crates/codex-win-engine/src/authenticode.rs
@@ -8,12 +8,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::EngineError;
 
-pub const OPENAI_PUBLISHER_NEEDLE: &str = "openai";
-#[cfg(windows)]
 pub const OPENAI_MARKETPLACE_PUBLISHER_SUBJECT: &str =
     "cn=50bdfd77-8903-4850-9ffe-6e8522f64d5b";
-#[cfg(windows)]
-const MICROSOFT_MARKETPLACE_ISSUER_NEEDLE: &str = "microsoft marketplace";
+#[cfg(any(windows, test))]
+const MICROSOFT_MARKETPLACE_ISSUER_CN_PREFIX: &str = "cn=microsoft marketplace ca";
+#[cfg(any(windows, test))]
+const MICROSOFT_MARKETPLACE_ISSUER_ORG: &str = "o=microsoft corporation";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -38,7 +38,33 @@ fn ps_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, test))]
+fn normalized_dn_components(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(|component| component.trim().to_ascii_lowercase())
+        .filter(|component| !component.is_empty())
+        .collect()
+}
+
+#[cfg(any(windows, test))]
+fn has_pinned_marketplace_issuer(issuer: &str) -> bool {
+    let components = normalized_dn_components(issuer);
+    components
+        .iter()
+        .any(|component| component.starts_with(MICROSOFT_MARKETPLACE_ISSUER_CN_PREFIX))
+        && components
+            .iter()
+            .any(|component| component == MICROSOFT_MARKETPLACE_ISSUER_ORG)
+}
+
+#[cfg(any(windows, test))]
+fn is_pinned_openai_publisher(subject: &str, issuer: &str) -> bool {
+    let subject = subject.trim().to_ascii_lowercase();
+    subject == OPENAI_MARKETPLACE_PUBLISHER_SUBJECT && has_pinned_marketplace_issuer(issuer)
+}
+
+#[cfg(any(windows, test))]
 fn report_from_json(json: &str) -> Result<AuthenticodeReport, EngineError> {
     let value: serde_json::Value = serde_json::from_str(json)
         .map_err(|e| EngineError::Authenticode(format!("PowerShell JSON: {e}")))?;
@@ -52,11 +78,7 @@ fn report_from_json(json: &str) -> Result<AuthenticodeReport, EngineError> {
     let status = s("status");
     let subject = s("subject");
     let issuer = s("issuer");
-    let subject_lower = subject.to_ascii_lowercase();
-    let issuer_lower = issuer.to_ascii_lowercase();
-    let publisher_is_openai = subject_lower.contains(OPENAI_PUBLISHER_NEEDLE)
-        || (subject_lower == OPENAI_MARKETPLACE_PUBLISHER_SUBJECT
-            && issuer_lower.contains(MICROSOFT_MARKETPLACE_ISSUER_NEEDLE));
+    let publisher_is_openai = is_pinned_openai_publisher(&subject, &issuer);
 
     Ok(AuthenticodeReport {
         trusted: status.eq_ignore_ascii_case("Valid"),
@@ -133,12 +155,10 @@ pub fn verify_openai_authenticode(_path: &Path) -> Result<AuthenticodeReport, En
 
 #[cfg(test)]
 mod tests {
-    #[cfg(windows)]
     use super::report_from_json;
 
-    #[cfg(windows)]
     #[test]
-    fn parses_valid_openai_signature_report() {
+    fn rejects_direct_openai_subject_without_marketplace_anchor() {
         let report = report_from_json(
             r#"{
               "status":"Valid",
@@ -149,10 +169,9 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(report.is_valid_openai());
+        assert!(!report.is_valid_openai());
     }
 
-    #[cfg(windows)]
     #[test]
     fn accepts_current_store_publisher_guid_for_codex() {
         let report = report_from_json(
@@ -166,5 +185,20 @@ mod tests {
         )
         .unwrap();
         assert!(report.is_valid_openai());
+    }
+
+    #[test]
+    fn rejects_marketplace_subject_with_wrong_issuer() {
+        let report = report_from_json(
+            r#"{
+              "status":"Valid",
+              "statusMessage":"Signature verified.",
+              "subject":"CN=50BDFD77-8903-4850-9FFE-6E8522F64D5B",
+              "issuer":"CN=Contoso Marketplace CA, O=Contoso, C=US",
+              "thumbprint":"ABC"
+            }"#,
+        )
+        .unwrap();
+        assert!(!report.is_valid_openai());
     }
 }

--- a/crates/codex-win-engine/src/download.rs
+++ b/crates/codex-win-engine/src/download.rs
@@ -12,6 +12,25 @@ use crate::EngineError;
 static DOWNLOAD_ACTIVE: AtomicBool = AtomicBool::new(false);
 static DOWNLOAD_CANCELLED: AtomicBool = AtomicBool::new(false);
 
+struct DownloadGuard;
+
+impl DownloadGuard {
+    fn acquire() -> Result<Self, String> {
+        DOWNLOAD_CANCELLED.store(false, Ordering::SeqCst);
+        DOWNLOAD_ACTIVE
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map(|_| Self)
+            .map_err(|_| "another Windows package download is already active".to_string())
+    }
+}
+
+impl Drop for DownloadGuard {
+    fn drop(&mut self) {
+        DOWNLOAD_ACTIVE.store(false, Ordering::SeqCst);
+        DOWNLOAD_CANCELLED.store(false, Ordering::SeqCst);
+    }
+}
+
 pub fn cancel_active_download() -> bool {
     let active = DOWNLOAD_ACTIVE.load(Ordering::SeqCst);
     if active {
@@ -46,7 +65,6 @@ fn run_curl(url: &str, dest: &Path, resume: bool) -> Result<(), String> {
     }
     args.extend(["-o".to_string(), dest, url.to_string()]);
 
-    DOWNLOAD_CANCELLED.store(false, Ordering::SeqCst);
     let mut child = Command::new("curl")
         .args(args)
         .stdout(Stdio::piped())
@@ -54,12 +72,10 @@ fn run_curl(url: &str, dest: &Path, resume: bool) -> Result<(), String> {
         .spawn()
         .map_err(|e| format!("spawn curl: {e}"))?;
 
-    DOWNLOAD_ACTIVE.store(true, Ordering::SeqCst);
     loop {
         if DOWNLOAD_CANCELLED.load(Ordering::SeqCst) {
             let _ = child.kill();
             let _ = child.wait();
-            DOWNLOAD_ACTIVE.store(false, Ordering::SeqCst);
             return Err("download cancelled".to_string());
         }
         match child.try_wait() {
@@ -67,7 +83,6 @@ fn run_curl(url: &str, dest: &Path, resume: bool) -> Result<(), String> {
             Ok(None) => thread::sleep(Duration::from_millis(200)),
             Err(err) => {
                 let _ = child.kill();
-                DOWNLOAD_ACTIVE.store(false, Ordering::SeqCst);
                 return Err(format!("wait for curl: {err}"));
             }
         }
@@ -75,12 +90,8 @@ fn run_curl(url: &str, dest: &Path, resume: bool) -> Result<(), String> {
 
     let output = match child.wait_with_output() {
         Ok(output) => output,
-        Err(err) => {
-            DOWNLOAD_ACTIVE.store(false, Ordering::SeqCst);
-            return Err(format!("collect curl output: {err}"));
-        }
+        Err(err) => return Err(format!("collect curl output: {err}")),
     };
-    DOWNLOAD_ACTIVE.store(false, Ordering::SeqCst);
 
     if !output.status.success() {
         return Err(format!(
@@ -92,6 +103,10 @@ fn run_curl(url: &str, dest: &Path, resume: bool) -> Result<(), String> {
 }
 
 pub fn download_to(url: &str, dest: &Path) -> Result<(), EngineError> {
+    // The manager has one Windows package staging slot. Serialize downloads so
+    // auto-stage and manual-stage cannot reset each other's cancel flag.
+    let _guard = DownloadGuard::acquire().map_err(EngineError::Io)?;
+
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| EngineError::Io(format!("create staging dir: {e}")))?;
@@ -146,4 +161,18 @@ pub fn sha256_file(path: &Path) -> Result<String, EngineError> {
         hasher.update(&buf[..read]);
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn download_guard_rejects_concurrent_downloads() {
+        let guard = DownloadGuard::acquire().unwrap();
+        assert!(cancel_active_download());
+        assert!(DownloadGuard::acquire().is_err());
+        drop(guard);
+        assert!(!cancel_active_download());
+    }
 }

--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -22,7 +22,9 @@ pub mod portable;
 pub mod sys;
 pub mod version;
 
-pub use authenticode::{verify_openai_authenticode, AuthenticodeReport, OPENAI_PUBLISHER_NEEDLE};
+pub use authenticode::{
+    verify_openai_authenticode, AuthenticodeReport, OPENAI_MARKETPLACE_PUBLISHER_SUBJECT,
+};
 pub use capability::{
     CapabilityCheck, CapabilityState, SideloadRecommendation, WinCapabilityReport,
 };

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -70,7 +70,7 @@ fn extract_msix(msix_path: &Path, dest: &Path) -> Result<String, EngineError> {
         let mut file = zip
             .by_index(idx)
             .map_err(|e| EngineError::Msix(format!("read zip entry {idx}: {e}")))?;
-        let Some(enclosed) = file.enclosed_name().map(PathBuf::from) else {
+        let Some(enclosed) = file.enclosed_name() else {
             continue;
         };
         let out_path = dest.join(&enclosed);
@@ -196,6 +196,7 @@ fn request_codex_close_filtered(timeout_secs: u64, root: Option<&Path>) -> Resul
     let root_filter = root
         .map(|path| ps_quote(&path.to_string_lossy()))
         .unwrap_or_else(|| "$null".to_string());
+    let timeout = timeout_secs;
     let script = format!(
         r#"
 $RootFilter = {root_filter}
@@ -245,9 +246,7 @@ while ((Get-Date) -lt $deadline) {{
   }}
 }}
 'running:' + (($remaining | ForEach-Object {{ $_.Id }}) -join ',')
-"#,
-        root_filter = root_filter,
-        timeout = timeout_secs
+"#
     );
     let result = run_powershell(&script)?;
     if result.trim().ends_with("closed") || result.trim().ends_with("no-targets") {

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -440,6 +440,50 @@ fn dir_size_kb(root: &Path) -> u64 {
     total / 1024
 }
 
+fn restore_previous_install(
+    install_root: &Path,
+    backup: &Path,
+    had_previous: bool,
+) -> Result<(), EngineError> {
+    if install_root.exists() {
+        fs::remove_dir_all(install_root).map_err(|e| io_err("remove failed portable install", e))?;
+    }
+    if had_previous && backup.exists() {
+        fs::rename(backup, install_root)
+            .map_err(|e| io_err("restore portable rollback backup", e))?;
+    }
+    Ok(())
+}
+
+fn rollback_install_error(
+    install_root: &Path,
+    backup: &Path,
+    had_previous: bool,
+    err: EngineError,
+) -> EngineError {
+    match restore_previous_install(install_root, backup, had_previous) {
+        Ok(()) => EngineError::Install(format!("{err}; previous install was restored")),
+        Err(rollback_err) => EngineError::Install(format!("{err}; rollback failed: {rollback_err}")),
+    }
+}
+
+fn health_check_portable_install(install_root: &Path, launch: bool) -> Result<bool, EngineError> {
+    let exe = install_root.join("Codex.exe");
+    if !exe.is_file() {
+        return Err(EngineError::Install(format!(
+            "portable health check failed: {} is missing",
+            exe.display()
+        )));
+    }
+    if !launch {
+        return Ok(false);
+    }
+    Command::new(&exe)
+        .spawn()
+        .map(|_| true)
+        .map_err(|e| io_err("portable health check launch", e))
+}
+
 pub fn install_portable_from_msix(
     msix_path: &Path,
     install_root: &Path,
@@ -486,12 +530,24 @@ fn install_portable_from_msix_inner(
     match fs::rename(&payload, install_root) {
         Ok(()) => {}
         Err(err) => {
-            if had_previous {
-                let _ = fs::rename(&backup, install_root);
-            }
+            let _ = restore_previous_install(install_root, &backup, had_previous);
             return Err(io_err("install portable payload (rolled back)", err));
         }
     }
+
+    let relaunched =
+        match health_check_portable_install(install_root, manage_process && relaunch) {
+            Ok(relaunched) => relaunched,
+            Err(err) => {
+                let _ = fs::remove_dir_all(&work_dir);
+                return Err(rollback_install_error(
+                    install_root,
+                    &backup,
+                    had_previous,
+                    err,
+                ));
+            }
+        };
 
     let shortcut_created = match create_start_menu_shortcut(install_root) {
         Ok(created) => created,
@@ -515,15 +571,16 @@ fn install_portable_from_msix_inner(
     };
 
     let exe = install_root.join("Codex.exe");
-    let mut relaunched = false;
-    if relaunch && exe.exists() {
-        match Command::new(&exe).spawn() {
-            Ok(_) => {
-                relaunched = true;
+    let mut backup_path = None;
+    if had_previous && backup.exists() {
+        match fs::remove_dir_all(&backup) {
+            Ok(()) => {}
+            Err(err) => {
+                notes.push(format!(
+                    "Portable rollback backup could not be removed after successful install: {err}"
+                ));
+                backup_path = Some(backup.to_string_lossy().into_owned());
             }
-            Err(err) => notes.push(format!(
-                "Codex was installed but could not be relaunched: {err}"
-            )),
         }
     }
 
@@ -534,7 +591,7 @@ fn install_portable_from_msix_inner(
         install_root: install_root.to_string_lossy().into_owned(),
         executable_path: exe.exists().then(|| exe.to_string_lossy().into_owned()),
         version: prepared.identity.version,
-        backup_path: had_previous.then(|| backup.to_string_lossy().into_owned()),
+        backup_path,
         shortcut_created,
         uninstall_entry_created,
         relaunched,
@@ -628,6 +685,56 @@ mod tests {
         assert!(install_root.join("resources/app.asar").exists());
         assert!(install_root.join("AppxManifest.xml").exists());
         assert_eq!(report.version, "26.602.3474.0");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn replaces_existing_portable_and_removes_rollback_backup() {
+        let root = std::env::temp_dir().join(format!(
+            "codex-portable-replace-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let msix = root.join("codex.msix");
+        let install_root = root.join("Codex");
+        write_fake_msix(&msix);
+
+        fs::create_dir_all(&install_root).unwrap();
+        fs::write(install_root.join("Codex.exe"), b"old exe").unwrap();
+        fs::write(install_root.join("old-marker.txt"), b"old").unwrap();
+
+        let report = install_portable_from_msix_inner(&msix, &install_root, false, false).unwrap();
+        assert!(report.success);
+        assert!(report.backup_path.is_none());
+        assert!(!root.join("Codex.rollback").exists());
+        assert!(!install_root.join("old-marker.txt").exists());
+        assert!(install_root.join("resources/app.asar").exists());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn restore_previous_install_removes_failed_payload() {
+        let root = std::env::temp_dir().join(format!(
+            "codex-portable-rollback-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let install_root = root.join("Codex");
+        let backup = root.join("Codex.rollback");
+
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("old-marker.txt"), b"old").unwrap();
+        fs::create_dir_all(&install_root).unwrap();
+        fs::write(install_root.join("new-marker.txt"), b"new").unwrap();
+
+        restore_previous_install(&install_root, &backup, true).unwrap();
+        assert!(install_root.join("old-marker.txt").exists());
+        assert!(!install_root.join("new-marker.txt").exists());
+        assert!(!backup.exists());
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -433,6 +433,7 @@ fn capabilities_from_probe_json(value: &serde_json::Value) -> WinCapabilityRepor
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
     use super::*;
 
     #[cfg(windows)]


### PR DESCRIPTION
Fixes #1.

## What changed
- Pin Windows Authenticode to the real Store re-signing anchor: subject `CN=50BDFD77-8903-4850-9FFE-6E8522F64D5B` plus Microsoft Marketplace issuer/org, removing the loose `contains("openai")` branch.
- Add portable swap health checking and rollback: after publishing the new payload, verify `Codex.exe` exists and launch it when the install flow asks for relaunch; restore `Codex.rollback` on failure and remove the backup on success.
- Serialize Windows package downloads with a guard so auto-stage/manual-stage cannot reset each other's cancel flag.
- Clean clippy/cross-target warnings in the Windows engine.

## Real package notes
- Latest and old staged MSIX packages both hit the Store re-sign branch, not the direct OpenAI OpCo branch.
- Observed latest signer: subject `CN=50BDFD77-8903-4850-9FFE-6E8522F64D5B`, issuer `CN=Microsoft Marketplace CA G 028, OU=EOC, O=Microsoft Corporation, L=Redmond, S=Washington, C=US`.
- Observed old signer: same subject/issuer family with a different thumbprint, so thumbprint is intentionally not pinned.
- Latest MSIX layout keeps the runnable payload under `app/`, including `app/Codex.exe` and `app/resources/...`, so copying the `Codex.exe` directory remains the right portable extraction boundary.

## Verification
- `cargo test` in `crates/codex-win-engine`
- `cargo clippy --all-targets -- -D warnings` in `crates/codex-win-engine`
- `cargo test` in `src-tauri`
- `npm run build`
- `cargo check --target x86_64-apple-darwin` in `crates/codex-win-engine`
- `cargo check --target aarch64-apple-darwin` in `crates/codex-win-engine`
- `cargo run --bin win_real_smoke -- status` in `src-tauri` (read-only)

I did not run the destructive portable smoke in this PR pass because this machine currently has a managed latest MSIX install, and that smoke path starts by uninstalling any detected Windows Codex install.

The full `src-tauri` macOS cross-target check is blocked on this Windows machine by missing `cc` for `objc2-exception-helper`; the engine crate itself checks cleanly for both macOS targets.