### PR TITLE
fix(release): space-free Windows asset names + bump to 0.1.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,16 @@ jobs:
             for f in "$B"/macos/*.app.tar.gz.sig;  do cp "$f" "$DST/CodexAppManager_${ARCH}.app.tar.gz.sig"; done
             for f in "$B"/dmg/*.dmg;               do cp "$f" "$DST/CodexAppManager_${ARCH}.dmg"; done
           else
-            for f in "$B"/nsis/*-setup.exe;        do cp "$f" "$DST/"; done
-            for f in "$B"/nsis/*-setup.exe.sig;    do cp "$f" "$DST/"; done
-            for f in "$B"/nsis/*.nsis.zip;         do cp "$f" "$DST/"; done
-            for f in "$B"/nsis/*.nsis.zip.sig;     do cp "$f" "$DST/"; done
+            # Strip spaces from the NSIS filenames (productName is "Codex App
+            # Manager"). GitHub rewrites spaces to dots in uploaded asset names,
+            # but gen-updater-manifest.mjs builds the URL from the pre-upload
+            # filename — so a spaced name yields a %20 URL that 404s against the
+            # dotted asset. Renaming space-free here keeps asset name == manifest
+            # URL (the macOS branch already renames for the same reason).
+            for f in "$B"/nsis/*-setup.exe "$B"/nsis/*-setup.exe.sig \
+                     "$B"/nsis/*.nsis.zip "$B"/nsis/*.nsis.zip.sig; do
+              n="$(basename "$f")"; cp "$f" "$DST/${n// /}"
+            done
           fi
           ls -la "$DST"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.3"
+version = "0.1.4"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Problem found while verifying v0.1.3
v0.1.3 finally put `windows-x86_64` in `latest.json` — but its updater URL **404s**:

- manifest URL: `…/Codex%20App%20Manager_0.1.3_x64-setup.exe` → **404**
- actual asset:  `…/Codex.App.Manager_0.1.3_x64-setup.exe` → **200**

NSIS names the installer from `productName` (“Codex App Manager”), so it has spaces. GitHub rewrites spaces → dots in uploaded asset names, but `gen-updater-manifest.mjs` builds the URL from the **pre-upload** (spaced) filename → `%20` URL that doesn't match the dotted asset. (macOS is fine because the Collect step already renames those space-free.)

## Fix
Strip spaces when collecting the Windows artifacts, so **asset name == manifest URL**:

```bash
n="$(basename "$f")"; cp "$f" "$DST/${n// /}"
# Codex App Manager_0.1.4_x64-setup.exe → CodexAppManager_0.1.4_x64-setup.exe
```

Bumps to **0.1.4** to ship the corrected manifest (no app-code change since 0.1.1).

## After merge
Tag `v0.1.4` → release → verify the `windows-x86_64` URL in `latest.json` returns **200** (and all three platforms are present).