### PR TITLE
chore: remove dead frontend staging/cancel API wrappers

### DIFF
--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -7,10 +7,8 @@ import type {
   CommandError,
   MacInstallStatus,
   MacPerformReport,
-  MacStageReport,
   MacUninstallReport,
   MacUpdateReport,
-  WinAutoStageReport,
   WinInstallStatus,
   WinPerformReport,
   WinStageReport,
@@ -111,18 +109,6 @@ const FALLBACK_PLAN: MacUpdateReport = {
   },
 };
 
-const FALLBACK_STAGE: MacStageReport = {
-  upToDate: false,
-  strategy: "delta-from-3511",
-  latestBuild: 3575,
-  latestShortVersion: "26.602.30954",
-  downloadSize: 18260894,
-  fullSize: 406581087,
-  savingsPct: 95.5,
-  stagedPath: "(browser-dev mock) …/Codex3575-3511-arm64.delta",
-  verified: true,
-};
-
 const WIN_FALLBACK_PLAN: WinUpdateReport = {
   manifestUrl: "https://codexapp.agentsmirror.com/latest/manifest",
   checksumsUrl: "https://codexapp.agentsmirror.com/latest/checksums",
@@ -190,17 +176,6 @@ const WIN_FALLBACK_STAGE: WinStageReport = {
   notes: ["Non-destructive staging only; install execution is the next guarded step."],
 };
 
-const WIN_FALLBACK_AUTO_STAGE: WinAutoStageReport = {
-  enabled: true,
-  allowMetered: false,
-  attempted: true,
-  skipped: false,
-  reason: "staged",
-  stage: WIN_FALLBACK_STAGE,
-  capabilities: WIN_FALLBACK_PLAN.capabilities,
-  notes: ["browser-dev mock: package staged in the background."],
-};
-
 const WIN_FALLBACK_PERFORM: WinPerformReport = {
   success: true,
   action: "msix-sideload",
@@ -259,14 +234,6 @@ export const managerApi = {
       return Promise.resolve({ ...FALLBACK_PLAN, simulatedBuild: simulatedBuild ?? null });
     }
     return invoke<MacUpdateReport>("mac_plan_update", {
-      simulatedBuild: simulatedBuild ?? null,
-    });
-  },
-  macStageUpdate(simulatedBuild?: number): Promise<MacStageReport> {
-    if (!hasTauriRuntime()) {
-      return Promise.resolve(FALLBACK_STAGE);
-    }
-    return invoke<MacStageReport>("mac_stage_update", {
       simulatedBuild: simulatedBuild ?? null,
     });
   },
@@ -459,36 +426,6 @@ export const managerApi = {
       return Promise.resolve(WIN_FALLBACK_PLAN);
     }
     return invoke<WinUpdateReport>("win_plan_update");
-  },
-  winStageUpdate(): Promise<WinStageReport> {
-    if (!hasTauriRuntime()) {
-      return Promise.resolve(WIN_FALLBACK_STAGE);
-    }
-    return invoke<WinStageReport>("win_stage_update");
-  },
-  winAutoStageUpdate(enabled: boolean, allowMetered: boolean): Promise<WinAutoStageReport> {
-    if (!hasTauriRuntime()) {
-      if (!enabled) {
-        return Promise.resolve({
-          ...WIN_FALLBACK_AUTO_STAGE,
-          enabled,
-          allowMetered,
-          attempted: false,
-          skipped: true,
-          reason: "disabled",
-          stage: null,
-          notes: ["browser-dev mock: automatic pre-download is disabled."],
-        });
-      }
-      return Promise.resolve({ ...WIN_FALLBACK_AUTO_STAGE, enabled, allowMetered });
-    }
-    return invoke<WinAutoStageReport>("win_auto_stage_update", { enabled, allowMetered });
-  },
-  winCancelDownload(): Promise<boolean> {
-    if (!hasTauriRuntime()) {
-      return Promise.resolve(false);
-    }
-    return invoke<boolean>("win_cancel_download");
   },
   winPerformUpdate(confirm: boolean, installRoot?: string): Promise<WinPerformReport> {
     if (!hasTauriRuntime()) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -59,18 +59,6 @@ export interface MacUpdateReport {
   installedPubDate?: string | null;
 }
 
-export interface MacStageReport {
-  upToDate: boolean;
-  strategy: string;
-  latestBuild: number;
-  latestShortVersion: string;
-  downloadSize: number;
-  fullSize: number;
-  savingsPct: number;
-  stagedPath: string | null;
-  verified: boolean;
-}
-
 export interface MacPerformReport {
   upToDate: boolean;
   fromBuild: number;
@@ -230,17 +218,6 @@ export interface WinStageReport {
   identityVerified: boolean;
   installReady: boolean;
   portableFallbackReady: boolean;
-  notes: string[];
-}
-
-export interface WinAutoStageReport {
-  enabled: boolean;
-  allowMetered: boolean;
-  attempted: boolean;
-  skipped: boolean;
-  reason: "disabled" | "up-to-date" | "metered-network" | "metered-unknown" | "staged" | string;
-  stage: WinStageReport | null;
-  capabilities: WinCapabilityReport | null;
   notes: string[];
 }
 


### PR DESCRIPTION
## What

Removes four pre-download/staging wrapper functions from `src/services/managerApi.ts` that have no callers anywhere in `src/**`:

- `macStageUpdate`
- `winStageUpdate`
- `winAutoStageUpdate`
- `winCancelDownload`

Plus their browser-dev mock objects (`FALLBACK_STAGE`, `WIN_FALLBACK_AUTO_STAGE`) and the two `src/shared/types.ts` interfaces that become unreferenced as a result: `MacStageReport` and `WinAutoStageReport`.

**Frontend only.** Net: 86 deletions across two files.

## Why

The live update path goes `plan -> perform` directly; the staging/cancel layer is never invoked from any view, component, or hook. Verified with ripgrep across all of `src/`:

```
$ rg -n "macStageUpdate|winStageUpdate|winAutoStageUpdate|winCancelDownload" src/ -g '!src/services/managerApi.ts'
(no matches)
```

These were the only references to the now-deleted types, so the types are safe to drop too.

## How

- Dropped the four wrapper methods on the `managerApi` object.
- Dropped the `FALLBACK_STAGE` (Mac) and `WIN_FALLBACK_AUTO_STAGE` browser-dev mocks that only fed those wrappers, and removed their now-unused type imports.
- Removed `MacStageReport` and `WinAutoStageReport` from `src/shared/types.ts`.

**Deliberately kept** (still live, would orphan nothing):
- `WinStageReport` — still used by `WinPerformReport.stage` and the retained `WIN_FALLBACK_STAGE` mock (which feeds `WIN_FALLBACK_PERFORM`).
- `WinCapabilityReport`, `AuthenticodeReport`, `MsixIdentity` — still referenced by `WinUpdateReport` / `WinStageReport`.

## Verification

- `npx tsc --noEmit` → **pass** (exit 0), after symlinking the shared `node_modules`.
- Post-edit ripgrep confirms `MacStageReport` and `WinAutoStageReport` have zero remaining references in `src/`, while `WinStageReport`/`WinCapabilityReport` remain referenced.

## Residual risk / follow-up

- Low risk: pure dead-code removal, type-checks clean, no behavioral surface touched.
- The backend Tauri commands `mac_stage_update`, `win_stage_update`, `win_auto_stage_update`, `win_cancel_download` (in `src-tauri/src/commands.rs`, registered in `src-tauri/src/lib.rs`) are intentionally **left intact** per scope. They are now **frontend-unreferenced** and could be a separate backend cleanup follow-up.
- No `cfg(windows)` Rust code was modified, so there is nothing here that needs a real-Windows CI pass.