### PR TITLE
feat(windows): verify MSIX health post-install, warn on stripped systems

### DIFF
--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -46,7 +46,7 @@ pub use sys::{
     detect_installed_codex, detect_portable_install, fetch_text, launch_codex,
     probe_capabilities, remove_msix_package, InstalledWindowsCodex, MsixRemoveReport,
 };
-pub use sys::{install_msix_sideload, MsixSideloadReport};
+pub use sys::{install_msix_sideload, verify_msix_health, MsixHealthReport, MsixSideloadReport};
 pub use version::{compare_versions, version_key};
 
 pub const OPENAI_PACKAGE_IDENTITY: &str = "OpenAI.Codex";

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -53,6 +53,30 @@ pub struct MsixRemoveReport {
     pub raw_error: Option<String>,
 }
 
+/// Post-install sanity check for a sideloaded MSIX. `Add-AppxPackage` returning
+/// success only means the cmdlet did not throw — on a stripped Windows (no
+/// Store / App Installer, missing framework packages) the package can register
+/// yet fail to launch, which is exactly the failure users hit. We verify the
+/// package is registered, its Status is Ok, the app entry (AUMID) resolves, and
+/// every declared framework dependency is actually present; when any of these
+/// fail the caller removes the package and falls back to the portable build.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MsixHealthReport {
+    pub healthy: bool,
+    pub package_registered: bool,
+    /// Raw `Get-AppxPackage` Status string (e.g. "Ok", "Modified").
+    pub status: String,
+    pub status_ok: bool,
+    /// The app entry (AUMID) could be resolved from the package manifest.
+    pub aumid_resolved: bool,
+    /// Declared framework dependencies that are NOT installed on this machine —
+    /// the usual reason an MSIX installs but won't launch on a stripped Windows.
+    pub missing_dependencies: Vec<String>,
+    /// Human-facing reason when unhealthy; empty when healthy.
+    pub reason: String,
+}
+
 pub fn fetch_text(url: &str) -> Result<String, EngineError> {
     let output = hidden_command("curl")
         .args(["-fsSL", "--connect-timeout", "20", url])
@@ -219,6 +243,145 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
         message: "MSIX removal is only available on Windows".to_string(),
         raw_error: None,
     })
