### PR TITLE
chore(release): bump version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.0"
+version = "0.1.1"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release prep for **v0.1.1** — bumps the version across all sources of truth in lockstep:

- \`package.json\` / \`package-lock.json\`
- \`src-tauri/tauri.conf.json\` (the app version the updater compares)
- \`src-tauri/Cargo.toml\` / \`src-tauri/Cargo.lock\`

### What ships in 0.1.1 (on top of released v0.1.0)
- **i18n**: system-locale detection + 11 languages with Arabic RTL (#7)
- **Windows**: portable install location picker, with review fixes (#8)
- **CI**: PR-level type-check / tests / clippy / cargo test (#9)

### Why bump all five
\`release.yml\` builds the app version from \`tauri.conf.json\` but \`latest.json\`'s version comes from the git tag (\`vX.Y.Z\` → \`X.Y.Z\`). If they diverge, the updater advertises a version the installed build doesn't match and loops. Keeping every source at 0.1.1 avoids that.

After merge: tag \`v0.1.1\` on \`main\` and push it to trigger the signed/notarized release build.