### PR TITLE
fix(mac): propagate the real ~/.codex purge error like Windows does

### DIFF
--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -893,17 +893,25 @@ pub fn uninstall_macos(keep_codex_home: bool) -> Result<MacUninstallReport, AppE
     let (kept_codex_home, mut message) = if keep_codex_home {
         (true, "已卸载 Codex,保留了 ~/.codex".to_string())
     } else {
-        let mut cleared = true;
+        // Best-effort, non-fatal: a purge failure must not abort the uninstall
+        // report. But like the Windows path (purge_codex_user_data), surface the
+        // real underlying io/fs error instead of a generic "purge failed" so the
+        // user can diagnose it (permissions, busy file, …) rather than guess.
+        let mut purge_err: Option<String> = None;
         if let Ok(home) = std::env::var("HOME") {
             let codex_home = PathBuf::from(home).join(".codex");
             if codex_home.exists() {
-                cleared = std::fs::remove_dir_all(&codex_home).is_ok();
+                if let Err(e) = std::fs::remove_dir_all(&codex_home) {
+                    purge_err = Some(e.to_string());
+                }
             }
         }
-        if cleared {
-            (false, "已卸载 Codex,并清除了 ~/.codex".to_string())
-        } else {
-            (true, "已卸载 Codex,但 ~/.codex 清除失败,数据仍保留".to_string())
+        match purge_err {
+            None => (false, "已卸载 Codex,并清除了 ~/.codex".to_string()),
+            Some(err) => (
+                true,
+                format!("已卸载 Codex,但 ~/.codex 清除失败,数据仍保留: {err}"),
+            ),
         }
     };
     if !prov_saved {


### PR DESCRIPTION
## What
On the macOS uninstall path (`src-tauri/src/app/mac_update.rs`, `uninstall_macos`), when the user opts out of keeping `~/.codex` and the directory removal fails, the report now surfaces the concrete underlying io/fs error text instead of a generic "清除失败" message.

## Why
The Windows path (`crates/codex-win-engine/src/portable.rs`, `purge_codex_user_data`) propagates the real failure reason via `io_err("purge user data", e)` → `EngineError::Io`. The macOS path collapsed the error with `std::fs::remove_dir_all(&codex_home).is_ok()`, throwing away the actual reason (permissions, busy file, etc.) and leaving the user to guess. This makes the two platforms diverge in diagnosability for the same operation.

## How
Replaced the `is_ok()` boolean with an `Option<String>` capturing `e.to_string()` on failure. On failure the report message becomes `已卸载 Codex,但 ~/.codex 清除失败,数据仍保留: <error>`. Behavior is otherwise identical:
- Still best-effort and non-fatal: a purge failure does NOT abort the uninstall report (the report still returns `Ok` with `removed: true` and `kept_codex_home: true`). This is why a localized macOS fix was chosen over a shared helper — the Windows helper propagates via `?` and would abort the function, whereas macOS must keep returning the report.
- `kept_codex_home` / `removed` flags and the success-path message are unchanged.

## Verification
- `cargo check --manifest-path src-tauri/Cargo.toml`: PASS (clean compile of the full workspace, including this macOS module which builds on the macOS CI/host).
- `cargo test -p codex-win-engine` not run: the shared Windows crate was not modified, only macOS-specific code in `src-tauri`.

## Residual risk
Low. The change is confined to the macOS-specific `cfg(target_os = "macos")` uninstall path and is a string-formatting change to an existing error branch. No `cfg(windows)` code was touched. The runtime behavior (an actual purge failure) is hard to exercise without a permission-denied `~/.codex` on a real machine, but the logic is a straightforward error-text passthrough mirroring the verified Windows pattern.