### PR TITLE
fix(updater): sync progress bar to percent, rework result banner

### DIFF
--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -397,8 +397,17 @@ pub struct MacPerformReport {
     pub verified: bool,
     /// The new version was relaunched (only when Codex had been running).
     pub relaunched: bool,
+    /// Codex WAS running but the relaunch failed — the user must start it
+    /// manually. Distinct from a plain `!relaunched`, which also covers the
+    /// clean case where Codex simply wasn't running (no action needed).
+    pub relaunch_failed: bool,
     /// The post-swap health check failed and we restored the previous bundle.
     pub rolled_back: bool,
+    /// A non-fatal warning to surface alongside an otherwise *successful* update
+    /// — e.g. the provenance record couldn't be saved (the install will keep
+    /// being seen as external), or where the previous bundle's backup was kept
+    /// after a relaunch failure. None on a fully clean update.
+    pub warning: Option<String>,
     pub message: String,
 }
 
@@ -548,7 +557,9 @@ pub fn perform_macos_update(
             installed_path: installed.path,
             verified: false,
             relaunched: false,
+            relaunch_failed: false,
             rolled_back: false,
+            warning: None,
             message: format!("已是最新 (build {})", plan.latest_build),
         });
     }
@@ -632,9 +643,9 @@ pub fn perform_macos_update(
         // keep classifying this now-manager install as "external".
         let mut store = ProvenanceStore::load();
         store.record(installed.path.clone(), plan.latest_build, "manager-installed");
-        let save_note = match store.save() {
-            Ok(()) => String::new(),
-            Err(e) => format!("；但托管记录保存失败（{e}），安装暂仍会被识别为外部"),
+        let save_warning = match store.save() {
+            Ok(()) => None,
+            Err(e) => Some(format!("托管记录保存失败（{e}），安装暂仍会被识别为外部")),
         };
 
         if was_running {
@@ -651,13 +662,15 @@ pub fn perform_macos_update(
                     installed_path: installed.path,
                     verified: true,
                     relaunched: false,
+                    relaunch_failed: true,
                     rolled_back: false,
+                    warning: Some(match &save_warning {
+                        Some(note) => format!("旧版本备份暂留于 {}；{note}", backup.display()),
+                        None => format!("旧版本备份暂留于 {}", backup.display()),
+                    }),
                     message: format!(
-                        "已替换为 build {}，但自动重启失败（{err}）：请手动启动 Codex；\
-                         旧版本备份暂留于 {}{}",
-                        plan.latest_build,
-                        backup.display(),
-                        save_note
+                        "已替换为 build {}，但自动重启失败（{err}）：请手动启动 Codex",
+                        plan.latest_build
                     ),
                 });
             }
@@ -673,11 +686,10 @@ pub fn perform_macos_update(
             installed_path: installed.path,
             verified: true,
             relaunched: was_running,
+            relaunch_failed: false,
             rolled_back: false,
-            message: format!(
-                "已更新 build {} → {}{}",
-                installed.build, plan.latest_build, save_note
-            ),
+            warning: save_warning,
+            message: format!("已更新 build {} → {}", installed.build, plan.latest_build),
         })
     } else {
         rollback(&install_path, &backup)
@@ -691,7 +703,9 @@ pub fn perform_macos_update(
             installed_path: installed.path,
             verified: true,
             relaunched,
+            relaunch_failed: false,
             rolled_back: true,
+            warning: None,
             message: "新版本健康检查未通过，已回滚到旧版本".to_string(),
         })
     }

--- a/src/app/components.tsx
+++ b/src/app/components.tsx
@@ -155,6 +155,63 @@ export function Ring({
   );
 }
 
