### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "dependencies": {
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.1"
+version = "0.1.3"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release prep for **v0.1.3** — the release that makes **Windows in-app self-update** actually work.

The app binary is unchanged since v0.1.1; what changed is the release pipeline (#11): the NSIS installer is now signed, so this release's `latest.json` will carry `windows-x86_64` for the first time. Once v0.1.3 is the latest release, existing v0.1.1 Windows users can self-update (same updater pubkey, valid signature).

Bumps every version source in lockstep — `package.json` / `package-lock.json` / `tauri.conf.json` / `Cargo.toml` / `Cargo.lock` — so the built app version matches the `v0.1.3` tag that drives `latest.json`.

After merge: tag `v0.1.3` on `main` and push → release build → verify `latest.json` lists all three platforms (darwin-aarch64, darwin-x86_64, **windows-x86_64**).