### PR TITLE
ci(release): retry the Tauri build to survive transient bundler downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,22 @@ jobs:
 
       # ── Build WITHOUT a tauri signingIdentity; we sign inside-out after ────
       - name: Build (Tauri, unsigned)
+        shell: bash
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: npm run tauri build -- --target ${{ matrix.target }}
+        # Bundling downloads toolchains on the fly (e.g. the NSIS archive from
+        # GitHub) which occasionally 504s and fails the whole release. Retry a
+        # few times so a transient download hiccup doesn't sink the run — cargo
+        # output is cached, so a retry mostly just re-runs the bundling step.
+        run: |
+          for attempt in 1 2 3; do
+            npm run tauri build -- --target ${{ matrix.target }} && exit 0
+            echo "::warning::tauri build attempt ${attempt} failed (often a transient NSIS/toolchain download, e.g. HTTP 504) — retrying in 20s"
+            sleep 20
+          done
+          echo "::error::tauri build failed after 3 attempts"
+          exit 1
 
       # ── macOS: adaptive icon → sign → notarize → staple → repackage ───────
       - name: Finalize macOS bundle


### PR DESCRIPTION
## 背景
v0.1.8 的 Release 里 **Windows 构建失败**,卡在 Tauri 打 NSIS 安装包时——它会临时从 GitHub 下载 `nsis-3.11.zip` 工具链,这次撞上 **HTTP 504**:

```
Info Verifying NSIS package
Downloading https://github.com/tauri-apps/binary-releases/.../nsis-3.11.zip
failed to bundle project `http status: 504`
```

Rust 编译和 macOS 全程都成功,纯属下载工具链时的瞬时 CDN 抖动。当时靠手动 `gh run rerun --failed` 才发出去。

## 改动
把 `Build (Tauri, unsigned)` 步骤包一层 **3 次重试 + 退避**,这样瞬时下载失败不会再让整条 release 挂掉:
- 加 `shell: bash`,让重试循环在 Windows runner 上也能跑(默认是 pwsh)。
- 成功即 `exit 0`;失败打印 `::warning::` 后等 20s 重试;3 次都失败才 `::error::` 退出。
- cargo 产物有缓存,重试基本只重跑打包步骤,几乎不增加成功路径的耗时。

不影响成功路径(首次成功就直接退出),也不改签名/公证等后续步骤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)