### PR TITLE
fix(win): report MSIX health honestly when the probe cannot run

### DIFF
--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -64,6 +64,12 @@ pub struct MsixRemoveReport {
 #[serde(rename_all = "camelCase")]
 pub struct MsixHealthReport {
     pub healthy: bool,
+    /// Whether the health probe actually ran and the `healthy` verdict reflects
+    /// real checks. `false` means the probe could not run and `healthy` is a
+    /// conservative "keep the MSIX" default, not a clean bill of health that was
+    /// observed. Callers/UI/notes use this to tell "verified healthy" apart from
+    /// "kept because unverifiable".
+    pub verified: bool,
     pub package_registered: bool,
     /// Raw `Get-AppxPackage` Status string (e.g. "Ok", "Modified").
     pub status: String,
@@ -342,8 +348,12 @@ try {{
     let Some(value) = parsed else {
         // The health probe itself could not run. Don't overturn a successful
         // Add-AppxPackage on an unverifiable signal — keep the MSIX install.
+        // The keep-MSIX decision (healthy = true) is intentional, but mark the
+        // report unverified so callers don't mistake it for an observed clean
+        // bill of health.
         return MsixHealthReport {
             healthy: true,
+            verified: false,
             package_registered: true,
             status: "probe-failed".to_string(),
             status_ok: true,
@@ -399,6 +409,8 @@ try {{
 
     MsixHealthReport {
         healthy,
+        // The probe ran and produced a real verdict.
+        verified: true,
         package_registered,
         status,
         status_ok,
@@ -411,9 +423,11 @@ try {{
 #[cfg(not(windows))]
 pub fn verify_msix_health() -> MsixHealthReport {
     // Non-Windows builds never sideload, so there is nothing to verify; report
-    // healthy so this can never be the thing that blocks a (non-existent) path.
+    // healthy so this can never be the thing that blocks a (non-existent) path,
+    // but leave verified = false since no real check was performed.
     MsixHealthReport {
         healthy: true,
+        verified: false,
         package_registered: false,
         status: "not-windows".to_string(),
         status_ok: true,

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -209,7 +209,7 @@ const WIN_FALLBACK_PERFORM: WinPerformReport = {
     rawError: null,
   },
   portable: null,
-  msixHealth: { healthy: true, packageRegistered: true, status: "Ok", statusOk: true, aumidResolved: true, missingDependencies: [], reason: "" },
+  msixHealth: { healthy: true, verified: true, packageRegistered: true, status: "Ok", statusOk: true, aumidResolved: true, missingDependencies: [], reason: "" },
   installed: {
     path: "C:\\Program Files\\WindowsApps\\OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0",
     version: "26.602.3474.0",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -242,6 +242,13 @@ export interface MsixSideloadReport {
 
 export interface MsixHealthReport {
   healthy: boolean;
+  /**
+   * Whether the health probe actually ran. When false, `healthy` is a
+   * conservative "keep the MSIX" default (the probe could not run), not an
+   * observed clean bill of health. Use this to tell "verified healthy" apart
+   * from "kept because unverifiable".
+   */
+  verified: boolean;
   packageRegistered: boolean;
   /** Raw Get-AppxPackage Status string (e.g. "Ok", "Modified"). */
   status: string;


### PR DESCRIPTION
## What

Add a `verified: bool` field to `MsixHealthReport` (`crates/codex-win-engine/src/sys.rs`) so callers/UI/notes can tell a **verified-healthy** result apart from one that is merely **kept because the health probe was unverifiable**. Mirrored in the frontend `MsixHealthReport` interface (`src/shared/types.ts`) and the mock report (`src/services/managerApi.ts`).

## Why

`verify_msix_health()` returns `healthy = true` in the branch where the health probe itself could not run (reason: "health probe could not run; keeping the MSIX install"). The conservative install **decision** there — keep the successfully sideloaded MSIX rather than wrongly forcing a portable fallback when we cannot verify — is intentional and correct.

The problem was purely one of **honesty**: the report asserted a clean bill of health (`healthy = true`, `statusOk = true`, `aumidResolved = true`, etc.) that was never actually observed. Anything reading the report could not distinguish "we checked and it's fine" from "we couldn't check, so we kept it." The non-Windows stub had the same issue (it reports `healthy = true` without ever running a check).

## How

Added `verified: bool` to `MsixHealthReport` and set it at every construction site **without changing any keep-MSIX decision**:

- **Real Windows probe path** (the branch that parses the PowerShell verdict): `verified = true` — the probe ran and produced a real result. `healthy` is still computed exactly as before.
- **Probe-failed branch**: `verified = false`, `healthy` left as `true` (unchanged). Deliberately did **not** flip `healthy` to `false`, which would have triggered an unwarranted portable fallback. The keep-MSIX behavior is preserved verbatim.
- **Non-Windows stub**: `verified = false`, `healthy` left as `true` (unchanged) since no real check is performed off-Windows.
- Frontend: added `verified` to the TS `MsixHealthReport` interface and set `verified: true` in the verified-healthy mock in `managerApi.ts`.

No call site (`src-tauri/src/app/win_update.rs`) had its control flow changed — the `!health.healthy` fallback path and the success path are byte-for-byte equivalent in behavior; they now just carry the extra honest signal.

## Verification

- Frontend: `npx tsc --noEmit` — passes (exit 0).
- Rust: `cargo check --manifest-path src-tauri/Cargo.toml` — passes.
- Rust: `cargo test --manifest-path src-tauri/Cargo.toml -p codex-win-engine` — 19 passed, 0 failed.

## Residual risk

The real probe path (`verified = true`) lives under `#[cfg(windows)]` and **cannot be compiled or exercised on this macOS host** — it is only reachable on Windows. On macOS, `cargo check`/`test` compile the `#[cfg(not(windows))]` stub instead. The Windows-only branch needs CI (Rust matrix) and ideally a real-Windows pass to confirm it compiles and that the `verified = true` construction is correct in context. The change there is a single added struct field with a literal `true`, so the risk is low, but it is unverified locally by definition.