### PR TITLE
fix(win): wire the MSIX risk banner to a signal the backend emits

### DIFF
--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -244,11 +244,13 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const updateAvailable = Boolean(plan) && !plan?.upToDate;
   const routeNote =
     plan?.route === "portable-fallback" ? t("win.route.portable") : t("win.route.msix");
-  // MSIX is the planned route, yet the App Installer / Store components weren't
-  // detected — a stripped Windows where the package may install but not run.
+  // MSIX is the planned route, yet the Desktop App Installer wasn't detected —
+  // a stripped Windows where the package may install but not launch. The probe
+  // only ever reports appInstaller as "available" or "unknown" (never
+  // "unavailable"), so "unknown" is the not-detected signal we gate on.
   const msixRisky =
     plan?.route === "msix-sideload" &&
-    report?.capabilities?.appInstaller?.state === "unavailable";
+    report?.capabilities?.appInstaller?.state === "unknown";
 
   const kind: Kind = useMemo(() => {
     if (!installed) {


### PR DESCRIPTION
## What

`src/app/views/WinHome.tsx` had a dead `msixRisky` computation that gated the MSIX risk banner (and the switch-to-portable button, i18n `win.msixRisk.*`) on `report?.capabilities?.appInstaller?.state === "unavailable"`. This change re-points it at `appInstaller.state === "unknown"`, the signal the backend actually emits, so the banner can fire.

## Why

The banner was dead. In `crates/codex-win-engine/src/sys.rs`, `probe_capabilities` only ever sets `appInstaller` to:
- `available` (line ~652) when the Desktop App Installer package is detected, or
- `unknown` (line ~654, `"Desktop App Installer package was not detected"`) when it is not.

It never returns `unavailable` for `appInstaller`, so the old `=== "unavailable"` condition could never be true and the warning never rendered.

The banner's intent — "Store/App Installer components missing, MSIX may install but not launch, suggest portable" — maps directly to the not-detected case, which the backend reports as `unknown`. The existing source comment already described "App Installer / Store components weren't detected", confirming `unknown` is the intended trigger.

## How

- Changed the `msixRisky` condition from `appInstaller.state === "unavailable"` to `=== "unknown"`.
- Kept the gate on `plan?.route === "msix-sideload"` so the warning only appears when an MSIX install is actually about to be attempted (an `unknown` appInstaller is harmless on the portable route).
- Updated the explanatory comment to document why `unknown` (not `unavailable`) is the not-detected signal, so this doesn't get "corrected" back to a dead state later.

This deliberately does NOT depend on the in-flight `msixDeployment` capability (PR #31, not on main yet) — it uses the `appInstaller` `unknown` signal that exists on main today.

## Verification

- Frontend: `npx tsc --noEmit` passes.
- The Rust backend was read (not modified) to confirm the emitted states; no Rust change in this PR.

## Residual risk / trade-off

- This revives an intended-but-previously-dead warning. The trade-off: `unknown` is a weaker signal than a true `unavailable` would be — the probe reports `unknown` both when the package is genuinely absent and, in principle, when detection is ambiguous. On the `msix-sideload` route a missing Desktop App Installer is the dominant cause, and the banner is advisory (offers a switch-to-portable, does not block), so the warning is appropriately conservative rather than a hard error.
- This touches `cfg(windows)`-adjacent runtime behavior (the banner only renders on the Windows view with a real capability report). It cannot be exercised on this macOS host; the actual probe output and banner rendering need CI plus a real-Windows pass to confirm end-to-end.