### PR TITLE
feat(motion): GSAP-orchestrated home entrances & transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "codex-app-manager",
       "version": "0.1.7",
       "dependencies": {
+        "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
+        "gsap": "^3.15.0",
         "lucide-react": "1.17.0",
         "react": "19.2.7",
         "react-dom": "19.2.7"
@@ -57,6 +59,16 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@gsap/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==",
+      "license": "SEE LICENSE AT https://gsap.com/standard-license",
+      "peerDependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=17"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -909,6 +921,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/gsap": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
+      "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "tauri:build:mac": "tauri build && bash scripts/macos-adaptive-icon.sh"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.2",
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
+    "gsap": "^3.15.0",
     "lucide-react": "1.17.0",
     "react": "19.2.7",
     "react-dom": "19.2.7"

--- a/src/app/motion.ts
+++ b/src/app/motion.ts
@@ -1,0 +1,124 @@
+// Central GSAP setup + the orchestrated home-screen motion.
+//
+// Importing this module registers every plugin once and defines the project's
+// signature easing curves. The platform home views call useHomeMotion() to play
+// a choreographed entrance/transition each time the visible "scene" changes.
+
+import { useGSAP } from "@gsap/react";
+import gsap from "gsap";
+import { CustomEase } from "gsap/CustomEase";
+import { DrawSVGPlugin } from "gsap/DrawSVGPlugin";
+import { Flip } from "gsap/Flip";
+import { SplitText } from "gsap/SplitText";
+import type { RefObject } from "react";
+
+gsap.registerPlugin(useGSAP, CustomEase, DrawSVGPlugin, Flip, SplitText);
+
+// Signature curves — smooth deceleration (no tacky bounce); "pop" is a
+// restrained overshoot reserved for the focal medallion.
+CustomEase.create("cam-out", "0.16, 1, 0.3, 1"); // expo-out settle
+CustomEase.create("cam-in-out", "0.65, 0, 0.35, 1");
+CustomEase.create("cam-pop", "0.34, 1.3, 0.5, 1"); // gentle overshoot
+
+export { gsap, useGSAP, Flip, SplitText };
+
+interface HomeMotionOpts {
+  /** Reveal the headline character-by-character (skip for shimmer/loading text,
+   *  whose background-clip:text gradient can't survive per-char wrapping). */
+  splitHeadline: boolean;
+  /** Draw the success checkmark stroke in. */
+  success: boolean;
+}
+
+/**
+ * Choreograph the home hero + details + actions whenever `scene` changes.
+ * Scoped to `scope`; gated behind prefers-reduced-motion via matchMedia so
+ * reduced-motion users get the static, fully-visible layout.
+ */
+export function useHomeMotion(
+  scope: RefObject<HTMLElement | null>,
+  scene: string,
+  opts: HomeMotionOpts,
+): void {
+  const { splitHeadline, success } = opts;
+  useGSAP(
+    () => {
+      const mm = gsap.matchMedia();
+      mm.add("(prefers-reduced-motion: no-preference)", () => {
+        const q = gsap.utils.selector(scope);
+        // Skip aria-hidden placeholders (e.g. the rechecking-state .microcue
+        // height spacer) so autoAlpha never reveals them.
+        const at = (sel: string) => {
+          const els = q(sel).filter((el) => el.getAttribute("aria-hidden") !== "true");
+          return els.length ? els : null;
+        };
+        // Strip GSAP's inline opacity/visibility/transform when each tween ends,
+        // so CSS regains control (otherwise inline opacity:1 outranks the
+        // .btn:disabled fade and the :active press transform).
+        const CLEAR = "transform,opacity,visibility";
+        let split: SplitText | undefined;
+        const tl = gsap.timeline({ defaults: { ease: "cam-out", duration: 0.58 } });
+        // fromTo with EXPLICIT end states (not from(): persistent sibling nodes
+        // like .actions/.list.meta aren't remounted with the keyed hero, and a
+        // bare from() would read a leftover inline opacity:0 as the end target
+        // and animate 0→0, leaving them stuck hidden).
+
+        const ring = at(".hero .ring");
+        if (ring) {
+          tl.fromTo(
+            ring,
+            { scale: 0.62, autoAlpha: 0 },
+            { scale: 1, autoAlpha: 1, ease: "cam-pop", duration: 0.72, clearProps: CLEAR },
+            0,
+          );
+        }
+
+        const headline = q(".hero .headline")[0] as HTMLElement | undefined;
+        if (headline && splitHeadline) {
+          split = SplitText.create(headline, { type: "chars", aria: "auto" });
+          tl.fromTo(
+            split.chars,
+            { yPercent: 90, autoAlpha: 0 },
+            { yPercent: 0, autoAlpha: 1, stagger: 0.034, duration: 0.55, clearProps: CLEAR },
+            0.14,
+          );
+        } else if (headline) {
+          tl.fromTo(
+            headline,
+            { y: 12, autoAlpha: 0 },
+            { y: 0, autoAlpha: 1, duration: 0.5, clearProps: CLEAR },
+            0.14,
+          );
+        }
+
+        const reveal = (sel: string, y: number, stagger: number, at0: number) => {
+          const els = at(sel);
+          if (els) {
+            tl.fromTo(
+              els,
+              { y, autoAlpha: 0 },
+              { y: 0, autoAlpha: 1, stagger, duration: 0.5, clearProps: CLEAR },
+              at0,
+            );
+          }
+        };
+        reveal(".hero .sub, .hero .flow, .hero .microcue, .hero .prov, .hero .desc", 10, 0.06, 0.24);
+        reveal(".hero .pctbig, .hero .bar, .hero .dlmeta", 10, 0.07, 0.26);
+        reveal(".list.meta .row", 12, 0.07, 0.32);
+        reveal(".actions > *", 14, 0.08, 0.38);
+
+        if (success) {
+          const check = at(".hero .ring svg polyline");
+          if (check) {
+            tl.fromTo(check, { drawSVG: "0% 0%" }, { drawSVG: "0% 100%", duration: 0.5 }, 0.46);
+          }
+        }
+
+        return () => {
+          split?.revert();
+        };
+      });
+    },
+    { scope, dependencies: [scene], revertOnUpdate: true },
+  );
+}

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -11,12 +11,13 @@ import type {
 } from "../../shared/types";
 import { DEFAULT_SETTINGS } from "../../shared/types";
 import { Icon, CodexGlyph } from "../icons";
-import { useI18n, type TKey } from "../i18n";
+import { useI18n, dirOf, type TKey } from "../i18n";
 import { Ring, TopBar } from "../components";
 import { currentPlatform } from "../platform";
 import { WinHome } from "./WinHome";
 import { useCountUp } from "../useCountUp";
 import { mib, fmtDateTime } from "../format";
+import { useHomeMotion } from "../motion";
 
 type Kind = "loading" | "error" | "none" | "idle" | "update" | "external" | "uptodate";
 
@@ -28,9 +29,6 @@ export function Home(props: { onOpenSettings: () => void }) {
 function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const { t, lang } = useI18n();
   const [report, setReport] = useState<MacUpdateReport | null>(null);
-  // Bumped after each successful check so the success medallion re-mounts and
-  // replays its pop + checkmark-draw — the visible "re-confirmed" feedback.
-  const [recheckPulse, setRecheckPulse] = useState(0);
   const [status, setStatus] = useState<MacInstallStatus | null>(null);
   const [perform, setPerform] = useState<MacPerformReport | null>(null);
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
@@ -50,6 +48,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [dl, setDl] = useState<DownloadProgress | null>(null);
   const [speed, setSpeed] = useState(0);
   const dlSample = useRef<{ t: number; bytes: number } | null>(null);
+  const scopeRef = useRef<HTMLDivElement>(null);
   // Smoothly roll the live download figures instead of snapping per event.
   const dlPctTarget = dl && dl.total > 0 ? Math.min(100, (dl.downloaded / dl.total) * 100) : 0;
   const dlPct = useCountUp(dlPctTarget);
@@ -86,7 +85,6 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     setError(null);
     try {
       setReport(await managerApi.macPlanUpdate());
-      setRecheckPulse((p) => p + 1);
     } catch (cause) {
       // Drop any stale plan so a failed re-check can't keep driving "立即更新"
       // off an outdated currentBuild/latestBuild.
@@ -227,6 +225,26 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     void managerApi.macLaunch().catch((cause) => setError(errorMessage(cause)));
   };
 
+  // One string identifying the visible "scene"; when it changes the hero
+  // remounts and GSAP replays the choreographed entrance (see useHomeMotion).
+  // `lang` is part of the key so a language switch (Home stays mounted) remounts
+  // the headline and re-splits it — otherwise SplitText's aria-label would keep
+  // the old language's text for screen readers.
+  const progressing = busy === "perform" || busy === "install";
+  const isShimmer = progressing || rechecking || kind === "loading";
+  const scene = `${lang}/${
+    progressing
+      ? `progress-${busy}`
+      : justInstalled
+        ? "done"
+        : `${kind}${rechecking ? "-checking" : ""}`
+  }`;
+  const success = justInstalled || (!rechecking && kind === "uptodate");
+  // Char-split only LTR scripts — splitting a cursive RTL script (Arabic) into
+  // per-char elements breaks its contextual letter joining.
+  const splitHeadline = !isShimmer && dirOf(lang) === "ltr";
+  useHomeMotion(scopeRef, scene, { splitHeadline, success });
+
   // ── progress (performing / installing) takes over the whole screen ─────────
   if (busy === "perform" || busy === "install") {
     const known = Boolean(dl && dl.total > 0);
@@ -234,8 +252,8 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     return (
       <div className="pop">
         <TopBar />
-        <div className="scroll view">
-          <div className="hero" style={{ marginTop: 24 }}>
+        <div className="scroll" ref={scopeRef}>
+          <div className="hero" style={{ marginTop: 24 }} key={scene}>
             <Ring icon="loader" spin className="glow" />
             <div className="headline shimmer">
               {busy === "install" ? t("progress.installing") : t("progress.title")}
@@ -272,15 +290,15 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     return (
       <div className="pop">
         <TopBar />
-        <div className="scroll view">
+        <div className="scroll" ref={scopeRef}>
           {error ? (
             <div className="banner err">
               <Icon name="alert" />
               <span>{error}</span>
             </div>
           ) : null}
-          <section className="hero" style={{ marginTop: 16 }}>
-            <Ring icon="check" variant="success" className="pop" />
+          <section className="hero" style={{ marginTop: 16 }} key={scene}>
+            <Ring icon="check" variant="success" />
             <div className="headline">{t("install.done.title")}</div>
             <div className="sub">
               {installedVersion ? t("home.uptodate.sub", { version: installedVersion }) : ""}
@@ -308,7 +326,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
         </button>
       </TopBar>
 
-      <div className="scroll view">
+      <div className="scroll" ref={scopeRef}>
         {perform ? (
           <div className={`banner ${perform.rolledBack ? "err" : "ok"}`}>
             <Icon name={perform.rolledBack ? "alert" : "check"} />
@@ -324,7 +342,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
           </div>
         ) : null}
 
-        <section className="hero">
+        <section className="hero" key={scene}>
           {rechecking ? (
             // Mirror the settled hero's line count (ring + headline + sub +
             // status line) so nothing below shifts while the check runs.
@@ -397,7 +415,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
             </>
           ) : (
             <>
-              <Ring icon="check" variant="success" className="pop" key={`ok-${recheckPulse}`} />
+              <Ring icon="check" variant="success" />
               <div className="headline">{t("home.uptodate.title")}</div>
               <div className="sub">{t("home.uptodate.sub", { version: installedVersion })}</div>
               <div className="microcue">

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -11,10 +11,11 @@ import type {
 } from "../../shared/types";
 import { DEFAULT_SETTINGS } from "../../shared/types";
 import { Icon, CodexGlyph } from "../icons";
-import { useI18n, type TKey } from "../i18n";
+import { useI18n, dirOf, type TKey } from "../i18n";
 import { Ring, TopBar } from "../components";
 import { useCountUp } from "../useCountUp";
 import { mib, fmtDateTime } from "../format";
+import { useHomeMotion } from "../motion";
 
 function samePath(a: string, b: string): boolean {
   const norm = (value: string) =>
@@ -29,9 +30,6 @@ type Kind = "loading" | "error" | "none" | "idle" | "update" | "external" | "upt
 export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const { t, lang } = useI18n();
   const [report, setReport] = useState<WinUpdateReport | null>(null);
-  // Bumped after each successful check so the success medallion re-mounts and
-  // replays its pop + checkmark-draw — the visible "re-confirmed" feedback.
-  const [recheckPulse, setRecheckPulse] = useState(0);
   const [status, setStatus] = useState<WinInstallStatus | null>(null);
   const [perform, setPerform] = useState<WinPerformReport | null>(null);
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
@@ -46,6 +44,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [dl, setDl] = useState<DownloadProgress | null>(null);
   const [speed, setSpeed] = useState(0);
   const dlSample = useRef<{ t: number; bytes: number } | null>(null);
+  const scopeRef = useRef<HTMLDivElement>(null);
   // Smoothly roll the live download figures instead of snapping per event.
   const dlPctTarget = dl && dl.total > 0 ? Math.min(100, (dl.downloaded / dl.total) * 100) : 0;
   const dlPct = useCountUp(dlPctTarget);
@@ -81,7 +80,6 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     setError(null);
     try {
       setReport(await managerApi.winPlanUpdate());
-      setRecheckPulse((p) => p + 1);
     } catch (cause) {
       setReport(null);
       setError(errorMessage(cause));
@@ -247,14 +245,25 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     void managerApi.winLaunch().catch((cause) => setError(errorMessage(cause)));
   };
 
-  if (busy === "perform" || busy === "install") {
+  // Scene id; on change the hero remounts and GSAP replays the entrance. `lang`
+  // is part of the key so a language switch re-splits the headline (otherwise
+  // SplitText's aria-label keeps the old language's text for screen readers).
+  const progressing = busy === "perform" || busy === "install";
+  const isShimmer = progressing || rechecking || kind === "loading";
+  const scene = `${lang}/${progressing ? `progress-${busy}` : `${kind}${rechecking ? "-checking" : ""}`}`;
+  const success = !rechecking && kind === "uptodate";
+  // Char-split only LTR scripts — splitting cursive RTL (Arabic) breaks joining.
+  const splitHeadline = !isShimmer && dirOf(lang) === "ltr";
+  useHomeMotion(scopeRef, scene, { splitHeadline, success });
+
+  if (progressing) {
     const known = Boolean(dl && dl.total > 0);
     const pct = known ? Math.round(dlPct) : null;
     return (
       <div className="pop">
         <TopBar />
-        <div className="scroll view">
-          <div className="hero" style={{ marginTop: 24 }}>
+        <div className="scroll" ref={scopeRef}>
+          <div className="hero" style={{ marginTop: 24 }} key={scene}>
             <Ring icon="loader" spin className="glow" />
             <div className="headline shimmer">
               {busy === "install" ? t("progress.installing") : t("progress.title")}
@@ -294,7 +303,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
         </button>
       </TopBar>
 
-      <div className="scroll view">
+      <div className="scroll" ref={scopeRef}>
         {perform ? (
           <div className={`banner ${perform.success ? "ok" : "err"}`}>
             <Icon name={perform.success ? "check" : "alert"} />
@@ -308,7 +317,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
           </div>
         ) : null}
 
-        <section className="hero">
+        <section className="hero" key={scene}>
           {rechecking ? (
             // Mirror the settled hero's line count (ring + headline + sub +
             // status line) so nothing below shifts while the check runs.
@@ -384,7 +393,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
             </>
           ) : (
             <>
-              <Ring icon="check" variant="success" className="pop" key={`ok-${recheckPulse}`} />
+              <Ring icon="check" variant="success" />
               <div className="headline">{t("home.uptodate.title")}</div>
               <div className="sub">{t("home.uptodate.sub", { version })}</div>
               <div className="microcue">


### PR DESCRIPTION
叠加在 #15 之上(base = `claude/reverent-sutherland-7cd5f5`),所以本 PR 的 diff 只含 GSAP 动效部分。#15 合并后可改 base 到 `main`。

## 做了什么
为主页加入 GSAP 编排式动效(`src/app/motion.ts` 统一注册插件 + 签名 CustomEase + `useHomeMotion()`):

- **编排入场**:每次主页「场景」(状态 / 重新检查 / 下载 / 完成,含语言)变化,hero 重挂载并由一条 GSAP 时间线重放——勋章 `cam-pop` 弹入 → 标题 **SplitText 逐字揭示** → 副标题/详情卡/按钮依次错落。
- **DrawSVG** 让「已是最新 / 已安装」对勾自绘。
- 全部由 `gsap.matchMedia('(prefers-reduced-motion: no-preference)')` 包裹 → reduced-motion 用户得到静态、完全可见的布局。
- mac + win 两个主页都接入;Settings/About/Uninstall 维持原 CSS 入场;环境动效(呼吸光/微光/进度流光)不变。

## 关键实现细节(均由 Codex review 迭代收敛而来)
- `fromTo()` 显式终点(持久兄弟节点不随 keyed hero 重挂载,裸 `from()` 会读到残留 inline `opacity:0` 当终点而卡住隐藏)。
- 入场结束 `clearProps` 清掉 GSAP 内联样式,交还给 CSS(否则 inline `opacity:1` 会盖过 `.btn:disabled` 淡化与 `:active` 按压)。
- 跳过 `aria-hidden` 占位元素(避免 `autoAlpha` 把「重新检查」态的隐藏 `.microcue` 撑高占位行显示出来)。
- `lang` 纳入 scene key:切换语言时重挂载标题并重拆,避免 SplitText 的 `aria-label` 残留旧语言文本。
- **RTL/阿拉伯语跳过逐字拆分**(`dirOf(lang)`):阿拉伯字母需按词形连写,逐字拆分会断字。

## 体积
JS 99.7KB → 144.6KB gz(+45KB,GSAP core + Flip + SplitText + DrawSVG + CustomEase)。桌面端本地打包,影响可忽略。

## 验证
经 **6 轮 `codex review` 迭代**(共发现并修复 4 个真实 P2 问题:语言切换 aria 残留、内联样式覆盖禁用/按压态、隐藏占位行被显示、阿拉伯语断字),最后**连续两轮无意见**。
本地:`tsc` ✓ · `vitest` 11 ✓ · `vite build` ✓ · headless Chrome 逐态截图核对(none/uptodate/重新检查循环/设置页)+ 控制台零报错 + 终态全部可见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)