### PR TITLE
[codex] Add Windows portable install location picker

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -365,9 +365,11 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "thiserror 2.0.18",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2797,6 +2799,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,6 +3685,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "2.11.2", features = ["tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-autostart = "2"
+tauri-plugin-dialog = "2.7.1"
 tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 thiserror = "2.0"
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,8 +7,8 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-close",
+    "dialog:allow-open",
     "updater:default",
     "process:default"
   ]
 }
-

--- a/src-tauri/src/app/settings_store.rs
+++ b/src-tauri/src/app/settings_store.rs
@@ -4,7 +4,10 @@
 //! Codex bundle), mirroring `provenance::ProvenanceStore`.
 
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
+use crate::adapters::host;
+use crate::domain::target::Target;
 use crate::errors::AppError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,6 +28,10 @@ pub struct AppSettings {
     /// still fall back to portable when the machine blocks sideloading.
     #[serde(default = "default_windows_install_mode")]
     pub windows_install_mode: String,
+    /// Portable Windows install root. Kept across uninstall so the next fresh
+    /// portable install can default to the user's last chosen location.
+    #[serde(default = "default_install_root")]
+    pub install_root: String,
 }
 
 fn default_true() -> bool {
@@ -33,6 +40,10 @@ fn default_true() -> bool {
 
 fn default_windows_install_mode() -> String {
     "msix".to_string()
+}
+
+pub fn default_install_root() -> String {
+    host::default_install_root(&Target::current())
 }
 
 impl Default for AppSettings {
@@ -45,6 +56,7 @@ impl Default for AppSettings {
             signed_only: true,
             confirm_close: true,
             windows_install_mode: default_windows_install_mode(),
+            install_root: default_install_root(),
         }
     }
 }
@@ -55,6 +67,20 @@ fn store_path() -> Option<std::path::PathBuf> {
 }
 
 impl AppSettings {
+    pub fn normalize(&mut self) {
+        self.signed_only = true; // enforce regardless of what is on disk
+        if !matches!(self.windows_install_mode.as_str(), "msix" | "portable") {
+            self.windows_install_mode = default_windows_install_mode();
+        }
+        if self.install_root.trim().is_empty()
+            || !PathBuf::from(self.install_root.trim()).is_absolute()
+        {
+            self.install_root = default_install_root();
+        } else {
+            self.install_root = self.install_root.trim().to_string();
+        }
+    }
+
     pub fn load() -> Self {
         let Some(path) = store_path() else {
             return Self::default();
@@ -63,10 +89,7 @@ impl AppSettings {
             .ok()
             .and_then(|bytes| serde_json::from_slice(&bytes).ok())
             .unwrap_or_default();
-        s.signed_only = true; // enforce regardless of what is on disk
-        if !matches!(s.windows_install_mode.as_str(), "msix" | "portable") {
-            s.windows_install_mode = default_windows_install_mode();
-        }
+        s.normalize();
         s
     }
 

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -179,6 +179,13 @@ fn detect_managed_codex(
             return Some(portable);
         }
     }
+    for record in &store.managed {
+        if let Some(portable) = detect_portable_install(PathBuf::from(&record.path).as_path()) {
+            if store.is_managed(&portable.path) {
+                return Some(portable);
+            }
+        }
+    }
     detect_installed_codex(root.as_path())
 }
 
@@ -426,7 +433,8 @@ pub fn auto_stage_windows_update_with_install_mode(
         }
     }
 
-    let stage = stage_windows_update_with_install_mode(endpoints, settings, install_mode, &no_progress)?;
+    let stage =
+        stage_windows_update_with_install_mode(endpoints, settings, install_mode, &no_progress)?;
     let notes = if stage.install_ready {
         vec!["Windows package is staged and ready for user-confirmed installation.".to_string()]
     } else {
@@ -470,9 +478,11 @@ pub fn perform_windows_update_with_install_mode(
         ));
     }
 