+}
+
+#[cfg(windows)]
+pub fn verify_msix_health() -> MsixHealthReport {
+    let script = format!(
+        r#"
+$ErrorActionPreference = 'SilentlyContinue'
+$pkg = Get-AppxPackage -Name {name} |
+  Sort-Object -Property Version -Descending |
+  Select-Object -First 1
+if ($null -eq $pkg) {{
+  [pscustomobject]@{{
+    packageRegistered = $false
+    statusOk = $false
+    status = 'not-registered'
+    aumidResolved = $false
+    missingDependencies = ''
+  }} | ConvertTo-Json -Compress
+  exit 0
+}}
+$statusStr = [string]$pkg.Status
+$statusOk = ([string]::IsNullOrEmpty($statusStr) -or $statusStr -eq 'Ok')
+$aumidResolved = $false
+$missing = @()
+try {{
+  $manifest = Get-AppxPackageManifest $pkg -ErrorAction Stop
+  $app = $manifest.Package.Applications.Application
+  if ($app -is [array]) {{ $app = $app[0] }}
+  $appId = [string]$app.Id
+  if (-not [string]::IsNullOrEmpty($appId)) {{ $aumidResolved = $true }}
+  $deps = $manifest.Package.Dependencies.PackageDependency
+  foreach ($d in @($deps)) {{
+    if ($null -ne $d) {{
+      $dn = [string]$d.Name
+      if (-not [string]::IsNullOrEmpty($dn)) {{
+        $depPkg = Get-AppxPackage -Name $dn -ErrorAction SilentlyContinue |
+          Select-Object -First 1
+        if ($null -eq $depPkg) {{ $missing += $dn }}
+      }}
+    }}
+  }}
+}} catch {{}}
+[pscustomobject]@{{
+  packageRegistered = $true
+  statusOk = $statusOk
+  status = $statusStr
+  aumidResolved = $aumidResolved
+  missingDependencies = ($missing -join ', ')
+}} | ConvertTo-Json -Compress
+"#,
+        name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
+    );
+
+    let parsed = run_powershell_json(&script)
+        .ok()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok());
+
+    let Some(value) = parsed else {
+        // The health probe itself could not run. Don't overturn a successful
+        // Add-AppxPackage on an unverifiable signal — keep the MSIX install.
+        return MsixHealthReport {
+            healthy: true,
+            package_registered: true,
+            status: "probe-failed".to_string(),
+            status_ok: true,
+            aumid_resolved: true,
+            missing_dependencies: vec![],
+            reason: "health probe could not run; keeping the MSIX install".to_string(),
+        };
+    };
+
+    let package_registered = value
+        .get("packageRegistered")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let status_ok = value
+        .get("statusOk")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let aumid_resolved = value
+        .get("aumidResolved")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let missing_text = value
+        .get("missingDependencies")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let missing_dependencies: Vec<String> = missing_text
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let healthy =
+        package_registered && status_ok && aumid_resolved && missing_dependencies.is_empty();
+    let reason = if healthy {
+        String::new()
+    } else if !package_registered {
+        "the package is not registered after install".to_string()
+    } else if !status_ok {
+        format!("package status is {status}")
+    } else if !aumid_resolved {
+        "could not resolve the app entry (AUMID)".to_string()
+    } else {
+        format!(
+            "missing framework dependencies: {}",
+            missing_dependencies.join(", ")
+        )
+    };
+
+    MsixHealthReport {
+        healthy,
+        package_registered,
+        status,
+        status_ok,
+        aumid_resolved,
+        missing_dependencies,
+        reason,
+    }
+}
+
+#[cfg(not(windows))]
+pub fn verify_msix_health() -> MsixHealthReport {
+    // Non-Windows builds never sideload, so there is nothing to verify; report
+    // healthy so this can never be the thing that blocks a (non-existent) path.
+    MsixHealthReport {
+        healthy: true,
+        package_registered: false,
+        status: "not-windows".to_string(),
+        status_ok: true,
+        aumid_resolved: true,
+        missing_dependencies: vec![],
+        reason: "MSIX health checks are only meaningful on Windows".to_string(),
+    }
 }
 
 #[cfg(windows)]

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -267,20 +267,59 @@ $statusStr = [string]$pkg.Status
 $statusOk = ([string]::IsNullOrEmpty($statusStr) -or $statusStr -eq 'Ok')
 $aumidResolved = $false
 $missing = @()
