### PR TITLE
chore(release): bump version to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.8"
+version = "0.1.9"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Patch release **v0.1.9**.

Bumps the version across the 5 canonical files (package.json, package-lock.json, Cargo.toml, Cargo.lock, tauri.conf.json), same as #17.

Ships everything merged since v0.1.8:
- #18 — release CI retries the Tauri build to survive transient NSIS/toolchain download 504s
- #19 — Windows MSIX health verification post-install
- #20 — manager-owned R2 + IHEP S3 update mirror at `/manager/` (self-update no longer depends on GitHub; CN served via IHEP)

After merge: tag `v0.1.9` on the bump commit → `release.yml` builds/signs/notarizes, publishes the GitHub Release, and (new this version) auto-syncs artifacts + a URL-rewritten latest.json to the mirror.