### PR TITLE
ci: upgrade actions to Node 24 runtimes + bump to 0.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -42,8 +42,8 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ jobs:
           - { platform: windows-latest, target: x86_64-pc-windows-msvc, os: windows }
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -147,7 +147,7 @@ jobs:
           fi
           ls -la "$DST"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bundle-${{ matrix.target }}
           path: dist-artifacts/*
@@ -157,9 +157,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -168,7 +168,7 @@ jobs:
         run: node scripts/gen-updater-manifest.mjs "${{ github.ref_name }}" dist
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           draft: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.4"
+version = "0.1.5"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Clears the **Node 20 runtime deprecation** warnings (GitHub forces Node 24 on 2026-06-16) by bumping every JavaScript action to its current Node 24 major.

| Action | Was | Now | Runtime |
|---|---|---|---|
| actions/checkout | v4 | **v6** | node24 |
| actions/setup-node | v4 | **v6** | node24 |
| actions/upload-artifact | v4 | **v7** | node24 |
| actions/download-artifact | v4 | **v8** | node24 |
| softprops/action-gh-release | v2 | **v3** | node24 |

Left as-is: `Swatinem/rust-cache@v2` (already floats to a Node 24 release), `dtolnay/rust-toolchain@stable` (composite action, no Node runtime).

### Compatibility checked (not assumed)
Pulled each action's `action.yml` at the target tag and confirmed `using: node24` plus the inputs we rely on:
- `upload-artifact@v7`: `name`, `path`, `if-no-files-found` ✅
- `download-artifact@v8`: `path`, `merge-multiple` ✅ (per-target artifact names stay unique → no immutability clash)
- `action-gh-release@v3`: `tag_name`, `draft`, `prerelease`, `files` ✅ — v3.0.0's release notes say it's purely the Node 20→24 runtime move, no input changes.

`node-version: 20` (the Node that runs `npm`/`vite`) is unchanged — that's a supported build toolchain, not the deprecated action runtime.

Patch bump to **0.1.5** ships it. The release-pipeline action upgrades (upload/download-artifact, action-gh-release) only execute at tag time, so they get validated by the v0.1.5 release run.