### PR TITLE
ci: add pull-request checks (type-check, tests, clippy, cargo test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+# Fast pull-request gate: type-check, unit tests and a cross-platform Rust
+# clippy/test pass. The heavy signed/notarized bundle build stays in
+# release.yml (tags only) — this never builds or signs the .app.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Newer pushes to the same ref supersede in-flight runs.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Type-check
+        run: npm run check
+      - name: Unit tests
+        run: npm run test --if-present
+      - name: Build frontend
+        run: npm run build
+
+  rust:
+    name: Rust
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+      - run: npm ci
+      # tauri-build (frontendDist: ../dist) reads the built frontend at compile
+      # time, so produce dist before touching cargo. We deliberately do NOT run
+      # `tauri build` here — no bundling, no signing, no notarization.
+      - name: Build frontend (for tauri-build)
+        run: npm run build
+      - name: Clippy (deny warnings)
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
+      - name: Test
+        run: cargo test --manifest-path src-tauri/Cargo.toml --workspace


### PR DESCRIPTION
Adds a fast CI gate that runs on every PR and on pushes to \`main\`, separate from the existing tag-driven \`release.yml\` (which is the only workflow today and never runs on PRs).

## Jobs
- **Frontend** (ubuntu): \`npm ci\` → \`tsc --noEmit\` → \`vitest\` (via \`npm run test --if-present\`) → \`vite build\`.
- **Rust** (macos-latest + windows-latest): build the frontend first so \`tauri-build\`'s \`frontendDist: ../dist\` resolves, then \`cargo clippy --workspace --all-targets -- -D warnings\` and \`cargo test --workspace\`.

## Notes
- Deliberately does **not** run \`tauri build\` — no bundling, signing or notarization. That stays in \`release.yml\`.
- \`rustfmt --check\` is intentionally omitted for now: some pre-existing example bins under \`crates/*/src/bin\` are unformatted and would fail the gate on arrival.
- Verified locally on macOS: workspace \`cargo test\` and \`cargo clippy -D warnings\` are clean; \`tsc\`, vitest (11 tests) and \`vite build\` all pass.

Once this is green it can be wired in as a required status check on the \`main\` ruleset.