### PR TITLE
ci: publish releases to winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -28,7 +28,22 @@ jobs:
   winget:
     runs-on: ubuntu-latest
     steps:
+      # No-op cleanly (warn, don't fail) until WINGET_TOKEN is configured, so
+      # releases don't show a red X before the token + first bootstrap are done.
+      - name: Check for WINGET_TOKEN
+        id: gate
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [ -n "$WINGET_TOKEN" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::WINGET_TOKEN not set — skipping winget submission"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Submit to winget-pkgs
+        if: steps.gate.outputs.ok == 'true'
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: Wangnov.CodexAppManager

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,37 @@
+name: Publish to winget
+
+# Submits each stable release to the Windows Package Manager community repo
+# (microsoft/winget-pkgs) so users can `winget install Wangnov.CodexAppManager`.
+#
+# Prerequisites (one-time):
+#   1. Secret WINGET_TOKEN — a *classic* Personal Access Token with the
+#      `public_repo` scope (the action forks winget-pkgs and opens a PR under
+#      your account). Fine-grained tokens do not work.
+#   2. First submission: winget-releaser updates an existing package; the very
+#      first version of a brand-new package usually has to be bootstrapped once
+#      (e.g. `wingetcreate new` on Windows, or a hand-authored winget-pkgs PR).
+#      After that initial PR is merged, this workflow auto-submits every release.
+#
+# The installer is an unsigned NSIS setup.exe — winget accepts it, but a new
+# publisher's first PR may get extra manual review on the winget-pkgs side.
+
+on:
+  release:
+    types: [released] # stable only — prereleases (tags with a hyphen) don't fire this
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Release tag to publish (e.g. v0.1.10)"
+        required: true
+
+jobs:
+  winget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Wangnov.CodexAppManager
+          installers-regex: '_x64-setup\.exe$'
+          release-tag: ${{ inputs.release-tag || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/winget.yml` — on each **stable** release, submits `Wangnov.CodexAppManager` to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) via [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser), enabling `winget install Wangnov.CodexAppManager`.

**Prerequisites (one-time, documented in the workflow header):**
1. Secret **`WINGET_TOKEN`** — a *classic* PAT with `public_repo` scope (forks winget-pkgs + opens the PR under your account).
2. **First submission** of a brand-new package usually needs a one-time bootstrap (`wingetcreate new` on Windows or a hand-authored winget-pkgs PR); the action auto-submits every release after that.

The installer is an unsigned NSIS `setup.exe` — winget accepts it; a new publisher's first PR may get extra manual review on winget-pkgs.

`workflow_dispatch` (with a `release-tag` input) lets you submit an existing tag once the token is set.