### PR TITLE
feat(dist): manager-owned R2 + IHEP S3 update mirror at /manager/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,3 +180,23 @@ jobs:
           files: |
             dist/*
             latest.json
+
+      # Mirror the release to the CDN so in-app self-update works without GitHub
+      # (slow/blocked for the CN audience). Skips pre-releases so a -rc tag never
+      # overwrites the mirror's single latest.json. No-ops cleanly until the
+      # MANAGER_R2_* (and optionally MANAGER_IHEP_S3_*) secrets are configured.
+      - name: Sync to CDN mirror (R2 + IHEP S3)
+        if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          MANAGER_R2_S3_ENDPOINT: ${{ secrets.MANAGER_R2_S3_ENDPOINT }}
+          MANAGER_R2_ACCESS_KEY_ID: ${{ secrets.MANAGER_R2_ACCESS_KEY_ID }}
+          MANAGER_R2_SECRET_ACCESS_KEY: ${{ secrets.MANAGER_R2_SECRET_ACCESS_KEY }}
+          MANAGER_IHEP_S3_ENDPOINT: ${{ secrets.MANAGER_IHEP_S3_ENDPOINT }}
+          MANAGER_IHEP_S3_BUCKET: ${{ secrets.MANAGER_IHEP_S3_BUCKET }}
+          MANAGER_IHEP_S3_REGION: ${{ secrets.MANAGER_IHEP_S3_REGION }}
+          MANAGER_IHEP_S3_PREFIX: ${{ secrets.MANAGER_IHEP_S3_PREFIX }}
+          MANAGER_IHEP_S3_ACCESS_KEY_ID: ${{ secrets.MANAGER_IHEP_S3_ACCESS_KEY_ID }}
+          MANAGER_IHEP_S3_SECRET_ACCESS_KEY: ${{ secrets.MANAGER_IHEP_S3_SECRET_ACCESS_KEY }}
+        run: |
+          [ -f dist/latest.json ] || cp latest.json dist/latest.json
+          bash scripts/sync-mirror.sh dist

--- a/cloudflare/manager-download-router/README.md
+++ b/cloudflare/manager-download-router/README.md
@@ -1,0 +1,66 @@
+# manager-download-router
+
+Cloudflare Worker that serves the **manager's own** self-update artifacts at
+`https://codexapp.agentsmirror.com/manager/*`, so the in-app updater doesn't
+depend on GitHub (slow/blocked for the mainland-China audience).
+
+It mirrors the `codex-app-mirror` download-router's dual-backend design, but on
+the manager's **own** bucket so the two never mix:
+
+- **Global** → streamed directly from the bound R2 bucket `codex-app-manager`.
+- **Mainland China** (`request.cf.country` ∈ `SECONDARY_COUNTRY_CODES`) → 302 to
+  a presigned **IHEP S3** URL, once the `SECONDARY_S3_*` secrets are set. Until
+  then CN also falls back to R2 (still far better than GitHub).
+
+The updater (`src-tauri/tauri.conf.json`) already checks
+`…/manager/latest.json` first, GitHub second — no app change needed.
+
+## Why a separate latest.json on the mirror
+`latest.json`'s embedded signatures sign the artifact **bytes**, not the URL, so
+re-hosting the same files keeps them valid — we only rewrite the download URLs to
+`…/manager/<file>`. `scripts/sync-mirror.sh` does this on every (non-pre-)release.
+
+> ⚠️ The mirror's `latest.json` MUST be refreshed on every stable release, or the
+> first endpoint serves a stale version and **blocks** updates. That's why the
+> `release.yml` "Sync to CDN mirror" step exists.
+
+## Already provisioned (done)
+- R2 bucket `codex-app-manager` created.
+- This worker deployed with route `codexapp.agentsmirror.com/manager/*` + the R2
+  binding.
+- v0.1.8 seeded (latest.json + installers) — the endpoint is live.
+
+## Remaining setup (your part — S3 + secrets)
+
+### 1. IHEP S3 (CN acceleration) — worker secrets
+Create the manager's IHEP bucket, then set the worker's secrets so CN traffic is
+presigned there:
+```bash
+cd cloudflare/manager-download-router
+wrangler secret put SECONDARY_S3_ENDPOINT          # e.g. https://s3.ihep.ac.cn
+wrangler secret put SECONDARY_S3_BUCKET
+wrangler secret put SECONDARY_S3_ACCESS_KEY_ID
+wrangler secret put SECONDARY_S3_SECRET_ACCESS_KEY
+# optional: SECONDARY_S3_REGION (default "auto"), SECONDARY_S3_PREFIX
+```
+
+### 2. Release auto-sync — GitHub repo secrets
+So each release uploads to the mirror (`release.yml` → `scripts/sync-mirror.sh`):
+
+| Secret | Notes |
+| --- | --- |
+| `MANAGER_R2_S3_ENDPOINT` | `https://d39dc6c92d1c4cfde580bf13e946b616.r2.cloudflarestorage.com` |
+| `MANAGER_R2_ACCESS_KEY_ID` / `MANAGER_R2_SECRET_ACCESS_KEY` | R2 S3 API token (can reuse the mirror's; account-scoped) |
+| `MANAGER_IHEP_S3_ENDPOINT` / `_BUCKET` / `_ACCESS_KEY_ID` / `_SECRET_ACCESS_KEY` | IHEP creds (optional; `_REGION`/`_PREFIX` optional) |
+
+R2 secrets missing → step warns and skips (mirror goes stale). IHEP missing →
+CN just falls back to R2 via the worker.
+
+## Deploy / manual sync
+```bash
+wrangler deploy                         # from this directory
+# manual re-sync of a tag's assets (download release → rewrite → upload):
+#   gh release download vX.Y.Z -D dist && cp -f dist/latest.json dist/ && \
+#   MANAGER_R2_S3_ENDPOINT=… MANAGER_R2_ACCESS_KEY_ID=… MANAGER_R2_SECRET_ACCESS_KEY=… \
+#   bash ../../scripts/sync-mirror.sh dist
+```

--- a/cloudflare/manager-download-router/README.md
+++ b/cloudflare/manager-download-router/README.md
@@ -18,7 +18,16 @@ The updater (`src-tauri/tauri.conf.json`) already checks
 ## Why a separate latest.json on the mirror
 `latest.json`'s embedded signatures sign the artifact **bytes**, not the URL, so
 re-hosting the same files keeps them valid — we only rewrite the download URLs to
-`…/manager/<file>`. `scripts/sync-mirror.sh` does this on every (non-pre-)release.
+`…/manager/<version>/<file>`. `scripts/sync-mirror.sh` does this on every
+(non-pre-)release.
+
+Installers are uploaded under a **per-version** key (`<version>/<file>`) and
+`latest.json` stays at the fixed root the updater polls. macOS updater tarballs
+are renamed upstream to versionless arch-only names, so without the version
+segment every release would reuse one URL and the worker's long installer cache
+could serve a previous version's bytes against the new signature. (The seeded
+v0.1.8 predates this and lives at flat `…/manager/<file>` keys — still
+self-consistent; v0.1.9+ use the versioned layout.)
 
 > ⚠️ The mirror's `latest.json` MUST be refreshed on every stable release, or the
 > first endpoint serves a stale version and **blocks** updates. That's why the

--- a/cloudflare/manager-download-router/src/index.js
+++ b/cloudflare/manager-download-router/src/index.js
@@ -34,7 +34,11 @@ export default {
     // ── Mainland China: presign the IHEP S3 object and redirect ──────────────
     if (secondaryCountryCodes.has(country.toUpperCase()) && hasSecondaryS3Config(env)) {
       const objectKey = objectKeyForKey(key, env.SECONDARY_S3_PREFIX || "");
-      const signedUrl = await presignS3GetUrl({
+      const signedUrl = await presignS3Url({
+        // Sign for the actual method: the redirect preserves it, and an
+        // S3 URL presigned for GET is rejected when followed with HEAD — the
+        // R2 branch below answers HEAD directly, so keep CN symmetric.
+        method: request.method === "HEAD" ? "HEAD" : "GET",
         endpoint: env.SECONDARY_S3_ENDPOINT,
         bucket: env.SECONDARY_S3_BUCKET,
         key: objectKey,
@@ -97,8 +101,8 @@ function objectKeyForKey(key, prefix) {
   return cleanPrefix ? `${cleanPrefix}/${key}` : key;
 }
 
-// ── AWS SigV4 presigner (GET), identical scheme to codex-app-mirror ──────────
-async function presignS3GetUrl(options) {
+// ── AWS SigV4 presigner (GET/HEAD), identical scheme to codex-app-mirror ─────
+async function presignS3Url(options) {
   const endpointUrl = new URL(options.endpoint);
   const now = new Date();
   const amzDate = formatAmzDate(now);
@@ -118,7 +122,7 @@ async function presignS3GetUrl(options) {
   const canonicalQuery = canonicalQueryString(queryParams);
   const canonicalHeaders = `host:${endpointUrl.host}\n`;
   const canonicalRequest = [
-    "GET",
+    options.method || "GET",
     canonicalUri,
     canonicalQuery,
     canonicalHeaders,

--- a/cloudflare/manager-download-router/src/index.js
+++ b/cloudflare/manager-download-router/src/index.js
@@ -1,0 +1,189 @@
+// Manager update-artifact router for https://codexapp.agentsmirror.com/manager/*
+//
+// Global  → served directly from the bound R2 bucket (codex-app-manager).
+// Mainland China (request.cf.country in SECONDARY_COUNTRY_CODES) → 302 to a
+//          presigned IHEP S3 URL, when those secrets are configured.
+//
+// The path after /manager/ is the object key (e.g. /manager/latest.json →
+// "latest.json"). Mirrors codex-app-mirror's download-router, but binds R2
+// directly (self-contained, no extra public domain) and keys on /manager/.
+
+const PREFIX = "/manager/";
+const DEFAULT_SECONDARY_COUNTRY_CODES = "CN";
+const DEFAULT_SIGNED_URL_TTL_SECONDS = 3600;
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith(PREFIX)) {
+      return new Response("Not found", { status: 404 });
+    }
+    const key = decodeURIComponent(url.pathname.slice(PREFIX.length));
+    if (!key || key.endsWith("/") || key.includes("..")) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const country = request.cf?.country || request.headers.get("CF-IPCountry") || "";
+    const secondaryCountryCodes = new Set(
+      (env.SECONDARY_COUNTRY_CODES || DEFAULT_SECONDARY_COUNTRY_CODES)
+        .split(",")
+        .map((code) => code.trim().toUpperCase())
+        .filter(Boolean),
+    );
+
+    // ── Mainland China: presign the IHEP S3 object and redirect ──────────────
+    if (secondaryCountryCodes.has(country.toUpperCase()) && hasSecondaryS3Config(env)) {
+      const objectKey = objectKeyForKey(key, env.SECONDARY_S3_PREFIX || "");
+      const signedUrl = await presignS3GetUrl({
+        endpoint: env.SECONDARY_S3_ENDPOINT,
+        bucket: env.SECONDARY_S3_BUCKET,
+        key: objectKey,
+        region: env.SECONDARY_S3_REGION || "auto",
+        accessKeyId: env.SECONDARY_S3_ACCESS_KEY_ID,
+        secretAccessKey: env.SECONDARY_S3_SECRET_ACCESS_KEY,
+        expiresInSeconds: ttlSeconds(env.SECONDARY_S3_SIGNED_URL_TTL_SECONDS),
+        responseHeaders: {},
+      });
+      return redirect(signedUrl);
+    }
+
+    // ── Everyone else: stream straight from the bound R2 bucket ──────────────
+    const object = await env.BUCKET.get(key);
+    if (!object) {
+      return new Response("Not found", { status: 404 });
+    }
+    const headers = new Headers();
+    object.writeHttpMetadata(headers); // Content-Type etc. from R2 metadata
+    headers.set("ETag", object.httpEtag);
+    headers.set("Cache-Control", cacheControlForKey(key));
+    if (request.method === "HEAD") {
+      return new Response(null, { headers });
+    }
+    return new Response(object.body, { headers });
+  },
+};
+
+// latest.json must refresh quickly so new releases are seen; the (immutable,
+// versioned) installers can cache hard.
+function cacheControlForKey(key) {
+  if (key.endsWith(".json")) return "public, max-age=120, s-maxage=120";
+  return "public, max-age=86400, s-maxage=86400";
+}
+
+function hasSecondaryS3Config(env) {
+  return Boolean(
+    env.SECONDARY_S3_ENDPOINT &&
+      env.SECONDARY_S3_BUCKET &&
+      env.SECONDARY_S3_ACCESS_KEY_ID &&
+      env.SECONDARY_S3_SECRET_ACCESS_KEY,
+  );
+}
+
+function ttlSeconds(value) {
+  const parsed = Number.parseInt(value || DEFAULT_SIGNED_URL_TTL_SECONDS, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_SIGNED_URL_TTL_SECONDS;
+  return Math.min(Math.max(parsed, 1), 604800);
+}
+
+function redirect(location) {
+  return new Response(null, {
+    status: 302,
+    headers: { Location: location, "Cache-Control": "private, no-store" },
+  });
+}
+
+function objectKeyForKey(key, prefix) {
+  const cleanPrefix = prefix.replace(/^\/+|\/+$/g, "");
+  return cleanPrefix ? `${cleanPrefix}/${key}` : key;
+}
+
+// ── AWS SigV4 presigner (GET), identical scheme to codex-app-mirror ──────────
+async function presignS3GetUrl(options) {
+  const endpointUrl = new URL(options.endpoint);
+  const now = new Date();
+  const amzDate = formatAmzDate(now);
+  const dateStamp = amzDate.slice(0, 8);
+  const credentialScope = `${dateStamp}/${options.region}/s3/aws4_request`;
+  const signedHeaders = "host";
+  const canonicalUri = canonicalS3Uri(endpointUrl, options.bucket, options.key);
+
+  const queryParams = [
+    ["X-Amz-Algorithm", "AWS4-HMAC-SHA256"],
+    ["X-Amz-Credential", `${options.accessKeyId}/${credentialScope}`],
+    ["X-Amz-Date", amzDate],
+    ["X-Amz-Expires", String(options.expiresInSeconds)],
+    ["X-Amz-SignedHeaders", signedHeaders],
+    ...Object.entries(options.responseHeaders || {}),
+  ];
+  const canonicalQuery = canonicalQueryString(queryParams);
+  const canonicalHeaders = `host:${endpointUrl.host}\n`;
+  const canonicalRequest = [
+    "GET",
+    canonicalUri,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+  const canonicalRequestHash = await sha256Hex(canonicalRequest);
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, canonicalRequestHash].join("\n");
+  const signingKey = await signingKeyBytes(options.secretAccessKey, dateStamp, options.region, "s3");
+  const signature = toHex(await hmac(signingKey, stringToSign));
+
+  endpointUrl.pathname = canonicalUri;
+  endpointUrl.search = `${canonicalQuery}&X-Amz-Signature=${signature}`;
+  return endpointUrl.toString();
+}
+
+function canonicalS3Uri(endpointUrl, bucket, key) {
+  const basePath = endpointUrl.pathname === "/" ? "" : endpointUrl.pathname.replace(/\/$/, "");
+  const encodedKey = key.split("/").map(encodeRfc3986).join("/");
+  return `${basePath}/${encodeRfc3986(bucket)}/${encodedKey}`;
+}
+
+function canonicalQueryString(params) {
+  return params
+    .map(([key, value]) => [encodeRfc3986(key), encodeRfc3986(value)])
+    .sort(([lk, lv], [rk, rv]) => (lk === rk ? (lv < rv ? -1 : lv > rv ? 1 : 0) : lk < rk ? -1 : 1))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+}
+
+function encodeRfc3986(value) {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function formatAmzDate(date) {
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}
+
+async function signingKeyBytes(secretAccessKey, dateStamp, region, service) {
+  const dateKey = await hmac(utf8(`AWS4${secretAccessKey}`), dateStamp);
+  const regionKey = await hmac(dateKey, region);
+  const serviceKey = await hmac(regionKey, service);
+  return hmac(serviceKey, "aws4_request");
+}
+
+async function sha256Hex(value) {
+  const digest = await crypto.subtle.digest("SHA-256", utf8(value));
+  return toHex(new Uint8Array(digest));
+}
+
+async function hmac(keyBytes, value) {
+  const cryptoKey = await crypto.subtle.importKey("raw", keyBytes, { name: "HMAC", hash: "SHA-256" }, false, [
+    "sign",
+  ]);
+  const signature = await crypto.subtle.sign("HMAC", cryptoKey, utf8(value));
+  return new Uint8Array(signature);
+}
+
+function utf8(value) {
+  return new TextEncoder().encode(value);
+}
+
+function toHex(bytes) {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/cloudflare/manager-download-router/wrangler.jsonc
+++ b/cloudflare/manager-download-router/wrangler.jsonc
@@ -1,0 +1,29 @@
+{
+  // Serves the manager's own update artifacts at
+  // https://codexapp.agentsmirror.com/manager/* — global traffic from the
+  // dedicated R2 bucket (bound directly), mainland-China traffic from a
+  // presigned IHEP S3 URL (parallel to the codex-app-mirror download-router,
+  // but on the manager's OWN bucket so the two never mix).
+  "name": "codex-app-manager-download-router",
+  "main": "src/index.js",
+  "compatibility_date": "2026-06-04",
+  "workers_dev": false,
+  "r2_buckets": [{ "binding": "BUCKET", "bucket_name": "codex-app-manager" }],
+  "vars": {
+    "SECONDARY_COUNTRY_CODES": "CN",
+    "SECONDARY_S3_SIGNED_URL_TTL_SECONDS": "3600"
+  },
+  // The IHEP S3 credentials are set as encrypted secrets (NOT here):
+  //   wrangler secret put SECONDARY_S3_ENDPOINT
+  //   wrangler secret put SECONDARY_S3_BUCKET
+  //   wrangler secret put SECONDARY_S3_ACCESS_KEY_ID
+  //   wrangler secret put SECONDARY_S3_SECRET_ACCESS_KEY
+  //   (optional) SECONDARY_S3_REGION, SECONDARY_S3_PREFIX
+  // Until they exist the worker serves everyone from R2 (CN included).
+  "routes": [
+    {
+      "pattern": "codexapp.agentsmirror.com/manager/*",
+      "zone_id": "a5bae9b722f3c5fe1a24aaebe7a8e663"
+    }
+  ]
+}

--- a/scripts/sync-mirror.sh
+++ b/scripts/sync-mirror.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Publish the manager's release artifacts + a URL-rewritten latest.json to the
+# CDN mirror, so in-app self-update works without depending on GitHub (which is
+# slow/blocked for the mainland-China audience).
+#
+#   • R2 (global)  — uploaded when MANAGER_R2_* env vars are set.
+#   • IHEP S3 (CN) — uploaded when MANAGER_IHEP_S3_* env vars are set.
+#
+# The worker at codexapp.agentsmirror.com/manager/* serves R2 globally and the
+# presigned IHEP object for CN. The artifact bytes are identical to the GitHub
+# release, so the signatures already embedded in latest.json stay valid — we
+# only rewrite the download URLs.
+#
+# Usage: scripts/sync-mirror.sh <dist-dir>   (dist-dir holds the release assets
+#        + the GitHub latest.json produced by gen-updater-manifest.mjs)
+set -euo pipefail
+
+dist="${1:?usage: sync-mirror.sh <dist-dir>}"
+mirror_base="https://codexapp.agentsmirror.com/manager"
+
+if [ ! -f "$dist/latest.json" ]; then
+  echo "::error::no latest.json in $dist" >&2
+  exit 1
+fi
+
+# 1) Mirror variant of latest.json: same signatures, URLs pointed at the mirror.
+node -e '
+  const fs = require("fs");
+  const [dir, base] = [process.argv[1], process.argv[2]];
+  const j = JSON.parse(fs.readFileSync(dir + "/latest.json", "utf8"));
+  for (const k of Object.keys(j.platforms || {})) {
+    const name = j.platforms[k].url.split("/").pop();
+    j.platforms[k].url = `${base}/${name}`;
+  }
+  fs.writeFileSync(dir + "/latest.mirror.json", JSON.stringify(j, null, 2) + "\n");
+' "$dist" "$mirror_base"
+
+content_type() {
+  case "$1" in
+    *.json) echo "application/json" ;;
+    *.tar.gz) echo "application/gzip" ;;
+    *.exe) echo "application/octet-stream" ;;
+    *.dmg) echo "application/x-apple-diskimage" ;;
+    *) echo "application/octet-stream" ;;
+  esac
+}
+
+# Upload every asset (+ the mirror latest.json, stored as latest.json) to one
+# S3-compatible endpoint. Path-style addressing works for both R2 and IHEP.
+upload_all() { # endpoint bucket region access_key secret_key [prefix]
+  local endpoint="$1" bucket="$2" region="$3" ak="$4" sk="$5" prefix="${6:-}"
+  local f name key
+  for f in "$dist"/*; do
+    name="$(basename "$f")"
+    [ "$name" = "latest.json" ] && continue          # GitHub variant — skip
+    key="$name"
+    [ "$name" = "latest.mirror.json" ] && key="latest.json"
+    [ -n "$prefix" ] && key="${prefix%/}/$key"
+    AWS_ACCESS_KEY_ID="$ak" \
+    AWS_SECRET_ACCESS_KEY="$sk" \
+    AWS_DEFAULT_REGION="$region" \
+    AWS_S3_ADDRESSING_STYLE="path" \
+      aws s3 cp "$f" "s3://$bucket/$key" \
+        --endpoint-url "$endpoint" \
+        --content-type "$(content_type "$name")" \
+        --only-show-errors
+    echo "  ↑ $key"
+  done
+}
+
+if [ -n "${MANAGER_R2_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_R2_ACCESS_KEY_ID:-}" ]; then
+  echo "→ R2 (${MANAGER_R2_BUCKET:-codex-app-manager})"
+  upload_all "$MANAGER_R2_S3_ENDPOINT" "${MANAGER_R2_BUCKET:-codex-app-manager}" "auto" \
+    "$MANAGER_R2_ACCESS_KEY_ID" "$MANAGER_R2_SECRET_ACCESS_KEY"
+else
+  echo "::warning::MANAGER_R2_* not set — skipped R2 mirror sync (self-update mirror endpoint will go stale)"
+fi
+
+if [ -n "${MANAGER_IHEP_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_IHEP_S3_ACCESS_KEY_ID:-}" ]; then
+  echo "→ IHEP S3 (${MANAGER_IHEP_S3_BUCKET})"
+  upload_all "$MANAGER_IHEP_S3_ENDPOINT" "$MANAGER_IHEP_S3_BUCKET" "${MANAGER_IHEP_S3_REGION:-auto}" \
+    "$MANAGER_IHEP_S3_ACCESS_KEY_ID" "$MANAGER_IHEP_S3_SECRET_ACCESS_KEY" "${MANAGER_IHEP_S3_PREFIX:-}"
+else
+  echo "IHEP S3 not configured — CN falls back to R2 via the worker"
+fi
+
+echo "✓ mirror sync done"

--- a/scripts/sync-mirror.sh
+++ b/scripts/sync-mirror.sh
@@ -59,7 +59,6 @@ upload_all() { # endpoint bucket region access_key secret_key [prefix]
     AWS_ACCESS_KEY_ID="$ak" \
     AWS_SECRET_ACCESS_KEY="$sk" \
     AWS_DEFAULT_REGION="$region" \
-    AWS_S3_ADDRESSING_STYLE="path" \
       aws s3 cp "$f" "s3://$bucket/$key" \
         --endpoint-url "$endpoint" \
         --content-type "$(content_type "$name")" \
@@ -67,6 +66,14 @@ upload_all() { # endpoint bucket region access_key secret_key [prefix]
     echo "  ↑ $key"
   done
 }
+
+# Force path-style addressing via a temp config — the AWS CLI ignores an
+# AWS_S3_ADDRESSING_STYLE env var, and both R2 and IHEP need path-style here.
+export AWS_EC2_METADATA_DISABLED=true
+AWS_CONFIG_FILE="$(mktemp)"
+export AWS_CONFIG_FILE
+printf '[default]\nregion = auto\ns3 =\n    addressing_style = path\n' > "$AWS_CONFIG_FILE"
+trap 'rm -f "$AWS_CONFIG_FILE"' EXIT
 
 if [ -n "${MANAGER_R2_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_R2_ACCESS_KEY_ID:-}" ]; then
   echo "→ R2 (${MANAGER_R2_BUCKET:-codex-app-manager})"

--- a/scripts/sync-mirror.sh
+++ b/scripts/sync-mirror.sh
@@ -23,17 +23,32 @@ if [ ! -f "$dist/latest.json" ]; then
   exit 1
 fi
 
+# Installers live under a per-version path on the mirror (see below), so read the
+# version once and reuse it for both the rewritten URLs and the upload keys.
+version="$(node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version||""))' "$dist/latest.json")"
+if [ -z "$version" ]; then
+  echo "::error::latest.json has no version" >&2
+  exit 1
+fi
+
 # 1) Mirror variant of latest.json: same signatures, URLs pointed at the mirror.
+#    Each installer URL gets a /<version>/ segment so every release is an
+#    immutable, uniquely-addressed object. The macOS updater tarballs are renamed
+#    to versionless arch-only names upstream (CodexAppManager_<arch>.app.tar.gz),
+#    so without this each release would reuse one URL — and the worker's long
+#    installer cache could then serve a previous version's bytes against the new
+#    latest.json signature, breaking self-update. latest.json itself stays at the
+#    fixed root path the updater polls.
 node -e '
   const fs = require("fs");
-  const [dir, base] = [process.argv[1], process.argv[2]];
+  const [dir, base, ver] = [process.argv[1], process.argv[2], process.argv[3]];
   const j = JSON.parse(fs.readFileSync(dir + "/latest.json", "utf8"));
   for (const k of Object.keys(j.platforms || {})) {
     const name = j.platforms[k].url.split("/").pop();
-    j.platforms[k].url = `${base}/${name}`;
+    j.platforms[k].url = `${base}/${ver}/${name}`;
   }
   fs.writeFileSync(dir + "/latest.mirror.json", JSON.stringify(j, null, 2) + "\n");
-' "$dist" "$mirror_base"
+' "$dist" "$mirror_base" "$version"
 
 content_type() {
   case "$1" in
@@ -53,8 +68,11 @@ upload_all() { # endpoint bucket region access_key secret_key [prefix]
   for f in "$dist"/*; do
     name="$(basename "$f")"
     [ "$name" = "latest.json" ] && continue          # GitHub variant — skip
-    key="$name"
-    [ "$name" = "latest.mirror.json" ] && key="latest.json"
+    if [ "$name" = "latest.mirror.json" ]; then
+      key="latest.json"                              # updater polls this fixed path
+    else
+      key="$version/$name"                           # immutable, per-version object
+    fi
     [ -n "$prefix" ] && key="${prefix%/}/$key"
     AWS_ACCESS_KEY_ID="$ak" \
     AWS_SECRET_ACCESS_KEY="$sk" \
@@ -75,7 +93,7 @@ export AWS_CONFIG_FILE
 printf '[default]\nregion = auto\ns3 =\n    addressing_style = path\n' > "$AWS_CONFIG_FILE"
 trap 'rm -f "$AWS_CONFIG_FILE"' EXIT
 
-if [ -n "${MANAGER_R2_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_R2_ACCESS_KEY_ID:-}" ]; then
+if [ -n "${MANAGER_R2_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_R2_ACCESS_KEY_ID:-}" ] && [ -n "${MANAGER_R2_SECRET_ACCESS_KEY:-}" ]; then
   echo "→ R2 (${MANAGER_R2_BUCKET:-codex-app-manager})"
   upload_all "$MANAGER_R2_S3_ENDPOINT" "${MANAGER_R2_BUCKET:-codex-app-manager}" "auto" \
     "$MANAGER_R2_ACCESS_KEY_ID" "$MANAGER_R2_SECRET_ACCESS_KEY"
@@ -83,7 +101,7 @@ else
   echo "::warning::MANAGER_R2_* not set — skipped R2 mirror sync (self-update mirror endpoint will go stale)"
 fi
 
-if [ -n "${MANAGER_IHEP_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_IHEP_S3_ACCESS_KEY_ID:-}" ]; then
+if [ -n "${MANAGER_IHEP_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_IHEP_S3_BUCKET:-}" ] && [ -n "${MANAGER_IHEP_S3_ACCESS_KEY_ID:-}" ] && [ -n "${MANAGER_IHEP_S3_SECRET_ACCESS_KEY:-}" ]; then
   echo "→ IHEP S3 (${MANAGER_IHEP_S3_BUCKET})"
   upload_all "$MANAGER_IHEP_S3_ENDPOINT" "$MANAGER_IHEP_S3_BUCKET" "${MANAGER_IHEP_S3_REGION:-auto}" \
     "$MANAGER_IHEP_S3_ACCESS_KEY_ID" "$MANAGER_IHEP_S3_SECRET_ACCESS_KEY" "${MANAGER_IHEP_S3_PREFIX:-}"


### PR DESCRIPTION
## 问题
自更新检查先打 `codexapp.agentsmirror.com/manager/latest.json`,但该路径一直 **404**(从没被填充),于是回退到 GitHub——对国内用户慢/不可达,检查就一直「等很久然后失败(暂时无法检查管理器更新)」。

## 方案:给 Manager 自己的分发(独立于 Codex 镜像桶)
仿照 `codex-app-mirror` 的双后端,但用 **Manager 自己的桶**,互不混杂:
- **`cloudflare/manager-download-router/`** — Worker,路由 `codexapp.agentsmirror.com/manager/*`;**全球**直接绑定 R2 桶 `codex-app-manager` 读取;**中国大陆**(`request.cf.country`)用与 mirror 相同的 SigV4 预签名重定向到 **IHEP S3**(设了 `SECONDARY_S3_*` 密钥后生效,未设时 CN 也回退 R2)。
- **`scripts/sync-mirror.sh` + release.yml 新增步骤** — 每个**正式版**发布时,把产物 + 一份**改写过下载 URL 的 latest.json**(签名签的是字节,URL 改写不影响,签名仍有效)推到 R2(配了密钥再加推 IHEP)。预发布(`-rc`)跳过,避免污染镜像的单一 latest.json。
- README 写清了剩余的 S3 + 密钥交接。

## 已经在线(我用 wrangler 做掉的部分)
- 新建 R2 桶 `codex-app-manager`。
- 部署本 Worker(路由 + R2 绑定)。
- 灌入 v0.1.8(latest.json + 安装包)。
- **实测**:`GET /manager/latest.json` → **200**(此前 404),安装包从 R2 正常下载。自更新第一个端点已恢复。

## 交接给你的部分(S3 + 密钥)
1. **IHEP S3(CN 加速)** — 建 Manager 的 IHEP 桶,然后 `wrangler secret put SECONDARY_S3_ENDPOINT/BUCKET/ACCESS_KEY_ID/SECRET_ACCESS_KEY`(见 README)。
2. **发布自动同步** — 在仓库加 secrets:`MANAGER_R2_S3_ENDPOINT` / `MANAGER_R2_ACCESS_KEY_ID` / `MANAGER_R2_SECRET_ACCESS_KEY`(R2,可复用镜像那套);可选 `MANAGER_IHEP_S3_*`。没配 R2 → 同步步骤告警跳过;没配 IHEP → CN 回退 R2。

> 注:本 PR 与 #18(NSIS 重试)都改了 release.yml,但改的是不同区段,正常不冲突;谁先合另一个 rebase 一下即可。Worker 目前是手动 `wrangler deploy`(README 有说明)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)