+function Convert-ToVersion($value) {{
+  try {{
+    $text = [string]$value
+    if ([string]::IsNullOrWhiteSpace($text)) {{ return $null }}
+    return [version]$text
+  }} catch {{
+    return $null
+  }}
+}}
+function Same-Publisher($package, [string]$publisher) {{
+  if ([string]::IsNullOrWhiteSpace($publisher)) {{ return $true }}
+  return [string]$package.Publisher -eq $publisher
+}}
+function Same-Architecture($package, [string]$required) {{
+  if ([string]::IsNullOrWhiteSpace($required) -or $required -eq 'neutral') {{ return $true }}
+  $arch = [string]$package.Architecture
+  return [string]::IsNullOrWhiteSpace($arch) -or $arch -eq 'Neutral' -or $arch -eq $required
+}}
 try {{
   $manifest = Get-AppxPackageManifest $pkg -ErrorAction Stop
   $app = $manifest.Package.Applications.Application
   if ($app -is [array]) {{ $app = $app[0] }}
   $appId = [string]$app.Id
   if (-not [string]::IsNullOrEmpty($appId)) {{ $aumidResolved = $true }}
+  $mainArch = [string]$pkg.Architecture
   $deps = $manifest.Package.Dependencies.PackageDependency
   foreach ($d in @($deps)) {{
     if ($null -ne $d) {{
       $dn = [string]$d.Name
       if (-not [string]::IsNullOrEmpty($dn)) {{
-        $depPkg = Get-AppxPackage -Name $dn -ErrorAction SilentlyContinue |
+        $depPublisher = [string]$d.Publisher
+        $depMinText = [string]$d.MinVersion
+        $depMin = Convert-ToVersion $depMinText
+        $depArch = [string]$d.ProcessorArchitecture
+        if ([string]::IsNullOrWhiteSpace($depArch)) {{ $depArch = $mainArch }}
+        $candidates = @(Get-AppxPackage -Name $dn -ErrorAction SilentlyContinue |
+          Where-Object {{ Same-Publisher $_ $depPublisher }})
+        $archCandidates = @($candidates | Where-Object {{ Same-Architecture $_ $depArch }})
+        if ($candidates.Count -gt 0 -and $archCandidates.Count -eq 0) {{
+          $missing += "$dn architecture $depArch not installed"
+          continue
+        }}
+        $depPkg = $archCandidates |
+          Sort-Object -Property @{{ Expression = {{ Convert-ToVersion $_.Version }}; Descending = $true }} |
           Select-Object -First 1
-        if ($null -eq $depPkg) {{ $missing += $dn }}
+        if ($null -eq $depPkg) {{
+          $missing += "$dn not installed"
+        }} else {{
+          $installedVersion = Convert-ToVersion $depPkg.Version
+          if ($null -ne $depMin -and $null -ne $installedVersion -and $installedVersion -lt $depMin) {{
+            $missing += "$dn >= $depMinText required (installed $($depPkg.Version))"
+          }}
+        }}
       }}
     }}
   }}

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -533,17 +533,37 @@ pub fn perform_windows_update_with_install_mode(
         // Add-AppxPackage returning success only means the cmdlet didn't throw.
         // Verify the package is actually runnable before committing to it — on a
         // stripped Windows it can register yet fail to launch. If it's unhealthy,
-        // remove it and fall back to portable so the user gets a build that runs.
+        // first install the portable fallback so the user is never left without
+        // a runnable build, then clean up the bad MSIX best-effort.
         let health = verify_msix_health();
         if !health.healthy {
-            let _ = remove_msix_package();
-            return install_portable_after_stage(
+            let mut report = install_portable_after_stage(
                 settings,
                 stage,
                 Some(sideload),
                 Some(health),
                 previous_installed,
-            );
+            )?;
+            match remove_msix_package() {
+                Ok(remove) if remove.success => {
+                    report.notes.push(
+                        "Unhealthy MSIX package was removed after portable fallback succeeded."
+                            .to_string(),
+                    );
+                }
+                Ok(remove) => {
+                    report.notes.push(format!(
+                        "Portable fallback succeeded, but removing the unhealthy MSIX package failed: {}",
+                        remove.message
+                    ));
+                }
+                Err(err) => {
+                    report.notes.push(format!(
+                        "Portable fallback succeeded, but removing the unhealthy MSIX package could not run: {err}"
+                    ));
+                }
+            }
+            return Ok(report);
         }
 
         let installed = sideload

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -15,10 +15,11 @@ use codex_win_engine::{
     detect_portable_install, download_to_with_progress, fetch_text, find_msix_sha256,
     install_msix_sideload, install_portable_from_msix, parse_manifest, plan_update,
     probe_capabilities, purge_codex_user_data, read_msix_identity, remove_msix_package,
-    sha256_file, uninstall_portable, validate_codex_identity, verify_openai_authenticode,
-    version_key, AuthenticodeReport, CapabilityState, InstalledWindowsCodex, MsixIdentity,
-    MsixRemoveReport, MsixSideloadReport, PortableInstallReport, PortableUninstallReport,
-    WinCapabilityReport, WinInstallRoute, WindowsRelease, WindowsUpdatePlan,
+    sha256_file, uninstall_portable, validate_codex_identity, verify_msix_health,
+    verify_openai_authenticode, version_key, AuthenticodeReport, CapabilityState,
+    InstalledWindowsCodex, MsixHealthReport, MsixIdentity, MsixRemoveReport, MsixSideloadReport,
+    PortableInstallReport, PortableUninstallReport, WinCapabilityReport, WinInstallRoute,
+    WindowsRelease, WindowsUpdatePlan,
 };
 
 use crate::app::provenance::ProvenanceStore;
@@ -79,6 +80,7 @@ pub struct WinPerformReport {
     pub stage: WinStageReport,
     pub sideload: Option<MsixSideloadReport>,
     pub portable: Option<PortableInstallReport>,
+    pub msix_health: Option<MsixHealthReport>,
     pub installed: Option<InstalledWindowsCodex>,
     pub fallback_available: bool,
     pub fallback_attempted: bool,
@@ -491,6 +493,7 @@ pub fn perform_windows_update_with_install_mode(
             installed: win_install_status(settings).installed,
             sideload: None,
             portable: None,
+            msix_health: None,
             fallback_available: stage.portable_fallback_ready,
             fallback_attempted: false,
             notes: stage.notes.clone(),
@@ -499,7 +502,7 @@ pub fn perform_windows_update_with_install_mode(
     }
 
     if stage.route == "portable-fallback" {
-        return install_portable_after_stage(settings, stage, None, previous_installed);
+        return install_portable_after_stage(settings, stage, None, None, previous_installed);
     }
 
     let staged_path = stage
@@ -527,6 +530,22 @@ pub fn perform_windows_update_with_install_mode(
         install_msix_sideload(PathBuf::from(staged_path).as_path()).map_err(engine_err)?;
 
     if sideload.success {
+        // Add-AppxPackage returning success only means the cmdlet didn't throw.
+        // Verify the package is actually runnable before committing to it — on a
+        // stripped Windows it can register yet fail to launch. If it's unhealthy,
+        // remove it and fall back to portable so the user gets a build that runs.
+        let health = verify_msix_health();
+        if !health.healthy {
+            let _ = remove_msix_package();
+            return install_portable_after_stage(
+                settings,
+                stage,
+                Some(sideload),
+                Some(health),
+                previous_installed,
+            );
+        }
+
         let installed = sideload
             .installed
             .clone()
@@ -551,6 +570,7 @@ pub fn perform_windows_update_with_install_mode(
             installed,
             sideload: Some(sideload),
             portable: None,
+            msix_health: Some(health),
             fallback_available: stage.portable_fallback_ready,
             fallback_attempted: false,
             notes: stage.notes.clone(),
@@ -558,13 +578,14 @@ pub fn perform_windows_update_with_install_mode(
         });
     }
 
-    install_portable_after_stage(settings, stage, Some(sideload), previous_installed)
+    install_portable_after_stage(settings, stage, Some(sideload), None, previous_installed)
 }
 
 fn install_portable_after_stage(
     settings: &AppSettings,
     stage: WinStageReport,
     sideload: Option<MsixSideloadReport>,
+    health: Option<MsixHealthReport>,
     previous_installed: Option<InstalledWindowsCodex>,
 ) -> Result<WinPerformReport, AppError> {
     let staged_path = stage
@@ -602,7 +623,15 @@ fn install_portable_after_stage(
     }
 
     let mut notes = stage.notes.clone();
-    if let Some(sideload) = &sideload {
+    let msix_unhealthy = health.as_ref().is_some_and(|h| !h.healthy);
+    if let Some(health) = &health {
+        if !health.healthy {
+            notes.push(format!(
+                "MSIX installed but failed its post-install health check ({}); switched to the portable build.",
+                health.reason
+            ));
+        }
+    } else if let Some(sideload) = &sideload {
         notes.push(format!(
             "MSIX sideload failed without elevation or policy changes: {}",
             sideload.message
@@ -610,17 +639,23 @@ fn install_portable_after_stage(
     }
     notes.extend(portable.notes.clone());
 
+    let action = if msix_unhealthy {
+        "portable-fallback-after-msix-unhealthy"
+    } else if sideload.is_some() {
+        "portable-fallback-after-msix-failure"
+    } else {
+        "portable-fallback"
+    }
+    .to_string();
+
     Ok(WinPerformReport {
         success: true,
-        action: if sideload.is_some() {
-            "portable-fallback-after-msix-failure".to_string()
-        } else {
-            "portable-fallback".to_string()
-        },
+        action,
         message: portable.message.clone(),
         installed,
         sideload,
         portable: Some(portable),
+        msix_health: health,
         fallback_available: true,
         fallback_attempted: true,
         notes,

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -170,6 +170,8 @@ const ZH = {
   "win.confirm.body": "安装时会关闭 Codex,完成后可重新打开,大约一分钟。",
   "win.route.msix": "标准安装（MSIX）",
   "win.route.portable": "免安装版（EXE）",
+  "win.msixRisk.body": "这台电脑似乎缺少应用商店 / App Installer 组件,标准安装（MSIX）即使装上也可能无法启动。建议改用免安装版。",
+  "win.msixRisk.switch": "改用免安装版",
   "win.installDir.title": "选择安装位置",
   "win.installDir.body": "免安装版会安装到下面的文件夹。选择普通文件夹时,会使用其下的 Codex 子文件夹;系统目录会被拒绝。",
   "win.installDir.useDefault": "安装到默认位置",
@@ -329,6 +331,8 @@ const EN: Record<Key, string> = {
   "win.confirm.body": "Codex will close during install and can reopen after — about a minute.",
   "win.route.msix": "Standard install (MSIX)",
   "win.route.portable": "Portable install (EXE)",
+  "win.msixRisk.body": "This PC appears to be missing the Microsoft Store / App Installer components, so the standard MSIX install may not launch even after it installs. Switching to the portable build is recommended.",
+  "win.msixRisk.switch": "Switch to portable",
   "win.installDir.title": "Choose install location",
   "win.installDir.body": "The portable app will install in the folder below. Picking an ordinary folder uses a Codex subfolder; system folders are rejected.",
   "win.installDir.useDefault": "Install to default",
@@ -485,6 +489,8 @@ const FR: Record<Key, string> = {
   "win.confirm.body": "Codex va se fermer pendant l'installation et pourra rouvrir ensuite — environ une minute.",
   "win.route.msix": "Installation standard (MSIX)",
   "win.route.portable": "Installation portable (EXE)",
+  "win.msixRisk.body": "Ce PC semble dépourvu des composants Microsoft Store / App Installer ; l'installation standard (MSIX) pourrait ne pas démarrer même une fois installée. Il est recommandé de passer à la version portable.",
+  "win.msixRisk.switch": "Passer à la version portable",
   "win.installDir.title": "Choisir l'emplacement d'installation",
   "win.installDir.body": "La version portable sera installée dans le dossier ci-dessous. Si vous choisissez un dossier ordinaire, un sous-dossier Codex sera utilisé; les dossiers système sont refusés.",
   "win.installDir.useDefault": "Installer à l'emplacement par défaut",
@@ -652,6 +658,8 @@ const ZH_TW: Record<Key, string> = {
   "win.confirm.body": "安裝時 Codex 會關閉，完成後可重新開啟，約需一分鐘。",
   "win.route.msix": "標準安裝（MSIX）",
   "win.route.portable": "免安裝版（EXE）",
+  "win.msixRisk.body": "這台電腦似乎缺少應用程式商店 / App Installer 元件,標準安裝（MSIX）即使裝上也可能無法啟動。建議改用免安裝版。",
+  "win.msixRisk.switch": "改用免安裝版",
   "win.installDir.title": "選擇安裝位置",
   "win.installDir.body":
     "免安裝版會安裝到下面的資料夾。選擇一般資料夾時，會使用其下的 Codex 子資料夾；系統目錄會被拒絕。",
@@ -821,6 +829,8 @@ const DE: Record<Key, string> = {
     "Codex wird während der Installation geschlossen und kann danach wieder geöffnet werden — dauert etwa eine Minute.",
   "win.route.msix": "Standardinstallation (MSIX)",
   "win.route.portable": "Portable-Version (EXE)",
+  "win.msixRisk.body": "Auf diesem PC fehlen anscheinend die Microsoft Store / App Installer-Komponenten; die Standardinstallation (MSIX) startet möglicherweise selbst nach der Installation nicht. Es wird empfohlen, zur Portable-Version zu wechseln.",
+  "win.msixRisk.switch": "Zur Portable-Version wechseln",
   "win.installDir.title": "Installationsort auswählen",
   "win.installDir.body":
     "Die portable Version wird im unten stehenden Ordner installiert. Bei einem normalen Ordner wird ein Codex-Unterordner verwendet; Systemordner werden abgelehnt.",
@@ -989,6 +999,8 @@ const KO: Record<Key, string> = {
   "win.confirm.body": "설치 중 Codex가 종료되며, 완료 후 다시 열 수 있습니다 — 약 1분 소요.",
   "win.route.msix": "표준 설치 (MSIX)",
   "win.route.portable": "포터블 설치 (EXE)",
+  "win.msixRisk.body": "이 PC에는 Microsoft Store / App Installer 구성 요소가 없는 것 같습니다. 표준 설치(MSIX)는 설치되더라도 실행되지 않을 수 있습니다. 포터블 버전으로 전환하는 것을 권장합니다.",
+  "win.msixRisk.switch": "포터블로 전환",
   "win.installDir.title": "설치 위치 선택",
   "win.installDir.body":
     "포터블 버전은 아래 폴더에 설치됩니다. 일반 폴더를 선택하면 그 안의 Codex 하위 폴더를 사용하며, 시스템 폴더는 거부됩니다.",
@@ -1137,6 +1149,8 @@ const JA: Record<Key, string> = {
   "win.confirm.body": "インストール中は Codex が閉じ、完了後に再起動できます — 約 1 分かかります。",
   "win.route.msix": "標準インストール（MSIX）",
   "win.route.portable": "ポータブルインストール（EXE）",
+  "win.msixRisk.body": "この PC には Microsoft Store / App Installer コンポーネントが見当たりません。標準インストール（MSIX）はインストールできても起動しない場合があります。ポータブル版への切り替えをおすすめします。",
+  "win.msixRisk.switch": "ポータブル版に切り替え",
   "win.installDir.title": "インストール先を選択",
   "win.installDir.body":
     "ポータブル版は下のフォルダーにインストールされます。通常のフォルダーを選ぶと、その中の Codex サブフォルダーを使用します。システムフォルダーは拒否されます。",
@@ -1284,6 +1298,8 @@ const RU: Record<Key, string> = {
   "win.confirm.body": "Codex закроется во время установки и может быть открыт после — около минуты.",
   "win.route.msix": "Стандартная установка (MSIX)",
   "win.route.portable": "Портативная версия (EXE)",
+  "win.msixRisk.body": "На этом компьютере, похоже, отсутствуют компоненты Microsoft Store / App Installer; стандартная установка (MSIX) может не запуститься даже после установки. Рекомендуется перейти на портативную версию.",
+  "win.msixRisk.switch": "Перейти на портативную версию",
   "win.installDir.title": "Выбрать место установки",
   "win.installDir.body":
     "Портативная версия будет установлена в папку ниже. При выборе обычной папки будет использована подпапка Codex; системные папки отклоняются.",
@@ -1431,6 +1447,8 @@ const AR: Record<Key, string> = {
   "win.confirm.body": "سيُغلق Codex أثناء التثبيت ويمكن إعادة فتحه بعده — دقيقة تقريباً.",
   "win.route.msix": "تثبيت قياسي (MSIX)",
   "win.route.portable": "تثبيت محمول (EXE)",
+  "win.msixRisk.body": "يبدو أن هذا الجهاز يفتقر إلى مكوّنات متجر Microsoft / App Installer، لذا قد لا يبدأ التثبيت القياسي (MSIX) حتى بعد تثبيته. يُنصح بالتبديل إلى النسخة المحمولة.",
+  "win.msixRisk.switch": "التبديل إلى النسخة المحمولة",
   "win.installDir.title": "اختيار موقع التثبيت",
   "win.installDir.body":
     "سيُثبَّت الإصدار المحمول في المجلد أدناه. عند اختيار مجلد عادي، سيُستخدم مجلد Codex فرعي داخله؛ وسيتم رفض مجلدات النظام.",
@@ -1578,6 +1596,8 @@ const ES: Record<Key, string> = {
   "win.confirm.body": "Codex se cerrará durante la instalación y podrá reabrirse después — tarda alrededor de un minuto.",
   "win.route.msix": "Instalación estándar (MSIX)",
   "win.route.portable": "Instalación portátil (EXE)",
+  "win.msixRisk.body": "Parece que a este equipo le faltan los componentes de Microsoft Store / App Installer; la instalación estándar (MSIX) podría no abrirse aunque se instale. Se recomienda cambiar a la versión portátil.",
+  "win.msixRisk.switch": "Cambiar a portátil",
   "win.installDir.title": "Elegir ubicación de instalación",
   "win.installDir.body":
     "La versión portátil se instalará en la carpeta de abajo. Si eliges una carpeta normal, se usará una subcarpeta Codex; las carpetas del sistema se rechazan.",
@@ -1725,6 +1745,8 @@ const PT_BR: Record<Key, string> = {
   "win.confirm.body": "O Codex vai fechar durante a instalação e pode reabrir depois — cerca de um minuto.",
   "win.route.msix": "Instalação padrão (MSIX)",
   "win.route.portable": "Instalação portátil (EXE)",
+  "win.msixRisk.body": "Este PC parece não ter os componentes da Microsoft Store / App Installer; a instalação padrão (MSIX) pode não abrir mesmo depois de instalada. Recomendamos mudar para a versão portátil.",
+  "win.msixRisk.switch": "Mudar para portátil",
   "win.installDir.title": "Escolher local de instalação",
   "win.installDir.body":
     "A versão portátil será instalada na pasta abaixo. Ao escolher uma pasta comum, será usada uma subpasta Codex; pastas do sistema são recusadas.",

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1176,6 +1176,33 @@ button.row.danger:hover {
   border-color: var(--line);
   box-shadow: var(--elev-1);
 }
+.banner.warn {
+  background: var(--amber-tint);
+  color: var(--amber-deep);
+  border-color: color-mix(in oklch, var(--amber) 24%, transparent);
+}
+/* Inline "switch to portable" action inside the MSIX-risk warning banner. */
+.banner .linkbtn {
+  margin-inline-start: auto;
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  padding: 2px 5px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.16s var(--ease);
+}
+.banner .linkbtn:hover {
+  background: color-mix(in oklch, var(--amber) 18%, transparent);
+}
+.banner .linkbtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
 .note {
   font-size: var(--fs-label);
   color: var(--text-faint);

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -123,6 +123,23 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     }
   }, []);
 
+  // The probe recommended MSIX, but this PC looks like it's missing the Store /
+  // App Installer components — the MSIX can install yet fail to launch (the very
+  // issue users hit). Let them switch to the portable build in one tap: persist
+  // the preference, then re-plan so the route flips to portable and this notice
+  // clears.
+  const switchToPortable = useCallback(async () => {
+    setError(null);
+    try {
+      const next: AppSettings = { ...settings, windowsInstallMode: "portable" };
+      setSettings(await managerApi.setSettings(next));
+    } catch (cause) {
+      setError(errorMessage(cause));
+      return;
+    }
+    await check();
+  }, [settings, check]);
+
   // Windows install + update both go through win_perform_update (the route —
   // MSIX sideload or portable fallback — is decided by the backend plan).
   const runPerform = useCallback(
@@ -214,6 +231,11 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const updateAvailable = Boolean(plan) && !plan?.upToDate;
   const routeNote =
     plan?.route === "portable-fallback" ? t("win.route.portable") : t("win.route.msix");
+  // MSIX is the planned route, yet the App Installer / Store components weren't
+  // detected — a stripped Windows where the package may install but not run.
+  const msixRisky =
+    plan?.route === "msix-sideload" &&
+    report?.capabilities?.appInstaller?.state !== "available";
 
   const kind: Kind = useMemo(() => {
     if (!installed) {
@@ -423,6 +445,16 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
                 {installed.path}
               </span>
             </div>
+          </div>
+        ) : null}
+
+        {!rechecking && msixRisky && (kind === "none" || kind === "update") ? (
+          <div className="banner warn">
+            <Icon name="alert" />
+            <span>{t("win.msixRisk.body")}</span>
+            <button className="linkbtn" onClick={switchToPortable} disabled={busy !== null}>
+              {t("win.msixRisk.switch")}
+            </button>
           </div>
         ) : null}
 

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -235,7 +235,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   // detected — a stripped Windows where the package may install but not run.
   const msixRisky =
     plan?.route === "msix-sideload" &&
-    report?.capabilities?.appInstaller?.state !== "available";
+    report?.capabilities?.appInstaller?.state === "unavailable";
 
   const kind: Kind = useMemo(() => {
     if (!installed) {

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -208,6 +208,7 @@ const WIN_FALLBACK_PERFORM: WinPerformReport = {
     rawError: null,
   },
   portable: null,
+  msixHealth: { healthy: true, packageRegistered: true, status: "Ok", statusOk: true, aumidResolved: true, missingDependencies: [], reason: "" },
   installed: {
     path: "C:\\Program Files\\WindowsApps\\OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0",
     version: "26.602.3474.0",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -229,6 +229,19 @@ export interface MsixSideloadReport {
   rawError: string | null;
 }
 
+export interface MsixHealthReport {
+  healthy: boolean;
+  packageRegistered: boolean;
+  /** Raw Get-AppxPackage Status string (e.g. "Ok", "Modified"). */
+  status: string;
+  statusOk: boolean;
+  aumidResolved: boolean;
+  /** Declared framework dependencies missing on this machine. */
+  missingDependencies: string[];
+  /** Human-facing reason when unhealthy; empty when healthy. */
+  reason: string;
+}
+
 export interface WinPerformReport {
   success: boolean;
   action: string;
@@ -236,6 +249,7 @@ export interface WinPerformReport {
   stage: WinStageReport;
   sideload: MsixSideloadReport | null;
   portable: PortableInstallReport | null;
+  msixHealth: MsixHealthReport | null;
   installed: InstalledWindowsCodex | null;
   fallbackAvailable: boolean;
   fallbackAttempted: boolean;


### PR DESCRIPTION
## 背景

[codex-app-mirror#11](https://github.com/Wangnov/codex-app-mirror/issues/11) 的用户(Windows 11 家庭中文版、系统更新组件缺失、无 Microsoft Store)装上 MSIX 后启动反复弹窗。这类精简/魔改系统能用 `Add-AppxPackage` 注册包,但缺 Store / App Installer / 框架依赖,**装得上却跑不动**。

manager 原本检测不到这种情况:能力探测的三个硬阻塞信号(`Add-AppxPackage` / `AppXSvc` / sideload policy)都不触发,plan 仍判 MSIX;而 sideload "成功" 仅代表 cmdlet 没抛异常,于是不会回退——最终给用户一个跑不动的 MSIX。

## 改动(两层)

### 1. 装后静态健康校验 + 自动回退(治本)
- `verify_msix_health()`(engine):`Add-AppxPackage` 成功后用 PowerShell 复查——包已注册、`Status=Ok`、声明的框架依赖(VCLibs / WindowsAppRuntime 等)都在、AUMID 可解析。probe 自身跑不起来时返回 healthy,不推翻已成功的安装。
- `perform_windows_update`:MSIX 不健康时 best-effort 卸掉坏包并回退 portable;新增 `portable-fallback-after-msix-unhealthy` action。`WinPerformReport` 带上 `msixHealth`。

### 2. 前端风险提示 + 一键切换(知情/兜底)
- plan 推荐 MSIX 但未探测到 App Installer(精简系统强特征)时,`WinHome` 在"未检测到 / 有更新"卡片显示 amber 提示 + 「改用免安装版」按钮:`setSettings` 切 portable 后重新 plan,提示自动消失。文案覆盖 **11 种语言**。

### 局限
静态校验抓不到"静态全正常、一运行才崩"的极端情况——由方向 2 的提示让用户提前知情、主动选 portable 兜底(对应放弃真激活探活的取舍)。

## 验证
- 引擎 `cargo test` 19 通过、app `cargo check`、`clippy` 零警告
- `tsc` 通过、`vitest` 11 通过
- 新增代码 rustfmt-clean;预存格式债务未触碰

🤖 Generated with [Claude Code](https://claude.com/claude-code)