+/** Update-outcome strip shown after a perform/install completes. Unlike the
+ *  inline `.banner` notes it owns its lifecycle: it can be dismissed by hand
+ *  (✕), and a clean success auto-dismisses after `autoDismissMs`. On exit it
+ *  collapses its own height (grid-rows) so the content below glides up instead
+ *  of snapping. Carries one rare accent of color (the badge) and a tabular
+ *  title, so a version bump like "26.602.40724 → 26.602.71036" reads cleanly. */
+export function ResultBanner({
+  tone,
+  title,
+  detail,
+  autoDismissMs,
+  onClose,
+}: {
+  tone: "ok" | "err";
+  title: ReactNode;
+  detail?: ReactNode;
+  autoDismissMs?: number;
+  onClose: () => void;
+}) {
+  const { t } = useI18n();
+  const [leaving, setLeaving] = useState(false);
+
+  // Clean, relaunched success fades itself out; everything else stays until the
+  // user dismisses it (a rollback or a "launch manually" note must be read).
+  useEffect(() => {
+    if (!autoDismissMs) return;
+    const id = window.setTimeout(() => setLeaving(true), autoDismissMs);
+    return () => window.clearTimeout(id);
+  }, [autoDismissMs]);
+
+  // Once leaving, let the collapse/fade play, then actually unmount. Honor
+  // reduced-motion by unmounting immediately (the CSS drops the transition too).
+  useEffect(() => {
+    if (!leaving) return;
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    const id = window.setTimeout(onClose, reduce ? 0 : 340);
+    return () => window.clearTimeout(id);
+  }, [leaving, onClose]);
+
+  return (
+    <div className={`resultbar-slot${leaving ? " leaving" : ""}`}>
+      <div className={`resultbar ${tone}`} role="status" aria-live="polite">
+        <span className="rb-badge" aria-hidden="true">
+          <Icon name={tone === "ok" ? "check" : "alert"} />
+        </span>
+        <span className="rb-text">
+          <span className="rb-title">{title}</span>
+          {detail ? <span className="rb-detail">{detail}</span> : null}
+        </span>
+        <button className="rb-close" title={t("nav.close")} onClick={() => setLeaving(true)}>
+          <Icon name="close" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function Toggle({
   checked,
   onChange,

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -81,6 +81,7 @@ const ZH = {
   "install.done.open": "打开 Codex",
 
   "success.title": "已更新",
+  "success.flow": "已更新 {from} → {to}",
   "success.sub": "现在是 {version}",
   "success.relaunched": "Codex 已重启",
   "success.manualLaunch": "请手动启动 Codex",
@@ -242,6 +243,7 @@ const EN: Record<Key, string> = {
   "install.done.open": "Open Codex",
 
   "success.title": "Updated",
+  "success.flow": "Updated {from} → {to}",
   "success.sub": "Now on {version}",
   "success.relaunched": "Codex restarted",
   "success.manualLaunch": "Please launch Codex manually",
@@ -400,6 +402,7 @@ const FR: Record<Key, string> = {
   "install.done.open": "Ouvrir Codex",
 
   "success.title": "Mis à jour",
+  "success.flow": "Mis à jour {from} → {to}",
   "success.sub": "Maintenant en {version}",
   "success.relaunched": "Codex a redémarré",
   "success.manualLaunch": "Veuillez lancer Codex manuellement",
@@ -559,6 +562,7 @@ const ZH_TW: Record<Key, string> = {
   "install.done.open": "開啟 Codex",
 
   "success.title": "更新完成",
+  "success.flow": "已更新 {from} → {to}",
   "success.sub": "目前版本 {version}",
   "success.relaunched": "Codex 已重新啟動",
   "success.manualLaunch": "請手動啟動 Codex",
@@ -730,6 +734,7 @@ const DE: Record<Key, string> = {
   "install.done.open": "Codex öffnen",
 
   "success.title": "Aktualisiert",
+  "success.flow": "Aktualisiert {from} → {to}",
   "success.sub": "Jetzt Version {version}",
   "success.relaunched": "Codex neu gestartet",
   "success.manualLaunch": "Bitte Codex manuell starten",
@@ -901,6 +906,7 @@ const KO: Record<Key, string> = {
   "install.done.open": "Codex 열기",
 
   "success.title": "업데이트 완료",
+  "success.flow": "{from} → {to} 업데이트 완료",
   "success.sub": "현재 버전: {version}",
   "success.relaunched": "Codex가 재시작되었습니다",
   "success.manualLaunch": "Codex를 수동으로 실행해 주세요",
@@ -1063,6 +1069,7 @@ const JA: Record<Key, string> = {
   "install.done.title": "Codex をインストールしました",
   "install.done.open": "Codex を開く",
   "success.title": "アップデート完了",
+  "success.flow": "{from} → {to} に更新",
   "success.sub": "{version} になりました",
   "success.relaunched": "Codex を再起動しました",
   "success.manualLaunch": "Codex を手動で起動してください",
@@ -1212,6 +1219,7 @@ const RU: Record<Key, string> = {
   "install.done.title": "Codex установлен",
   "install.done.open": "Открыть Codex",
   "success.title": "Обновлено",
+  "success.flow": "Обновлено {from} → {to}",
   "success.sub": "Теперь версия {version}",
   "success.relaunched": "Codex перезапущен",
   "success.manualLaunch": "Запустите Codex вручную",
@@ -1361,6 +1369,7 @@ const AR: Record<Key, string> = {
   "install.done.title": "تم تثبيت Codex",
   "install.done.open": "فتح Codex",
   "success.title": "تم التحديث",
+  "success.flow": "تم التحديث {from} ← {to}",
   "success.sub": "الإصدار الحالي {version}",
   "success.relaunched": "أُعيد تشغيل Codex",
   "success.manualLaunch": "يُرجى تشغيل Codex يدوياً",
@@ -1510,6 +1519,7 @@ const ES: Record<Key, string> = {
   "install.done.title": "Codex instalado",
   "install.done.open": "Abrir Codex",
   "success.title": "Actualizado",
+  "success.flow": "Actualizado {from} → {to}",
   "success.sub": "Ahora en {version}",
   "success.relaunched": "Codex reiniciado",
   "success.manualLaunch": "Inicia Codex manualmente",
@@ -1659,6 +1669,7 @@ const PT_BR: Record<Key, string> = {
   "install.done.title": "Codex instalado",
   "install.done.open": "Abrir Codex",
   "success.title": "Atualizado",
+  "success.flow": "Atualizado {from} → {to}",
   "success.sub": "Agora na {version}",
   "success.relaunched": "Codex reiniciado",
   "success.manualLaunch": "Inicie o Codex manualmente",

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -986,7 +986,10 @@ button.row.danger:hover {
   border-radius: var(--r-pill);
   box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.3),
     0 0 12px color-mix(in oklch, var(--accent) 45%, transparent);
-  transition: width 0.4s var(--ease);
+  /* NO width transition. The fill width is already eased frame-by-frame by
+     useCountUp — the SAME value that drives the % readout. Layering a CSS
+     transition on top double-eases it: every rAF tick restarts a 0.4s tween,
+     so the bar lags tens of percent behind the number (46% number, ~15% bar). */
 }
 .pct {
   margin-top: var(--space-xs);
@@ -1203,6 +1206,114 @@ button.row.danger:hover {
   opacity: 0.5;
   cursor: default;
 }
+
+/* ── Result strip (update / install outcome) ─────────────────────────────── */
+/* Owns its lifecycle (auto-dismiss + ✕), unlike the static .banner notes. A
+   calm neutral surface carrying a single tinted badge of color — the version
+   bump is the message, not a wall of green. On exit the slot collapses its own
+   height so the hero below glides up. */
+.resultbar-slot {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 0.34s var(--ease);
+}
+.resultbar-slot.leaving {
+  grid-template-rows: 0fr;
+}
+.resultbar {
+  min-height: 0; /* let the grid row collapse it to nothing on exit */
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  box-shadow: var(--elev-1);
+  animation: resultbar-in 0.42s var(--ease-out) both;
+  transition: opacity 0.22s var(--ease), transform 0.26s var(--ease);
+}
+.resultbar-slot.leaving .resultbar {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+@keyframes resultbar-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+}
+.rb-badge {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+}
+.rb-badge svg {
+  width: 15px;
+  height: 15px;
+}
+.resultbar.ok .rb-badge {
+  background: var(--success-tint);
+  color: var(--success-deep);
+}
+.resultbar.err .rb-badge {
+  background: var(--danger-tint);
+  color: var(--danger-deep);
+}
+.rb-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.rb-title {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.005em;
+  font-variant-numeric: tabular-nums;
+}
+.rb-detail {
+  font-size: var(--fs-label);
+  font-weight: 500;
+  color: var(--text-soft);
+}
+.rb-close {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  border: none;
+  background: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  transition: background 0.16s var(--ease), color 0.16s var(--ease);
+}
+.rb-close:hover {
+  background: var(--surface-3);
+  color: var(--text-soft);
+}
+.rb-close svg {
+  width: 15px;
+  height: 15px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .resultbar {
+    animation: none;
+    transition: none;
+  }
+  .resultbar-slot {
+    transition: none;
+  }
+}
+
 .note {
   font-size: var(--fs-label);
   color: var(--text-faint);

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -12,7 +12,7 @@ import type {
 import { DEFAULT_SETTINGS } from "../../shared/types";
 import { Icon, CodexGlyph } from "../icons";
 import { useI18n, dirOf, type TKey } from "../i18n";
-import { Ring, TopBar } from "../components";
+import { Ring, TopBar, ResultBanner } from "../components";
 import { currentPlatform } from "../platform";
 import { WinHome } from "./WinHome";
 import { useCountUp } from "../useCountUp";
@@ -31,6 +31,9 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [report, setReport] = useState<MacUpdateReport | null>(null);
   const [status, setStatus] = useState<MacInstallStatus | null>(null);
   const [perform, setPerform] = useState<MacPerformReport | null>(null);
+  // Human-facing version pair captured at perform time, so the outcome strip can
+  // read "26.602.40724 → 26.602.71036" instead of raw build numbers.
+  const [updatedVer, setUpdatedVer] = useState<{ from: string; to: string } | null>(null);
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const [busy, setBusy] = useState<"plan" | "perform" | "adopt" | "install" | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -154,6 +157,11 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     if (!installed || !plan || plan.upToDate) return;
     setBusy("perform");
     setError(null);
+    // Capture the human-facing versions BEFORE the swap — afterward a re-check
+    // makes installed/latest identical. Fall back to a build number only if a
+    // feed omits the short version.
+    const fromVersion = installed.shortVersion || `build ${installed.build}`;
+    const toVersion = plan.latestShortVersion || `build ${plan.latestBuild}`;
     const un = await startDlListen();
     try {
       const result = await managerApi.macPerformUpdate({
@@ -162,6 +170,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
         path: installed.path,
       });
       setPerform(result);
+      setUpdatedVer({ from: fromVersion, to: toVersion });
       setConfirmOpen(false);
       await refreshStatus();
       await check();
@@ -240,6 +249,20 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
         : `${kind}${rechecking ? "-checking" : ""}`
   }`;
   const success = justInstalled || (!rechecking && kind === "uptodate");
+  // Outcome-strip detail + persistence. Surface a relaunch-failure prompt and
+  // any backend warning (provenance save failure, kept backup path), and pin the
+  // strip — no auto-dismiss — whenever there's something to act on or read, so a
+  // real warning never silently fades. A fully clean update has neither and
+  // self-dismisses.
+  const performDetail =
+    (perform &&
+      [perform.relaunchFailed ? t("success.manualLaunch") : null, perform.warning]
+        .filter(Boolean)
+        .join(" · ")) ||
+    undefined;
+  const performPinned = Boolean(
+    perform && (perform.rolledBack || perform.relaunchFailed || perform.warning),
+  );
   // Char-split only LTR scripts — splitting a cursive RTL script (Arabic) into
   // per-char elements breaks its contextual letter joining.
   const splitHeadline = !isShimmer && dirOf(lang) === "ltr";
@@ -328,12 +351,22 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
 
       <div className="scroll" ref={scopeRef}>
         {perform ? (
-          <div className={`banner ${perform.rolledBack ? "err" : "ok"}`}>
-            <Icon name={perform.rolledBack ? "alert" : "check"} />
-            {/* Backend message carries the full outcome: relaunch-failed +
-                backup kept, provenance save failure, rollback, etc. */}
-            <span>{perform.message}</span>
-          </div>
+          <ResultBanner
+            tone={perform.rolledBack ? "err" : "ok"}
+            title={
+              perform.rolledBack
+                ? t("success.rolledBack")
+                : updatedVer
+                  ? t("success.flow", { from: updatedVer.from, to: updatedVer.to })
+                  : t("success.title")
+            }
+            detail={perform.rolledBack ? undefined : performDetail}
+            autoDismissMs={performPinned ? undefined : 6000}
+            onClose={() => {
+              setPerform(null);
+              setUpdatedVer(null);
+            }}
+          />
         ) : null}
         {error ? (
           <div className="banner err">

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -12,7 +12,7 @@ import type {
 import { DEFAULT_SETTINGS } from "../../shared/types";
 import { Icon, CodexGlyph } from "../icons";
 import { useI18n, dirOf, type TKey } from "../i18n";
-import { Ring, TopBar } from "../components";
+import { Ring, TopBar, ResultBanner } from "../components";
 import { useCountUp } from "../useCountUp";
 import { mib, fmtDateTime } from "../format";
 import { useHomeMotion } from "../motion";
@@ -32,6 +32,9 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [report, setReport] = useState<WinUpdateReport | null>(null);
   const [status, setStatus] = useState<WinInstallStatus | null>(null);
   const [perform, setPerform] = useState<WinPerformReport | null>(null);
+  // Version pair captured at update time (fresh installs have no "from"), so the
+  // outcome strip can read "X → Y" like the mac side.
+  const [updatedVer, setUpdatedVer] = useState<{ from: string; to: string } | null>(null);
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const [defaultInstallRoot, setDefaultInstallRoot] = useState(DEFAULT_SETTINGS.installRoot);
   const [busy, setBusy] = useState<"plan" | "perform" | "adopt" | "install" | null>(null);
@@ -146,10 +149,20 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     async (mode: "perform" | "install", installRoot?: string) => {
       setBusy(mode);
       setError(null);
+      // For an in-place update (not a fresh install) capture the human-facing
+      // versions before the swap, so the outcome strip can show "X → Y".
+      const fromVersion =
+        mode === "perform" ? status?.installed?.version ?? report?.installed?.version ?? "" : "";
+      const toVersion = report?.plan?.latestVersion ?? "";
       const unlisten = await startDlListen();
       try {
         const result = await managerApi.winPerformUpdate(true, installRoot);
         setPerform(result);
+        setUpdatedVer(
+          mode === "perform" && fromVersion && toVersion
+            ? { from: fromVersion, to: toVersion }
+            : null,
+        );
         setConfirmOpen(false);
         setInstallDirOpen(false);
         await refreshStatus();
@@ -164,7 +177,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
         setDl(null);
       }
     },
-    [refreshStatus, check, startDlListen],
+    [status, report, refreshStatus, check, startDlListen],
   );
 
   const freshInstallNeedsLocation = useCallback(async () => {
@@ -274,6 +287,14 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const isShimmer = progressing || rechecking || kind === "loading";
   const scene = `${lang}/${progressing ? `progress-${busy}` : `${kind}${rechecking ? "-checking" : ""}`}`;
   const success = !rechecking && kind === "uptodate";
+  // A Windows install/update is "clean" only when it actually changed something
+  // without a detour — not a stale-plan no-op (stage.upToDate) and not an
+  // MSIX→portable fallback. Non-clean successes keep the backend's explanation
+  // (message + notes) and stay pinned; only clean ones self-dismiss.
+  const winClean =
+    Boolean(perform?.success) && !perform?.stage?.upToDate && !perform?.fallbackAttempted;
+  const winResultDetail =
+    perform && !winClean ? perform.notes.filter(Boolean).join(" · ") || undefined : undefined;
   // Char-split only LTR scripts — splitting cursive RTL (Arabic) breaks joining.
   const splitHeadline = !isShimmer && dirOf(lang) === "ltr";
   useHomeMotion(scopeRef, scene, { splitHeadline, success });
@@ -327,10 +348,25 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
 
       <div className="scroll" ref={scopeRef}>
         {perform ? (
-          <div className={`banner ${perform.success ? "ok" : "err"}`}>
-            <Icon name={perform.success ? "check" : "alert"} />
-            <span>{perform.message}</span>
-          </div>
+          <ResultBanner
+            tone={perform.success ? "ok" : "err"}
+            // Clean success → the version bump / install line. Anything non-clean
+            // (no-op, fallback, or failure) keeps the backend's message so the
+            // reason is never lost.
+            title={
+              winClean
+                ? updatedVer
+                  ? t("success.flow", { from: updatedVer.from, to: updatedVer.to })
+                  : t("install.done.title")
+                : perform.message
+            }
+            detail={winResultDetail}
+            autoDismissMs={winClean ? 6000 : undefined}
+            onClose={() => {
+              setPerform(null);
+              setUpdatedVer(null);
+            }}
+          />
         ) : null}
         {error ? (
           <div className="banner err">

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -277,7 +277,9 @@ export const managerApi = {
         installedPath: expected.path,
         verified: true,
         relaunched: true,
+        relaunchFailed: false,
         rolledBack: false,
+        warning: null,
         message: "（浏览器开发态：真实替换仅在桌面 app 内执行）",
       });
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -67,7 +67,15 @@ export interface MacPerformReport {
   installedPath: string;
   verified: boolean;
   relaunched: boolean;
+  /** Codex was running but the relaunch failed — the user must start it
+   *  manually. Distinct from `!relaunched`, which also covers the clean case
+   *  where Codex simply wasn't running (no action needed). */
+  relaunchFailed: boolean;
   rolledBack: boolean;
+  /** Non-fatal warning to surface on an otherwise successful update (e.g. a
+   *  provenance save failure, or where the previous backup was kept). null when
+   *  the update was fully clean. */
+  warning: string | null;
   message: string;
 }
 


### PR DESCRIPTION
## 背景

更新流程有两个问题：

1. **进度条与百分比严重不同步**（截图里 46% 但进度条只到 ~15%）。
2. **更新完成横幅很丑、显示 build 号、且永久去不掉**（只有退出 Manager 才消失）。

## 修复

### 1. 进度条滞后
根因：`.bar-fill` 的宽度 `width: ${dlPct}%` 已经由 `useCountUp` 逐帧 RAF 缓动，CSS 上又叠了一层 `transition: width 0.4s` —— 两层缓动叠加，CSS transition 每帧被打断重启，进度条严重滞后于百分比数字（两者其实同源 `dlPct`）。移除该 transition，宽度与百分比从此严格同步。同一份 CSS 也修好了 Windows 端。

### 2. 更新结果横幅
原横幅 `setPerform` 后没有任何地方清除，且直接显示后端 `build X → Y` 字符串。重构为可复用的 **`ResultBanner`** 组件，mac/win 两端共用：
- **可手动关闭**（×）、**干净成功 6s 自动消失**、退场用 `grid-template-rows` 高度塌缩；
- 文案改为 **`shortVersion` 版本号迭代**（`已更新 26.602.40724 → 26.602.71036`），复用此前闲置的 `success.*` 文案并新增 `success.flow`（11 语种，RTL 用 `←`）；
- 视觉重做为中性材质表面 + 仅在小圆 badge 上的稀有强调色（符合项目 60-30-10 与"温润材质"设计原则），深浅主题同等精雕。

### 3. 不误报"非干净成功"（Codex review 反馈）
为避免把"有偏差的成功"当普通成功（自动消失 + 吞掉后端警告）：
- 后端 `MacPerformReport` 区分 **重启失败**（`relaunch_failed`）与"Codex 本来就没运行"，并将非致命警告（托管记录保存失败、保留的备份路径）放入结构化 `warning` 字段；
- mac 横幅把这些作为 detail 展示，并对任何非干净结果**钉住不自动消失**；
- Windows 横幅用 `stage.upToDate` / `fallbackAttempted` / `notes` 应用同样的"干净/非干净"规则。

## 验证

- `npm run check`、`npm test`（11 通过）、`npm run build`、`cargo check` 均通过。
- 浏览器内可视化验证：进度条 A/B 对比（旧滞后、新同步）、横幅深浅主题视觉、mac/win 端到端的挂载 / 6s 自动消失 / 手动关闭 / 版本号迭代。
- 经 `codex review` 审查，迭代至无意见。

## 改动文件
`mac_update.rs`（warning + relaunch_failed）、`components.tsx`（ResultBanner）、`styles.css`（进度条 + .resultbar）、`Home.tsx`、`WinHome.tsx`、`i18n.tsx`（success.flow ×11）、`types.ts`、`managerApi.ts`。