-    let previous_installed =
-        detect_installed_codex(PathBuf::from(&settings.install_root).as_path());
-    let stage = stage_windows_update_with_install_mode(endpoints, settings, install_mode, progress)?;
+    let store = ProvenanceStore::load();
+    let previous_installed = detect_managed_codex(settings, &store)
+        .or_else(|| detect_installed_codex(PathBuf::from(&settings.install_root).as_path()));
+    let stage =
+        stage_windows_update_with_install_mode(endpoints, settings, install_mode, progress)?;
     if stage.up_to_date {
         return Ok(WinPerformReport {
             success: true,
@@ -500,6 +510,16 @@ pub fn perform_windows_update_with_install_mode(
     {
         if installed.source == "msix" {
             close_codex_gracefully_for_root(30, PathBuf::from(&installed.path).as_path())
+                .map_err(engine_err)?;
+        }
+    }
+    // A managed portable build (possibly under a previous install root) is not
+    // stopped by the MSIX sideload below, so close it first — otherwise it keeps
+    // running after we switch the user over to the MSIX package. `previous_installed`
+    // comes from the provenance-aware detect_managed_codex above.
+    if let Some(previous) = &previous_installed {
+        if previous.source == "portable" {
+            close_codex_gracefully_for_root(30, PathBuf::from(&previous.path).as_path())
                 .map_err(engine_err)?;
         }
     }
@@ -551,9 +571,14 @@ fn install_portable_after_stage(
         .staged_path
         .as_ref()
         .ok_or_else(|| AppError::Engine("staged MSIX path missing".to_string()))?;
+    let install_root = previous_installed
+        .as_ref()
+        .filter(|installed| installed.source == "portable")
+        .map(|installed| installed.path.clone())
+        .unwrap_or_else(|| settings.install_root.clone());
     let portable = install_portable_from_msix(
         PathBuf::from(staged_path).as_path(),
-        PathBuf::from(&settings.install_root).as_path(),
+        PathBuf::from(&install_root).as_path(),
         true,
     )
     .map_err(engine_err)?;
@@ -562,7 +587,7 @@ fn install_portable_after_stage(
     // which prefers MSIX and would return a still-present older MSIX package
     // (e.g. when sideload was blocked by policy), recording the wrong target so
     // the user keeps seeing the same update and the portable build goes unmanaged.
-    let installed = detect_portable_install(PathBuf::from(&settings.install_root).as_path());
+    let installed = detect_portable_install(PathBuf::from(&install_root).as_path());
     if let Some(installed) = &installed {
         let mut store = ProvenanceStore::load();
         if let Some(previous) = &previous_installed {
@@ -608,7 +633,10 @@ pub fn win_install_status(settings: &AppSettings) -> WinInstallStatus {
     let installed = detect_managed_codex(settings, &store);
     let status = match &installed {
         None => "none",
-        Some(codex) if store.is_managed(&codex.path) => "managed",
+        // Build-aware (matching the macOS path): a self-updated or path-reused
+        // install no longer matches its record and reads as "external" so the
+        // user is prompted to re-adopt rather than silently treated as managed.
+        Some(codex) if store.is_managed_build(&codex.path, version_key(&codex.version)) => "managed",
         Some(_) => "external",
     }
     .to_string();
@@ -654,7 +682,11 @@ pub fn uninstall_windows_codex(
     };
 
     let mut store = ProvenanceStore::load();
-    if !store.is_managed(&installed_before.path) {
+    // Boundary (matching the macOS uninstall): refuse to delete anything that
+    // isn't an install we manage at this exact build. Path-only matching could
+    // delete a path-reused external install or one left by a stale record —
+    // more likely now that the install root is user-configurable.
+    if !store.is_managed_build(&installed_before.path, version_key(&installed_before.version)) {
         return Ok(WinUninstallReport {
             success: false,
             action: "external-not-managed".to_string(),
@@ -702,7 +734,7 @@ pub fn uninstall_windows_codex(
     }
 
     let portable = uninstall_portable(
-        PathBuf::from(&settings.install_root).as_path(),
+        PathBuf::from(&installed_before.path).as_path(),
         purge_user_data,
     )
     .map_err(engine_err)?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,8 @@
+use std::path::{Path, PathBuf};
+
 use tauri::{Emitter, Manager, State};
 use tauri_plugin_autostart::ManagerExt;
+use tauri_plugin_dialog::DialogExt;
 
 use crate::app::health_service::HealthService;
 use crate::app::mac_update::{
@@ -20,6 +23,7 @@ use crate::app::win_update::{
 };
 use crate::domain::health::HealthReport;
 use crate::domain::operations::{OperationKind, OperationPlan};
+use crate::domain::settings::AppSettings as DomainAppSettings;
 use crate::domain::target::OperatingSystem;
 use crate::errors::{AppError, CommandError};
 use crate::state::ManagerState;
@@ -72,6 +76,197 @@ fn windows_install_mode_for_settings() -> String {
     } else {
         "msix".to_string()
     }
+}
+
+fn windows_domain_settings_for_persisted(state: &ManagerState) -> DomainAppSettings {
+    let saved = PersistedAppSettings::load();
+    let mut settings = state.settings.clone();
+    settings.install_root = saved.install_root;
+    settings
+}
+
+fn dialog_start_dir(path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_dir() {
+        return path;
+    }
+    path.parent()
+        .filter(|parent| parent.is_dir())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from(PersistedAppSettings::load().install_root))
+}
+
+const MIN_PORTABLE_FREE_SPACE_BYTES: u64 = 1_073_741_824;
+
+fn path_key(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('/', "\\")
+        .trim_end_matches('\\')
+        .to_ascii_lowercase()
+}
+
+fn path_is_equal_or_child(path: &Path, root: &Path) -> bool {
+    let path = path_key(path);
+    let root = path_key(root);
+    path == root || path.starts_with(&format!("{root}\\"))
+}
+
+#[cfg(windows)]
+fn protected_windows_roots() -> Vec<PathBuf> {
+    [
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "ProgramW6432",
+        "ProgramData",
+        "SystemRoot",
+        "WINDIR",
+    ]
+    .into_iter()
+    .filter_map(std::env::var_os)
+    .filter(|value| !value.is_empty())
+    .map(PathBuf::from)
+    .collect()
+}
+
+#[cfg(not(windows))]
+fn protected_windows_roots() -> Vec<PathBuf> {
+    Vec::new()
+}
+
+fn is_filesystem_root(path: &Path) -> bool {
+    path.parent().is_none() || (path.has_root() && path.components().count() <= 2)
+}
+
+fn is_protected_install_root(path: &Path) -> bool {
+    is_filesystem_root(path)
+        || protected_windows_roots()
+            .iter()
+            .any(|root| path_is_equal_or_child(path, root))
+}
+
+fn is_existing_codex_portable_root(path: &Path) -> bool {
+    path.join("Codex.exe").is_file() && path.join("AppxManifest.xml").is_file()
+}
+
+fn directory_is_empty(path: &Path) -> Result<bool, AppError> {
+    let mut entries = std::fs::read_dir(path)
+        .map_err(|e| AppError::Internal(format!("读取安装位置失败: {e}")))?;
+    Ok(entries.next().is_none())
+}
+
+#[cfg(windows)]
+fn available_space(path: &Path) -> Result<Option<u64>, AppError> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let mut free_to_caller = 0_u64;
+    let mut total = 0_u64;
+    let mut total_free = 0_u64;
+    let ok = unsafe {
+        GetDiskFreeSpaceExW(
+            wide.as_ptr(),
+            &mut free_to_caller,
+            &mut total,
+            &mut total_free,
+        )
+    };
+    if ok == 0 {
+        return Err(AppError::Internal(format!(
+            "读取磁盘剩余空间失败: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(Some(free_to_caller))
+}
+
+#[cfg(not(windows))]
+fn available_space(_path: &Path) -> Result<Option<u64>, AppError> {
+    Ok(None)
+}
+
+fn validate_install_root_path(raw: &str) -> Result<String, AppError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Internal("安装位置不能为空".to_string()));
+    }
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        return Err(AppError::Internal("安装位置必须是绝对路径".to_string()));
+    }
+    if path.exists() && !path.is_dir() {
+        return Err(AppError::Internal("安装位置必须是文件夹".to_string()));
+    }
+    if is_protected_install_root(&path) {
+        return Err(AppError::Internal(
+            "安装位置不能放在系统目录、管理员目录或磁盘根目录".to_string(),
+        ));
+    }
+    if path.exists() && !directory_is_empty(&path)? && !is_existing_codex_portable_root(&path) {
+        return Err(AppError::Internal(
+            "安装位置必须是空文件夹，或已有的 Codex 免安装版目录".to_string(),
+        ));
+    }
+    // Probe writability and free space WITHOUT creating the target directory:
+    // merely validating or remembering a location must not leave folders on
+    // disk. We probe the nearest existing ancestor — it shares the volume (so
+    // the free-space figure matches) and a writable parent means the installer
+    // can create the leaf later. The directory is created at install time by
+    // install_portable_from_msix, not here.
+    let probe_dir = nearest_existing_dir(&path);
+    let probe = probe_dir.join(format!(".codex-manager-write-test-{}", std::process::id()));
+    std::fs::write(&probe, b"ok")
+        .map_err(|e| AppError::Internal(format!("安装位置不可写: {e}")))?;
+    let _ = std::fs::remove_file(&probe);
+    if let Some(free) = available_space(&probe_dir)? {
+        if free < MIN_PORTABLE_FREE_SPACE_BYTES {
+            return Err(AppError::Internal(
+                "安装位置所在磁盘剩余空间不足".to_string(),
+            ));
+        }
+    }
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// Nearest existing directory at or above `path`. Lets us probe writability and
+/// free space for a not-yet-created install root without creating it.
+fn nearest_existing_dir(path: &Path) -> PathBuf {
+    let mut cur = path;
+    loop {
+        if cur.is_dir() {
+            return cur.to_path_buf();
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => return cur.to_path_buf(),
+        }
+    }
+}
+
+fn install_root_from_picked_dir(raw: &str) -> Result<String, AppError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Internal("安装位置不能为空".to_string()));
+    }
+    let selected = PathBuf::from(trimmed);
+    if !selected.is_absolute() {
+        return Err(AppError::Internal("安装位置必须是绝对路径".to_string()));
+    }
+    if selected.exists() && !selected.is_dir() {
+        return Err(AppError::Internal("安装位置必须是文件夹".to_string()));
+    }
+    if is_filesystem_root(&selected) || is_protected_install_root(&selected) {
+        return validate_install_root_path(trimmed);
+    }
+    if selected.exists()
+        && selected.is_dir()
+        && !directory_is_empty(&selected)?
+        && !is_existing_codex_portable_root(&selected)
+    {
+        return validate_install_root_path(&selected.join("Codex").to_string_lossy());
+    }
+    validate_install_root_path(trimmed)
 }
 
 #[tauri::command]
@@ -264,9 +459,9 @@ pub fn win_plan_update(state: State<'_, ManagerState>) -> Result<WinUpdateReport
         return Err(AppError::UnsupportedPlatform.into());
     }
     let endpoints = windows_endpoints_for_settings(&state)?;
+    let settings = windows_domain_settings_for_persisted(&state);
     let install_mode = windows_install_mode_for_settings();
-    plan_windows_update_with_install_mode(&endpoints, &state.settings, &install_mode)
-        .map_err(Into::into)
+    plan_windows_update_with_install_mode(&endpoints, &settings, &install_mode).map_err(Into::into)
 }
 
 /// Windows-only: plan + download + size/SHA256/AuthentiCode/AppxManifest gates
@@ -279,14 +474,14 @@ pub async fn win_stage_update(
         return Err(AppError::UnsupportedPlatform.into());
     }
     let endpoints = windows_endpoints_for_settings(&state)?;
-    let settings = state.settings.clone();
+    let settings = windows_domain_settings_for_persisted(&state);
     let install_mode = windows_install_mode_for_settings();
     tauri::async_runtime::spawn_blocking(move || {
         stage_windows_update_with_install_mode(&endpoints, &settings, &install_mode, &|_| {})
     })
-        .await
-        .map_err(|e| AppError::Internal(format!("join: {e}")))?
-        .map_err(Into::into)
+    .await
+    .map_err(|e| AppError::Internal(format!("join: {e}")))?
+    .map_err(Into::into)
 }
 
 /// Read persisted app settings (update source + general).
@@ -299,9 +494,83 @@ pub fn get_settings() -> Result<PersistedAppSettings, CommandError> {
 #[tauri::command]
 pub fn set_settings(settings: PersistedAppSettings) -> Result<PersistedAppSettings, CommandError> {
     let mut s = settings;
-    s.signed_only = true;
+    s.normalize();
     s.save()?;
     Ok(s)
+}
+
+/// Windows-only: return the current user's default portable install root.
+#[tauri::command]
+pub fn win_default_install_root(state: State<'_, ManagerState>) -> Result<String, CommandError> {
+    if !matches!(state.target.os, OperatingSystem::Windows) {
+        return Err(AppError::UnsupportedPlatform.into());
+    }
+    Ok(PersistedAppSettings::default().install_root)
+}
+
+/// Windows-only: open a system folder picker for the portable install root.
+#[tauri::command]
+pub async fn win_pick_install_dir(
+    app: tauri::AppHandle,
+    state: State<'_, ManagerState>,
+) -> Result<Option<String>, CommandError> {
+    if !matches!(state.target.os, OperatingSystem::Windows) {
+        return Err(AppError::UnsupportedPlatform.into());
+    }
+    let start_dir = dialog_start_dir(&PersistedAppSettings::load().install_root);
+    let selected = tauri::async_runtime::spawn_blocking(move || {
+        app.dialog()
+            .file()
+            .set_title("选择 Codex 安装位置")
+            .set_directory(start_dir)
+            .blocking_pick_folder()
+            .map(|path| {
+                path.into_path()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .map_err(|e| AppError::Internal(format!("读取选择的文件夹失败: {e}")))
+            })
+            .transpose()
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("join: {e}")))??;
+    selected
+        .as_deref()
+        .map(install_root_from_picked_dir)
+        .transpose()
+        .map_err(Into::into)
+}
+
+/// Windows-only: persist a validated portable install root.
+#[tauri::command]
+pub fn win_set_install_root(
+    state: State<'_, ManagerState>,
+    path: String,
+) -> Result<PersistedAppSettings, CommandError> {
+    if !matches!(state.target.os, OperatingSystem::Windows) {
+        return Err(AppError::UnsupportedPlatform.into());
+    }
+    let install_root = validate_install_root_path(&path)?;
+    let mut settings = PersistedAppSettings::load();
+    settings.install_root = install_root;
+    settings.normalize();
+    settings.save()?;
+    Ok(settings)
+}
+
+/// Windows-only: reset the remembered portable install root to the per-user default.
+#[tauri::command]
+pub fn win_reset_install_root(
+    state: State<'_, ManagerState>,
+) -> Result<PersistedAppSettings, CommandError> {
+    if !matches!(state.target.os, OperatingSystem::Windows) {
+        return Err(AppError::UnsupportedPlatform.into());
+    }
+    let install_root = validate_install_root_path(&PersistedAppSettings::default().install_root)?;
+    let mut settings = PersistedAppSettings::load();
+    settings.install_root = install_root;
+    settings.normalize();
+    settings.save()?;
+    Ok(settings)
 }
 
 /// macOS-only **destructive**: uninstall Codex. Requires explicit `confirm`.
@@ -336,7 +605,7 @@ pub async fn win_auto_stage_update(
         return Err(AppError::UnsupportedPlatform.into());
     }
     let endpoints = windows_endpoints_for_settings(&state)?;
-    let settings = state.settings.clone();
+    let settings = windows_domain_settings_for_persisted(&state);
     let install_mode = windows_install_mode_for_settings();
     tauri::async_runtime::spawn_blocking(move || {
         auto_stage_windows_update_with_install_mode(
@@ -404,7 +673,8 @@ pub fn win_status(state: State<'_, ManagerState>) -> Result<WinInstallStatus, Co
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
     }
-    Ok(win_install_status(&state.settings))
+    let settings = windows_domain_settings_for_persisted(&state);
+    Ok(win_install_status(&settings))
 }
 
 /// Windows-only: adopt the detected external install (after explicit consent).
@@ -413,7 +683,8 @@ pub fn win_adopt(state: State<'_, ManagerState>) -> Result<WinInstallStatus, Com
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
     }
-    adopt_windows_install(&state.settings).map_err(Into::into)
+    let settings = windows_domain_settings_for_persisted(&state);
+    adopt_windows_install(&settings).map_err(Into::into)
 }
 
 /// Windows-only: guarded execution. Requires explicit confirmation, stages and
@@ -424,15 +695,27 @@ pub async fn win_perform_update(
     app: tauri::AppHandle,
     state: State<'_, ManagerState>,
     confirm: bool,
+    install_root: Option<String>,
 ) -> Result<WinPerformReport, CommandError> {
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
     }
     let endpoints = windows_endpoints_for_settings(&state)?;
-    let settings = state.settings.clone();
+    let mut settings = windows_domain_settings_for_persisted(&state);
+    // Validate (but don't yet persist) an explicitly chosen install root: it
+    // only becomes the remembered default after the install actually succeeds,
+    // so a failed or cancelled attempt never changes the user's saved location.
+    let pending_install_root = match install_root {
+        Some(raw) => {
+            let validated = validate_install_root_path(&raw)?;
+            settings.install_root = validated.clone();
+            Some(validated)
+        }
+        None => None,
+    };
     let install_mode = windows_install_mode_for_settings();
     let progress_app = app.clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let report = tauri::async_runtime::spawn_blocking(move || {
         let report = move |p: WinDownloadProgress| {
             let _ = progress_app.emit("win://download-progress", p);
         };
@@ -445,8 +728,16 @@ pub async fn win_perform_update(
         )
     })
     .await
-    .map_err(|e| AppError::Internal(format!("join: {e}")))?
-    .map_err(Into::into)
+    .map_err(|e| AppError::Internal(format!("join: {e}")))??;
+    if let Some(root) = pending_install_root {
+        if report.success {
+            let mut saved = PersistedAppSettings::load();
+            saved.install_root = root;
+            saved.normalize();
+            saved.save()?;
+        }
+    }
+    Ok(report)
 }
 
 /// Windows-only: guarded uninstall. Only removes installs recorded as managed
@@ -460,7 +751,7 @@ pub async fn win_uninstall(
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
     }
-    let settings = state.settings.clone();
+    let settings = windows_domain_settings_for_persisted(&state);
     tauri::async_runtime::spawn_blocking(move || {
         uninstall_windows_codex(&settings, confirm, purge_user_data)
     })
@@ -471,7 +762,14 @@ pub async fn win_uninstall(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_windows_source_base;
+    use super::{
+        install_root_from_picked_dir, normalize_windows_source_base, validate_install_root_path,
+    };
+    use std::fs;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("{name}-{}", std::process::id()))
+    }
 
     #[test]
     fn normalizes_windows_source_base_urls() {
@@ -488,5 +786,79 @@ mod tests {
             Some("https://example.test/custom")
         );
         assert!(normalize_windows_source_base("   ").is_none());
+    }
+
+    #[test]
+    fn rejects_non_empty_non_codex_install_root() {
+        let root = temp_path("codex-manager-non-empty-root");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("notes.txt"), b"not codex").unwrap();
+
+        let err = validate_install_root_path(&root.to_string_lossy()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("安装位置必须是空文件夹，或已有的 Codex 免安装版目录")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn accepts_existing_codex_portable_install_root() {
+        let root = temp_path("codex-manager-existing-portable-root");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("Codex.exe"), b"codex").unwrap();
+        fs::write(root.join("AppxManifest.xml"), b"<Package />").unwrap();
+
+        let validated = validate_install_root_path(&root.to_string_lossy()).unwrap();
+        assert_eq!(validated, root.to_string_lossy());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn picked_non_empty_folder_installs_into_codex_child() {
+        let parent = temp_path("codex-manager-picked-parent");
+        let _ = fs::remove_dir_all(&parent);
+        fs::create_dir_all(&parent).unwrap();
+        fs::write(parent.join("existing.txt"), b"user file").unwrap();
+
+        let validated = install_root_from_picked_dir(&parent.to_string_lossy()).unwrap();
+        assert_eq!(validated, parent.join("Codex").to_string_lossy());
+        // Validation maps to the Codex child but must not create it — the
+        // directory only appears at install time.
+        assert!(!parent.join("Codex").exists());
+
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn validation_does_not_create_the_target_directory() {
+        let root = temp_path("codex-manager-validate-no-create").join("Codex");
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+
+        let validated = validate_install_root_path(&root.to_string_lossy()).unwrap();
+        assert_eq!(validated, root.to_string_lossy());
+        // Validating a fresh location must leave the filesystem untouched.
+        assert!(!root.exists(), "validation must not create the install root");
+
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rejects_windows_protected_install_root() {
+        let Some(program_files) = std::env::var_os("ProgramFiles") else {
+            return;
+        };
+        let root = std::path::PathBuf::from(program_files).join("Codex");
+
+        let err = validate_install_root_path(&root.to_string_lossy()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("安装位置不能放在系统目录、管理员目录或磁盘根目录")
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_dialog::init())
         // Launch-at-login support. Off by default — the user opts in from
         // Settings; we only register the plugin so the toggle can flip it.
         .plugin(tauri_plugin_autostart::init(
@@ -37,6 +38,10 @@ pub fn run() {
             commands::mac_uninstall,
             commands::get_settings,
             commands::set_settings,
+            commands::win_default_install_root,
+            commands::win_pick_install_dir,
+            commands::win_set_install_root,
+            commands::win_reset_install_root,
             commands::get_autostart,
             commands::set_autostart,
             commands::open_url,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,5 +1,6 @@
 use crate::adapters::host;
 use crate::app::planner::InstallPlanner;
+use crate::app::settings_store::AppSettings as PersistedAppSettings;
 use crate::app::snapshot::ManagerSnapshot;
 use crate::domain::installation::ManagedInstallation;
 use crate::domain::manifest::MirrorEndpoints;
@@ -17,7 +18,12 @@ impl ManagerState {
     pub fn new() -> Self {
         let target = Target::current();
         let mirror_base_url = "https://codexapp.agentsmirror.com".to_string();
-        let install_root = host::default_install_root(&target);
+        let saved = PersistedAppSettings::load();
+        let install_root = if saved.install_root.trim().is_empty() {
+            host::default_install_root(&target)
+        } else {
+            saved.install_root
+        };
         let settings = AppSettings::new(mirror_base_url.clone(), install_root);
         let endpoints = MirrorEndpoints::from_base_url(&mirror_base_url);
 

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -125,6 +125,13 @@ button {
   font-family: inherit;
   cursor: pointer;
 }
+button:focus {
+  outline: none;
+}
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 input {
   font-family: inherit;
 }
@@ -605,6 +612,98 @@ button.row:hover {
   color: var(--danger);
 }
 
+.install-root-row {
+  display: block;
+  padding: 12px 13px 13px;
+  border-top: 1px solid var(--line);
+  font-size: 14px;
+}
+.install-root-copy {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+}
+.install-root-copy .ricon {
+  width: 18px;
+  height: 18px;
+  color: var(--text-soft);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.install-root-copy .rtext {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.install-root-copy .rtitle {
+  font-weight: 600;
+}
+.install-root-copy .rsub {
+  color: var(--text-faint);
+  font-size: 12px;
+  line-height: 1.4;
+  margin-top: 3px;
+}
+.install-root-path {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin-top: 10px;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  color: var(--text-soft);
+  text-align: left;
+  transition: background 0.12s var(--ease), border-color 0.12s var(--ease);
+}
+.install-root-path:hover {
+  background: var(--surface-3);
+  border-color: var(--line-2);
+}
+.install-root-value {
+  min-width: 0;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.install-root-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+.mini-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 28px;
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-soft);
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 0.12s var(--ease), color 0.12s var(--ease);
+}
+.mini-action:hover:not(:disabled) {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.mini-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.mini-action svg {
+  width: 14px;
+  height: 14px;
+}
+
 .tag {
   font-size: 10.5px;
   font-weight: 700;
@@ -884,6 +983,19 @@ button.row:hover {
   color: var(--text-soft);
   font-size: 13px;
   line-height: 1.5;
+}
+.sheet-path {
+  margin-top: 12px;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  color: var(--text-soft);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.35;
+  word-break: break-all;
+  text-align: left;
 }
 .sheet .row2 {
   display: flex;

--- a/src/app/views/About.tsx
+++ b/src/app/views/About.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 
-import { managerApi } from "../../services/managerApi";
+import { errorMessage, managerApi } from "../../services/managerApi";
 import { Icon, CodexMark } from "../icons";
 import { useI18n } from "../i18n";
 import { NavBar } from "../components";
@@ -19,7 +19,7 @@ export function About({ onBack }: { onBack: () => void }) {
     try {
       setMgrMsg(await managerApi.checkManagerUpdate());
     } catch (cause) {
-      setMgrMsg(cause instanceof Error ? cause.message : String(cause));
+      setMgrMsg(errorMessage(cause));
     } finally {
       setMgrBusy(false);
     }

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 
-import { managerApi } from "../../services/managerApi";
+import { errorMessage, managerApi } from "../../services/managerApi";
 import type {
   AppSettings,
   DownloadProgress,
@@ -90,7 +90,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       // Drop any stale plan so a failed re-check can't keep driving "立即更新"
       // off an outdated currentBuild/latestBuild.
       setReport(null);
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(errorMessage(cause));
     } finally {
       setBusy(null);
     }
@@ -126,7 +126,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     try {
       setStatus(await managerApi.macAdopt());
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(errorMessage(cause));
     } finally {
       setBusy(null);
     }
@@ -141,7 +141,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       setJustInstalled(true);
       await check();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(errorMessage(cause));
     } finally {
       un();
       setBusy(null);
@@ -167,7 +167,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       await refreshStatus();
       await check();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(errorMessage(cause));
       setConfirmOpen(false);
     } finally {
       un();

--- a/src/app/views/Settings.tsx
+++ b/src/app/views/Settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { managerApi } from "../../services/managerApi";
+import { errorMessage, managerApi } from "../../services/managerApi";
 import type { AppSettings, UpdateSourceKind, WindowsInstallMode } from "../../shared/types";
 import { DEFAULT_SETTINGS } from "../../shared/types";
 import { Icon } from "../icons";
@@ -25,9 +25,15 @@ const WINDOWS_INSTALL_MODES: { kind: WindowsInstallMode; label: TKey; desc: TKey
   {
     kind: "portable",
     label: "settings.windows.portable",
-    desc: "settings.windows.portableDesc",
+    desc: "settings.windows.portableDescDefault",
   },
 ];
+
+function samePath(a: string, b: string): boolean {
+  const norm = (value: string) =>
+    value.trim().replace(/[\\/]+$/, "").replace(/\//g, "\\").toLowerCase();
+  return norm(a) === norm(b);
+}
 
 export function Settings({
   onBack,
@@ -44,16 +50,45 @@ export function Settings({
   const { mode, setMode } = useTheme();
   const win = isWindows();
   const [s, setS] = useState<AppSettings>(DEFAULT_SETTINGS);
+  const [defaultInstallRoot, setDefaultInstallRoot] = useState(DEFAULT_SETTINGS.installRoot);
   const [autostart, setAutostart] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     void managerApi.getSettings().then(setS).catch(() => undefined);
     void managerApi.getAutostart().then(setAutostart).catch(() => undefined);
-  }, []);
+    if (win) {
+      void managerApi.winDefaultInstallRoot().then(setDefaultInstallRoot).catch(() => undefined);
+    }
+  }, [win]);
 
   const save = (next: AppSettings) => {
+    setError(null);
     setS(next);
-    void managerApi.setSettings(next).then(setS).catch(() => undefined);
+    void managerApi
+      .setSettings(next)
+      .then(setS)
+      .catch((cause) => setError(errorMessage(cause)));
+  };
+
+  const pickInstallRoot = async () => {
+    setError(null);
+    try {
+      const path = await managerApi.winPickInstallDir();
+      if (!path) return;
+      setS(await managerApi.winSetInstallRoot(path));
+    } catch (cause) {
+      setError(errorMessage(cause));
+    }
+  };
+
+  const resetInstallRoot = async () => {
+    setError(null);
+    try {
+      setS(await managerApi.winResetInstallRoot());
+    } catch (cause) {
+      setError(errorMessage(cause));
+    }
   };
 
   const toggleAutostart = (v: boolean) => {
@@ -67,10 +102,22 @@ export function Settings({
     { v: "light", k: "settings.appearance.light" },
     { v: "dark", k: "settings.appearance.dark" },
   ];
+  const installRootIsDefault = samePath(s.installRoot, defaultInstallRoot);
+  const portableDescKey: TKey = installRootIsDefault
+    ? "settings.windows.portableDescDefault"
+    : "settings.windows.portableDescCustom";
+
   return (
     <div className="pop">
       <NavBar title={t("settings.title")} onBack={onBack} />
       <div className="scroll view">
+        {error ? (
+          <div className="banner err">
+            <Icon name="alert" />
+            <span>{error}</span>
+          </div>
+        ) : null}
+
         {/* 更新源 */}
         <div className="group">
           <div className="group-h">{t("settings.source.header")}</div>
@@ -131,10 +178,44 @@ export function Settings({
                         </span>
                       ) : null}
                     </span>
-                    <span className="rsub">{t(mode.desc)}</span>
+                    <span className="rsub">{t(mode.kind === "portable" ? portableDescKey : mode.desc)}</span>
                   </span>
                 </button>
               ))}
+              {s.windowsInstallMode === "portable" ? (
+                <div className="install-root-row">
+                  <div className="install-root-copy">
+                    <Icon name="download" className="ricon" />
+                    <span className="rtext">
+                      <span className="rtitle">
+                        {t("settings.windows.installRoot")}
+                        <span className="tag" style={{ marginInlineStart: 8 }}>
+                          {t(
+                            installRootIsDefault
+                              ? "settings.windows.installRootDefault"
+                              : "settings.windows.installRootCustom",
+                          )}
+                        </span>
+                      </span>
+                      <span className="rsub">{t("settings.windows.installRootDesc")}</span>
+                    </span>
+                  </div>
+                  <button className="install-root-path" onClick={pickInstallRoot}>
+                    <span className="install-root-value mono">{s.installRoot}</span>
+                    <Icon name="chevron" className="chev" />
+                  </button>
+                  <div className="install-root-actions">
+                    <button
+                      className="mini-action"
+                      onClick={resetInstallRoot}
+                      disabled={installRootIsDefault}
+                    >
+                      <Icon name="refresh" />
+                      {t("settings.windows.installRootReset")}
+                    </button>
+                  </div>
+                </div>
+              ) : null}
             </div>
           </div>
         ) : null}

--- a/src/app/views/Uninstall.tsx
+++ b/src/app/views/Uninstall.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { managerApi } from "../../services/managerApi";
+import { errorMessage, managerApi } from "../../services/managerApi";
 import { Icon } from "../icons";
 import { useI18n } from "../i18n";
 import { NavBar, Ring, Toggle } from "../components";
@@ -38,7 +38,7 @@ export function Uninstall({ onBack }: { onBack: () => void }) {
         : await managerApi.macUninstall(keepData);
       setDone(r.message);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(errorMessage(cause));
     } finally {
       setBusy(false);
     }

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 
-import { managerApi } from "../../services/managerApi";
+import { errorMessage, managerApi } from "../../services/managerApi";
 import type {
   AppSettings,
   DownloadProgress,
@@ -19,6 +19,12 @@ function mib(bytes: number): string {
   return `${(bytes / 1_048_576).toFixed(1)} MB`;
 }
 
+function samePath(a: string, b: string): boolean {
+  const norm = (value: string) =>
+    value.trim().replace(/[\\/]+$/, "").replace(/\//g, "\\").toLowerCase();
+  return norm(a) === norm(b);
+}
+
 type Kind = "loading" | "error" | "none" | "idle" | "update" | "external" | "uptodate";
 
 // Windows counterpart of MacHome — same design system + state machine, driven by
@@ -29,9 +35,12 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [status, setStatus] = useState<WinInstallStatus | null>(null);
   const [perform, setPerform] = useState<WinPerformReport | null>(null);
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
+  const [defaultInstallRoot, setDefaultInstallRoot] = useState(DEFAULT_SETTINGS.installRoot);
   const [busy, setBusy] = useState<"plan" | "perform" | "adopt" | "install" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [installDirOpen, setInstallDirOpen] = useState(false);
+  const [installDirBusy, setInstallDirBusy] = useState(false);
   const [statusLoaded, setStatusLoaded] = useState(false);
   const [statusFailed, setStatusFailed] = useState(false);
   const [dl, setDl] = useState<DownloadProgress | null>(null);
@@ -74,7 +83,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       setReport(await managerApi.winPlanUpdate());
     } catch (cause) {
       setReport(null);
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(errorMessage(cause));
     } finally {
       setBusy(null);
     }
@@ -95,6 +104,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     void (async () => {
       const s = await managerApi.getSettings().catch(() => DEFAULT_SETTINGS);
       setSettings(s);
+      void managerApi.winDefaultInstallRoot().then(setDefaultInstallRoot).catch(() => undefined);
       void refreshStatus();
       if (s.autoCheck) {
         void check();
@@ -108,7 +118,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     try {
       setStatus(await managerApi.winAdopt());
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(errorMessage(cause));
     } finally {
       setBusy(null);
     }
@@ -117,19 +127,21 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   // Windows install + update both go through win_perform_update (the route —
   // MSIX sideload or portable fallback — is decided by the backend plan).
   const runPerform = useCallback(
-    async (mode: "perform" | "install") => {
+    async (mode: "perform" | "install", installRoot?: string) => {
       setBusy(mode);
       setError(null);
       const unlisten = await startDlListen();
       try {
-        const result = await managerApi.winPerformUpdate(true);
+        const result = await managerApi.winPerformUpdate(true, installRoot);
         setPerform(result);
         setConfirmOpen(false);
+        setInstallDirOpen(false);
         await refreshStatus();
         await check();
       } catch (cause) {
-        setError(cause instanceof Error ? cause.message : String(cause));
+        setError(errorMessage(cause));
         setConfirmOpen(false);
+        setInstallDirOpen(false);
       } finally {
         unlisten();
         setBusy(null);
@@ -138,6 +150,64 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     },
     [refreshStatus, check, startDlListen],
   );
+
+  const freshInstallNeedsLocation = useCallback(async () => {
+    if (settings.windowsInstallMode === "portable" || report?.plan?.route === "portable-fallback") {
+      return true;
+    }
+    if (report?.plan?.route === "msix-sideload") {
+      return false;
+    }
+    setBusy("plan");
+    setError(null);
+    try {
+      const next = await managerApi.winPlanUpdate();
+      setReport(next);
+      return next.plan?.route === "portable-fallback";
+    } catch (cause) {
+      setError(errorMessage(cause));
+      return null;
+    } finally {
+      setBusy(null);
+    }
+  }, [report?.plan?.route, settings.windowsInstallMode]);
+
+  const requestInstall = useCallback(async () => {
+    const needsLocation = await freshInstallNeedsLocation();
+    if (needsLocation === null) {
+      return;
+    }
+    if (needsLocation) {
+      setInstallDirOpen(true);
+      return;
+    }
+    await runPerform("install");
+  }, [freshInstallNeedsLocation, runPerform]);
+
+  const installToCurrentRoot = useCallback(async () => {
+    await runPerform("install", settings.installRoot);
+  }, [runPerform, settings.installRoot]);
+
+  const browseInstallRoot = useCallback(async () => {
+    setInstallDirBusy(true);
+    setError(null);
+    try {
+      const path = await managerApi.winPickInstallDir();
+      if (!path) return;
+      // One-shot: hand the chosen location straight to the install. The backend
+      // only persists it as the new default after the install succeeds, so a
+      // cancelled or failed attempt leaves the saved location untouched. Refresh
+      // settings afterwards to reflect whatever was (or wasn't) persisted.
+      await runPerform("install", path);
+      const refreshed = await managerApi.getSettings().catch(() => null);
+      if (refreshed) setSettings(refreshed);
+    } catch (cause) {
+      setError(errorMessage(cause));
+      setInstallDirOpen(false);
+    } finally {
+      setInstallDirBusy(false);
+    }
+  }, [runPerform]);
 
   const plan = report?.plan ?? null;
   const installed = status?.installed ?? report?.installed ?? null;
@@ -163,6 +233,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
 
   const version = installed?.version || plan?.latestVersion || "";
   const sourceLabel = t(`source.${settings.source}` as TKey);
+  const installRootIsDefault = samePath(settings.installRoot, defaultInstallRoot);
 
   if (busy === "perform" || busy === "install") {
     const known = Boolean(dl && dl.total > 0);
@@ -324,7 +395,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
           {kind === "none" ? (
             <button
               className="btn primary big"
-              onClick={() => runPerform("install")}
+              onClick={requestInstall}
               disabled={busy !== null}
             >
               <Icon name="download" />
@@ -366,6 +437,37 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
               </button>
               <button className="btn primary" onClick={() => runPerform("perform")}>
                 {t("confirm.ok")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {installDirOpen ? (
+        <div className="scrim" onClick={() => (installDirBusy ? undefined : setInstallDirOpen(false))}>
+          <div className="sheet" onClick={(e) => e.stopPropagation()}>
+            <Ring icon="download" />
+            <h3>{t("win.installDir.title")}</h3>
+            <p>{t("win.installDir.body")}</p>
+            <div className="sheet-path">{settings.installRoot}</div>
+            <div className="row2">
+              <button
+                className="btn ghost"
+                onClick={installToCurrentRoot}
+                disabled={installDirBusy}
+              >
+                {t(
+                  installRootIsDefault
+                    ? "win.installDir.useDefault"
+                    : "win.installDir.useCurrent",
+                )}
+              </button>
+              <button
+                className="btn primary"
+                onClick={browseInstallRoot}
+                disabled={installDirBusy}
+              >
+                {t("win.installDir.browse")}
               </button>
             </div>
           </div>

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -40,6 +40,30 @@ function hasTauriRuntime(): boolean {
   return typeof window !== "undefined" && Boolean(window.__TAURI_INTERNALS__);
 }
 
+export function errorMessage(cause: unknown): string {
+  if (cause instanceof Error) {
+    return cause.message;
+  }
+  if (typeof cause === "string") {
+    return cause;
+  }
+  if (cause && typeof cause === "object") {
+    const maybe = cause as { message?: unknown; code?: unknown };
+    if (typeof maybe.message === "string" && maybe.message.trim()) {
+      return maybe.message;
+    }
+    if (typeof maybe.code === "string" && maybe.code.trim()) {
+      return maybe.code;
+    }
+    try {
+      return JSON.stringify(cause);
+    } catch {
+      // fall through
+    }
+  }
+  return String(cause);
+}
+
 // Browser-dev fallbacks (no Tauri runtime) — a simulated "one version behind"
 // so the UI renders meaningfully outside the desktop shell.
 const FALLBACK_PLAN: MacUpdateReport = {
@@ -335,6 +359,38 @@ export const managerApi = {
     localStorage.setItem(SETTINGS_LS, JSON.stringify(saved));
     return saved;
   },
+  winPickInstallDir(): Promise<string | null> {
+    if (!hasTauriRuntime()) {
+      return Promise.resolve(localSettings().installRoot);
+    }
+    return invoke<string | null>("win_pick_install_dir");
+  },
+  winDefaultInstallRoot(): Promise<string> {
+    if (!hasTauriRuntime()) {
+      return Promise.resolve(DEFAULT_SETTINGS.installRoot);
+    }
+    return invoke<string>("win_default_install_root");
+  },
+  async winSetInstallRoot(path: string): Promise<AppSettings> {
+    if (!hasTauriRuntime()) {
+      const saved = { ...localSettings(), installRoot: path };
+      localStorage.setItem(SETTINGS_LS, JSON.stringify(saved));
+      return saved;
+    }
+    const saved = await invoke<AppSettings>("win_set_install_root", { path });
+    localStorage.setItem(SETTINGS_LS, JSON.stringify(saved));
+    return saved;
+  },
+  async winResetInstallRoot(): Promise<AppSettings> {
+    if (!hasTauriRuntime()) {
+      const saved = { ...localSettings(), installRoot: DEFAULT_SETTINGS.installRoot };
+      localStorage.setItem(SETTINGS_LS, JSON.stringify(saved));
+      return saved;
+    }
+    const saved = await invoke<AppSettings>("win_reset_install_root");
+    localStorage.setItem(SETTINGS_LS, JSON.stringify(saved));
+    return saved;
+  },
 
   // Launch-at-login (off by default). Backed by tauri-plugin-autostart.
   getAutostart(): Promise<boolean> {
@@ -398,13 +454,16 @@ export const managerApi = {
     }
     return invoke<boolean>("win_cancel_download");
   },
-  winPerformUpdate(confirm: boolean): Promise<WinPerformReport> {
+  winPerformUpdate(confirm: boolean, installRoot?: string): Promise<WinPerformReport> {
     if (!hasTauriRuntime()) {
       return confirm
         ? Promise.resolve(WIN_FALLBACK_PERFORM)
         : Promise.reject(new Error("explicit confirmation is required"));
     }
-    return invoke<WinPerformReport>("win_perform_update", { confirm });
+    return invoke<WinPerformReport>("win_perform_update", {
+      confirm,
+      installRoot: installRoot ?? null,
+    });
   },
   winUninstall(confirm: boolean, purgeUserData: boolean): Promise<WinUninstallReport> {
     if (!hasTauriRuntime()) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -86,6 +86,8 @@ export interface AppSettings {
   confirmClose: boolean;
   /** Windows payload install preference. MSIX still falls back safely if blocked. */
   windowsInstallMode: WindowsInstallMode;
+  /** Remembered portable install root for Windows. */
+  installRoot: string;
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -96,6 +98,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   signedOnly: true,
   confirmClose: true,
   windowsInstallMode: "msix",
+  installRoot: "%LOCALAPPDATA%\\Programs\\Codex",
 };
 
 export interface MacUninstallReport {


### PR DESCRIPTION
## What changed

- Added a persisted Windows portable `installRoot` setting with migration from older `settings.json` files.
- Added Tauri dialog support plus `win_pick_install_dir` and `win_set_install_root` commands.
- Validates portable install roots with absolute-path, folder, writable, and free-space checks.
- Makes Windows install/update/status/uninstall commands read the current persisted install root instead of the startup-only default.
- Preserves the no-migration rule: if a managed portable install already exists, updates and uninstall continue to use that actual managed path; a changed setting becomes the next fresh-install default.
- Adds Settings UI for portable install location and a fresh-install location chooser sheet with Default / Browse.

Closes #6

## Validation

- `npm run check`
- `npm run build`
- `cargo check`
- `cargo test`
- `cargo test --manifest-path crates\codex-win-engine\Cargo.toml`
- `cargo clippy`
- `cargo clippy --manifest-path crates\codex-win-engine\Cargo.toml --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `npm run tauri:build`

## Notes

- Browser development UI verified the portable Settings row appears after selecting the portable install mode.
- The actual folder picker is wired through the Tauri dialog plugin and is exercised by the built desktop bundle rather than the in-app browser fallback.
