### PR TITLE
fix(release): sign the Windows NSIS installer so the updater sees it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,33 @@ jobs:
           export AC_API_KEY="$RUNNER_TEMP/AuthKey.p8"
           bash scripts/finalize-macos.sh "${{ matrix.target }}"
 
+      # ── Windows: sign the NSIS installer for the updater ──────────────────
+      #    The build is intentionally unsigned (mirroring macOS), so Tauri emits
+      #    no `.sig`. In Tauri 2 the Windows updater ships the `-setup.exe`
+      #    itself, so signing it here with the updater key — exactly what
+      #    finalize-macos.sh does for the .app.tar.gz — is equivalent to
+      #    `createUpdaterArtifacts` and is what gets windows-x86_64 into
+      #    latest.json. Without it the manifest has macOS platforms only and
+      #    Windows in-app self-update never sees new versions.
+      - name: Sign Windows updater artifact
+        if: matrix.os == 'windows'
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          B="src-tauri/target/${{ matrix.target }}/release/bundle"
+          shopt -s nullglob
+          signed=0
+          for exe in "$B"/nsis/*-setup.exe; do
+            npx tauri signer sign "$exe"
+            signed=$((signed + 1))
+          done
+          if [ "$signed" -eq 0 ]; then
+            echo "::error::no NSIS -setup.exe found to sign under $B/nsis" >&2
+            exit 1
+          fi
+
       # ── Collect artifacts (rename macOS updater tarball with its arch so the
       #    two macOS jobs don't collide when merged) ──────────────────────────
       - name: Collect artifacts
@@ -139,6 +166,11 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           draft: false
+          # Tags carrying a pre-release identifier (e.g. v0.1.2-rc1) publish as a
+          # prerelease, so GitHub's `releases/latest` — and the updater endpoint
+          # pointing at it — keep resolving to the last stable build instead of
+          # serving a release-candidate to real users.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/*
             latest.json


### PR DESCRIPTION
## Problem
The Windows manager's in-app self-update never sees new versions. `latest.json` has only `darwin-aarch64` / `darwin-x86_64` — no `windows-x86_64` — and this has been true since v0.1.0 (verified on both v0.1.0 and v0.1.1 release manifests).

## Root cause
The release deliberately builds **unsigned** and signs inside-out in CI (see the `release.yml` header). `finalize-macos.sh` re-packs and `tauri signer sign`s the macOS `.app.tar.gz`, producing its `.sig`. **Windows has no such step**, and `bundle.createUpdaterArtifacts` is not enabled, so Tauri never emits a `*-setup.exe.sig`. `gen-updater-manifest.mjs` then `console.warn`s and skips the windows platform for lack of a `.sig`.

## Fix
Add a Windows-only CI step that signs the NSIS `-setup.exe` with the updater key:

```bash
npx tauri signer sign "$exe"   # reads TAURI_SIGNING_PRIVATE_KEY[_PASSWORD] from env
```

In Tauri 2 the Windows updater ships the `-setup.exe` itself (no zip), so signing it post-build is **equivalent to `createUpdaterArtifacts`** for Windows — but stays contained to CI and doesn't force-sign local `tauri build`s. The existing `Collect artifacts` glob (`*-setup.exe.sig`) and the `gen-updater-manifest.mjs` matcher (`(?:x64|x86_64).*-setup\.(?:exe|nsis\.zip)\.sig$`) already handle it, so `windows-x86_64` now lands in `latest.json`. The step `exit 1`s if no installer is found, so a future regression fails loudly instead of silently shipping a mac-only manifest.

### Bonus safety
Tags carrying a pre-release identifier (e.g. `v0.1.2-rc1`) now publish as **prereleases**, so GitHub's `releases/latest` (and the updater endpoint pointing at it) keep resolving to the last stable build — makes test tags safe to push without serving an RC to real users.

## Verification
- `npx tauri signer sign --help` confirms the CLI reads the key from `TAURI_SIGNING_PRIVATE_KEY` — the step matches.
- Logic traced end-to-end (sign → collect → manifest matcher → `windows-x86_64`).
- End-to-end requires a tag-triggered release run; can be confirmed safely with a `v0.1.2-rc1` prerelease tag (now non-"latest").

Does not touch app code; normal CI (type-check/tests/clippy) is unaffected.