### PR TITLE
feat(win): pre-check framework deps before MSIX sideload (steer portable)

### DIFF
--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -35,7 +35,9 @@ pub use download::{
 };
 pub use manifest::{parse_manifest, WindowsRelease};
 pub use msix::{
-    parse_appx_manifest_xml, read_msix_identity, validate_codex_identity, MsixIdentity,
+    framework_dependencies, is_framework_dependency, parse_appx_manifest_dependencies,
+    parse_appx_manifest_xml, read_msix_dependencies, read_msix_identity, validate_codex_identity,
+    MsixIdentity, MsixPackageDependency,
 };
 pub use plan::{plan_update, WinInstallRoute, WindowsUpdatePlan};
 pub use portable::{
@@ -46,7 +48,10 @@ pub use sys::{
     detect_installed_codex, detect_portable_install, fetch_text, launch_codex,
     probe_capabilities, remove_msix_package, InstalledWindowsCodex, MsixRemoveReport,
 };
-pub use sys::{install_msix_sideload, verify_msix_health, MsixHealthReport, MsixSideloadReport};
+pub use sys::{
+    install_msix_sideload, precheck_msix_dependencies, verify_msix_health, MsixDependencyPrecheck,
+    MsixHealthReport, MsixSideloadReport,
+};
 pub use version::{compare_versions, version_key};
 
 pub const OPENAI_PACKAGE_IDENTITY: &str = "OpenAI.Codex";

--- a/crates/codex-win-engine/src/msix.rs
+++ b/crates/codex-win-engine/src/msix.rs
@@ -15,6 +15,40 @@ pub struct MsixIdentity {
     pub processor_architecture: String,
 }
 
+/// A single `<PackageDependency>` declared in the staged MSIX manifest. These
+/// are the framework packages (VCLibs, WindowsAppRuntime, UI.Xaml, NET.Native,
+/// …) that `Add-AppxPackage` expects to already be present — on a stripped /
+/// Store-disabled Windows it cannot auto-acquire them, so a missing one means a
+/// doomed sideload. We read them up front to steer to the portable build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MsixPackageDependency {
+    pub name: String,
+    #[serde(default)]
+    pub min_version: Option<String>,
+}
+
+/// Known framework-package name prefixes that an MSIX can take a runtime
+/// dependency on. Matching is case-insensitive and prefix-based so future minor
+/// suffixes (e.g. `Microsoft.VCLibs.140.00`) are still recognized.
+const FRAMEWORK_DEPENDENCY_PREFIXES: &[&str] = &[
+    "Microsoft.VCLibs.",
+    "Microsoft.WindowsAppRuntime.",
+    "Microsoft.UI.Xaml.",
+    "Microsoft.NET.Native.",
+];
+
+/// Whether a declared dependency name is one of the redistributable framework
+/// packages we know how to pre-check. Non-framework dependencies (e.g. another
+/// of the vendor's own packages) are intentionally NOT pre-checked here: we only
+/// want to steer to portable when a *framework* the sideload cannot acquire is
+/// absent. Pure + cross-platform so it is unit-tested off Windows.
+pub fn is_framework_dependency(name: &str) -> bool {
+    FRAMEWORK_DEPENDENCY_PREFIXES
+        .iter()
+        .any(|prefix| name.len() >= prefix.len() && name[..prefix.len()].eq_ignore_ascii_case(prefix))
+}
+
 pub fn parse_appx_manifest_xml(xml: &str) -> Result<MsixIdentity, EngineError> {
     let doc = roxmltree::Document::parse(xml)
         .map_err(|e| EngineError::Msix(format!("AppxManifest.xml: {e}")))?;
@@ -50,6 +84,63 @@ pub fn read_msix_identity(path: &Path) -> Result<MsixIdentity, EngineError> {
         .read_to_string(&mut xml)
         .map_err(|e| EngineError::Msix(format!("decode AppxManifest.xml: {e}")))?;
     parse_appx_manifest_xml(&xml)
+}
+
+/// Parse the `<Dependencies><PackageDependency .../>` entries from an
+/// AppxManifest.xml. Pure + namespace-agnostic (we match by local tag name and
+/// read attributes directly) so it is unit-tested off Windows. Mirrors how
+/// `verify_msix_health` reads `Package.Dependencies.PackageDependency` in
+/// PowerShell, but here it runs against the staged package *before* install.
+pub fn parse_appx_manifest_dependencies(
+    xml: &str,
+) -> Result<Vec<MsixPackageDependency>, EngineError> {
+    let doc = roxmltree::Document::parse(xml)
+        .map_err(|e| EngineError::Msix(format!("AppxManifest.xml: {e}")))?;
+    let deps = doc
+        .descendants()
+        .filter(|node| node.has_tag_name("PackageDependency"))
+        .filter_map(|node| {
+            let name = node.attribute("Name")?.trim();
+            if name.is_empty() {
+                return None;
+            }
+            let min_version = node
+                .attribute("MinVersion")
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            Some(MsixPackageDependency {
+                name: name.to_string(),
+                min_version,
+            })
+        })
+        .collect();
+    Ok(deps)
+}
+
+/// Read and parse the declared `PackageDependency` entries from a staged MSIX on
+/// disk (same zip + AppxManifest.xml path as `read_msix_identity`).
+pub fn read_msix_dependencies(path: &Path) -> Result<Vec<MsixPackageDependency>, EngineError> {
+    let file = File::open(path).map_err(|e| EngineError::Io(format!("open MSIX: {e}")))?;
+    let mut zip =
+        zip::ZipArchive::new(file).map_err(|e| EngineError::Msix(format!("open MSIX zip: {e}")))?;
+    let mut manifest = zip
+        .by_name("AppxManifest.xml")
+        .map_err(|e| EngineError::Msix(format!("read AppxManifest.xml: {e}")))?;
+    let mut xml = String::new();
+    manifest
+        .read_to_string(&mut xml)
+        .map_err(|e| EngineError::Msix(format!("decode AppxManifest.xml: {e}")))?;
+    parse_appx_manifest_dependencies(&xml)
+}
+
+/// The subset of declared dependencies that are redistributable *framework*
+/// packages we pre-check before sideloading. Pure + cross-platform.
+pub fn framework_dependencies(deps: &[MsixPackageDependency]) -> Vec<MsixPackageDependency> {
+    deps.iter()
+        .filter(|d| is_framework_dependency(&d.name))
+        .cloned()
+        .collect()
 }
 
 fn arch_matches(actual: &str, expected: Option<&str>) -> bool {
@@ -120,5 +211,79 @@ mod tests {
             processor_architecture: "x64".to_string(),
         };
         assert!(validate_codex_identity(&identity, "26.602.3474.0", Some("x64")).is_err());
+    }
+
+    #[test]
+    fn classifies_framework_dependencies_by_prefix() {
+        for name in [
+            "Microsoft.VCLibs.140.00",
+            "Microsoft.VCLibs.140.00.UWPDesktop",
+            "Microsoft.WindowsAppRuntime.1.5",
+            "Microsoft.UI.Xaml.2.8",
+            "Microsoft.NET.Native.Framework.2.2",
+            // Case-insensitive: registry/manifest casing can vary.
+            "microsoft.vclibs.140.00",
+        ] {
+            assert!(is_framework_dependency(name), "{name} should be a framework");
+        }
+        for name in ["OpenAI.Codex", "Microsoft.WindowsTerminal", "Contoso.App"] {
+            assert!(
+                !is_framework_dependency(name),
+                "{name} should NOT be a framework"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_package_dependencies_from_manifest() {
+        let xml = r#"
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=OpenAI" Version="26.602.3474.0" ProcessorArchitecture="x64" />
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.30704.0" Publisher="CN=Microsoft" />
+    <PackageDependency Name="Microsoft.WindowsAppRuntime.1.5" MinVersion="5000.522.2030.0" Publisher="CN=Microsoft" />
+    <PackageDependency Name="Contoso.Helper" MinVersion="1.0.0.0" />
+  </Dependencies>
+</Package>"#;
+        let deps = parse_appx_manifest_dependencies(xml).unwrap();
+        assert_eq!(deps.len(), 3);
+        assert_eq!(deps[0].name, "Microsoft.VCLibs.140.00");
+        assert_eq!(deps[0].min_version.as_deref(), Some("14.0.30704.0"));
+
+        let frameworks = framework_dependencies(&deps);
+        // Contoso.Helper is a non-framework dependency and is excluded.
+        assert_eq!(frameworks.len(), 2);
+        assert!(frameworks.iter().all(|d| is_framework_dependency(&d.name)));
+        assert!(frameworks
+            .iter()
+            .any(|d| d.name == "Microsoft.WindowsAppRuntime.1.5"));
+    }
+
+    #[test]
+    fn parses_empty_when_no_dependencies_block() {
+        let xml = r#"
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=OpenAI" Version="1.0.0.0" ProcessorArchitecture="x64" />
+</Package>"#;
+        let deps = parse_appx_manifest_dependencies(xml).unwrap();
+        assert!(deps.is_empty());
+        assert!(framework_dependencies(&deps).is_empty());
+    }
+
+    #[test]
+    fn skips_package_dependency_without_name() {
+        let xml = r#"
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Dependencies>
+    <PackageDependency MinVersion="1.0.0.0" />
+    <PackageDependency Name="" MinVersion="1.0.0.0" />
+    <PackageDependency Name="Microsoft.UI.Xaml.2.8" />
+  </Dependencies>
+</Package>"#;
+        let deps = parse_appx_manifest_dependencies(xml).unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "Microsoft.UI.Xaml.2.8");
+        assert!(deps[0].min_version.is_none());
     }
 }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -83,6 +83,37 @@ pub struct MsixHealthReport {
     pub reason: String,
 }
 
+/// Result of the framework-dependency PRE-check run BEFORE attempting an MSIX
+/// sideload. On a stripped / China / Store-disabled Windows, `Add-AppxPackage`
+/// cannot auto-acquire missing framework packages (VCLibs, WindowsAppRuntime,
+/// UI.Xaml, NET.Native), so a sideload that needs an absent framework is doomed:
+/// it either errors outright or registers a package that won't launch. When a
+/// required framework is missing we proactively route to the portable build
+/// instead of burning a failed install attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MsixDependencyPrecheck {
+    /// Whether the pre-check could actually evaluate framework presence. False
+    /// when the manifest could not be read or the `Get-AppxPackage` probe could
+    /// not run — in that case we do NOT block the sideload on an unknown signal.
+    pub checked: bool,
+    /// True when every required framework dependency is present (or none are
+    /// declared). When false, `missing_frameworks` lists what is absent.
+    pub frameworks_ok: bool,
+    /// Framework packages the manifest requires that are NOT installed.
+    pub missing_frameworks: Vec<String>,
+    /// Human-facing reason; empty when `frameworks_ok` and there is nothing to say.
+    pub reason: String,
+}
+
+impl MsixDependencyPrecheck {
+    /// The pre-check has positively determined a required framework is missing,
+    /// so the sideload should be skipped in favor of the portable build.
+    pub fn should_route_portable(&self) -> bool {
+        self.checked && !self.frameworks_ok && !self.missing_frameworks.is_empty()
+    }
+}
+
 pub fn fetch_text(url: &str) -> Result<String, EngineError> {
     let output = hidden_command("curl")
         .args(["-fsSL", "--connect-timeout", "20", url])
@@ -201,6 +232,122 @@ pub fn install_msix_sideload(_path: &Path) -> Result<MsixSideloadReport, EngineE
         fallback_recommended: true,
         raw_error: None,
     })
+}
+
+/// PRE-check, before sideloading, that every redistributable framework the
+/// staged MSIX declares as a `PackageDependency` is already installed. Reads the
+/// staged manifest's `PackageDependency` entries (same source the post-install
+/// `verify_msix_health` inspects), filters to the framework packages, and asks
+/// `Get-AppxPackage` whether each is present. A missing framework means the
+/// sideload cannot succeed on this machine (no Store / App Installer to acquire
+/// it), so the caller routes straight to the portable build.
+///
+/// This is intentionally conservative: if the manifest cannot be read or the
+/// PowerShell probe cannot run, it returns `checked = false` and does NOT block
+/// the sideload — the existing post-install health check + portable fallback
+/// remain the backstop.
+#[cfg(windows)]
+pub fn precheck_msix_dependencies(path: &Path) -> MsixDependencyPrecheck {
+    let frameworks = match crate::msix::read_msix_dependencies(path) {
+        Ok(deps) => crate::msix::framework_dependencies(&deps),
+        Err(err) => {
+            return MsixDependencyPrecheck {
+                checked: false,
+                frameworks_ok: true,
+                missing_frameworks: vec![],
+                reason: format!("could not read staged MSIX dependencies: {err}"),
+            };
+        }
+    };
+
+    if frameworks.is_empty() {
+        return MsixDependencyPrecheck {
+            checked: true,
+            frameworks_ok: true,
+            missing_frameworks: vec![],
+            reason: String::new(),
+        };
+    }
+
+    let names: Vec<String> = frameworks.iter().map(|d| d.name.clone()).collect();
+    let names_literal = names
+        .iter()
+        .map(|n| ps_quote(n))
+        .collect::<Vec<_>>()
+        .join(", ");
+    // For each declared framework name, report whether ANY package with that
+    // name is registered. We deliberately check presence (not version) here: an
+    // outright-missing framework is the doomed case; version-floor mismatches
+    // are still caught by the post-install `verify_msix_health` check.
+    let script = format!(
+        r#"
+$ErrorActionPreference = 'SilentlyContinue'
+$names = @({names})
+$missing = @()
+foreach ($n in $names) {{
+  $present = @(Get-AppxPackage -Name $n -ErrorAction SilentlyContinue)
+  if ($present.Count -eq 0) {{ $missing += $n }}
+}}
+[pscustomobject]@{{
+  missing = ($missing -join ', ')
+}} | ConvertTo-Json -Compress
+"#,
+        names = names_literal
+    );
+
+    let parsed = run_powershell_json(&script)
+        .ok()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok());
+
+    let Some(value) = parsed else {
+        // Probe could not run — don't overturn the sideload on an unknown signal.
+        return MsixDependencyPrecheck {
+            checked: false,
+            frameworks_ok: true,
+            missing_frameworks: vec![],
+            reason: "framework dependency probe could not run; proceeding with sideload"
+                .to_string(),
+        };
+    };
+
+    let missing_frameworks: Vec<String> = value
+        .get("missing")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let frameworks_ok = missing_frameworks.is_empty();
+    let reason = if frameworks_ok {
+        String::new()
+    } else {
+        format!(
+            "required framework packages are not installed: {}",
+            missing_frameworks.join(", ")
+        )
+    };
+
+    MsixDependencyPrecheck {
+        checked: true,
+        frameworks_ok,
+        missing_frameworks,
+        reason,
+    }
+}
+
+#[cfg(not(windows))]
+pub fn precheck_msix_dependencies(_path: &Path) -> MsixDependencyPrecheck {
+    // Non-Windows builds never sideload, so there is nothing to pre-check. Report
+    // checked = false / frameworks_ok = true so this can never block a path that
+    // does not exist off Windows.
+    MsixDependencyPrecheck {
+        checked: false,
+        frameworks_ok: true,
+        missing_frameworks: vec![],
+        reason: "MSIX dependency pre-checks are only meaningful on Windows".to_string(),
+    }
 }
 
 #[cfg(windows)]
@@ -817,5 +964,51 @@ mod tests {
             report.msix_deployment.state,
             crate::capability::CapabilityState::Unavailable
         );
+    }
+
+    // Pure routing logic for the framework pre-check — verified on every host so
+    // the steer-to-portable decision is covered even though the probe that fills
+    // the struct only runs on Windows.
+    #[test]
+    fn precheck_routes_portable_only_when_a_framework_is_positively_missing() {
+        // Missing framework, positively determined -> route to portable.
+        let missing = super::MsixDependencyPrecheck {
+            checked: true,
+            frameworks_ok: false,
+            missing_frameworks: vec!["Microsoft.VCLibs.140.00".to_string()],
+            reason: "required framework packages are not installed: Microsoft.VCLibs.140.00"
+                .to_string(),
+        };
+        assert!(missing.should_route_portable());
+
+        // All frameworks present -> proceed with the sideload.
+        let ok = super::MsixDependencyPrecheck {
+            checked: true,
+            frameworks_ok: true,
+            missing_frameworks: vec![],
+            reason: String::new(),
+        };
+        assert!(!ok.should_route_portable());
+
+        // Probe could not run (manifest unreadable / PowerShell failed) -> do NOT
+        // block on an unknown signal; let the sideload + health check decide.
+        let unknown = super::MsixDependencyPrecheck {
+            checked: false,
+            frameworks_ok: true,
+            missing_frameworks: vec![],
+            reason: "framework dependency probe could not run; proceeding with sideload"
+                .to_string(),
+        };
+        assert!(!unknown.should_route_portable());
+
+        // Defensive: even if flags say not-ok, an empty list must not route (we
+        // only steer when we can name the missing framework).
+        let inconsistent = super::MsixDependencyPrecheck {
+            checked: true,
+            frameworks_ok: false,
+            missing_frameworks: vec![],
+            reason: String::new(),
+        };
+        assert!(!inconsistent.should_route_portable());
     }
 }

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -523,9 +523,21 @@ pub fn perform_windows_update_with_install_mode(
     // the post-install health check + transparent fallback remain the backstop.
     let precheck = precheck_msix_dependencies(PathBuf::from(&staged_path).as_path());
     if precheck.should_route_portable() {
-        // We're going to portable, but `install_portable_after_stage` overwrites
-        // the portable install in place and does not stop a running build, so a
-        // managed portable instance must be closed first (same as the MSIX path).
+        // We're switching to portable, but the running build must be stopped
+        // first — `install_portable_after_stage` overwrites the portable install
+        // in place and does NOT stop a running instance. Close BOTH a still-present
+        // MSIX install (we're skipping the sideload that would otherwise replace it)
+        // and any managed portable build, exactly like the sideload path below —
+        // otherwise the old MSIX Codex keeps running and the user ends up on the
+        // stale build or with two instances side by side.
+        if let Some(installed) =
+            detect_installed_codex(PathBuf::from(&settings.install_root).as_path())
+        {
+            if installed.source == "msix" {
+                close_codex_gracefully_for_root(30, PathBuf::from(&installed.path).as_path())
+                    .map_err(engine_err)?;
+            }
+        }
         if let Some(previous) = &previous_installed {
             if previous.source == "portable" {
                 close_codex_gracefully_for_root(30, PathBuf::from(&previous.path).as_path())

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -14,12 +14,12 @@ use codex_win_engine::{
     cancel_active_download, close_codex_gracefully_for_root, detect_installed_codex,
     detect_portable_install, download_to_with_progress, fetch_text, find_msix_sha256,
     install_msix_sideload, install_portable_from_msix, parse_manifest, plan_update,
-    probe_capabilities, purge_codex_user_data, read_msix_identity, remove_msix_package,
-    sha256_file, uninstall_portable, validate_codex_identity, verify_msix_health,
-    verify_openai_authenticode, version_key, AuthenticodeReport, CapabilityState,
-    InstalledWindowsCodex, MsixHealthReport, MsixIdentity, MsixRemoveReport, MsixSideloadReport,
-    PortableInstallReport, PortableUninstallReport, WinCapabilityReport, WinInstallRoute,
-    WindowsRelease, WindowsUpdatePlan,
+    precheck_msix_dependencies, probe_capabilities, purge_codex_user_data, read_msix_identity,
+    remove_msix_package, sha256_file, uninstall_portable, validate_codex_identity,
+    verify_msix_health, verify_openai_authenticode, version_key, AuthenticodeReport,
+    CapabilityState, InstalledWindowsCodex, MsixHealthReport, MsixIdentity, MsixRemoveReport,
+    MsixSideloadReport, PortableInstallReport, PortableUninstallReport, WinCapabilityReport,
+    WinInstallRoute, WindowsRelease, WindowsUpdatePlan,
 };
 
 use crate::app::provenance::ProvenanceStore;
@@ -508,7 +508,41 @@ pub fn perform_windows_update_with_install_mode(
     let staged_path = stage
         .staged_path
         .as_ref()
-        .ok_or_else(|| AppError::Engine("staged MSIX path missing".to_string()))?;
+        .ok_or_else(|| AppError::Engine("staged MSIX path missing".to_string()))?
+        .clone();
+
+    // PRE-check the staged MSIX's declared framework dependencies BEFORE touching
+    // the running install or attempting the sideload. On a stripped / China /
+    // Store-disabled Windows, `Add-AppxPackage` cannot auto-acquire a missing
+    // framework (VCLibs / WindowsAppRuntime / UI.Xaml / NET.Native), so the
+    // sideload is doomed — it either errors or registers a package that won't
+    // launch. When a required framework is positively missing we route straight
+    // to the portable build instead of burning a failed attempt. The probe is
+    // conservative: if the manifest can't be read or the check can't run it
+    // returns `checked = false` and we proceed to the sideload as before, where
+    // the post-install health check + transparent fallback remain the backstop.
+    let precheck = precheck_msix_dependencies(PathBuf::from(&staged_path).as_path());
+    if precheck.should_route_portable() {
+        // We're going to portable, but `install_portable_after_stage` overwrites
+        // the portable install in place and does not stop a running build, so a
+        // managed portable instance must be closed first (same as the MSIX path).
+        if let Some(previous) = &previous_installed {
+            if previous.source == "portable" {
+                close_codex_gracefully_for_root(30, PathBuf::from(&previous.path).as_path())
+                    .map_err(engine_err)?;
+            }
+        }
+        let mut stage = stage;
+        stage.notes.push(format!(
+            "Skipped MSIX sideload before attempting it: {}. Routed to the portable build, which carries its own runtime and does not need these framework packages.",
+            precheck.reason
+        ));
+        let mut report =
+            install_portable_after_stage(settings, stage, None, None, previous_installed)?;
+        report.action = "portable-fallback-missing-framework".to_string();
+        return Ok(report);
+    }
+
     if let Some(installed) = detect_installed_codex(PathBuf::from(&settings.install_root).as_path())
     {
         if installed.source == "msix" {
@@ -527,7 +561,7 @@ pub fn perform_windows_update_with_install_mode(
         }
     }
     let sideload =
-        install_msix_sideload(PathBuf::from(staged_path).as_path()).map_err(engine_err)?;
+        install_msix_sideload(PathBuf::from(&staged_path).as_path()).map_err(engine_err)?;
 
     if sideload.success {
         // Add-AppxPackage returning success only means the cmdlet didn't throw.


### PR DESCRIPTION
## What

Harden the Windows MSIX install flow with a **framework-dependency pre-check** (C1). Before attempting an `Add-AppxPackage` sideload, we now read the staged MSIX's declared `PackageDependency` entries and verify every required redistributable framework is already installed on the machine. If a required framework is **positively missing**, we proactively route to the portable build instead of attempting a doomed sideload.

Frameworks pre-checked (prefix, case-insensitive): `Microsoft.VCLibs.*`, `Microsoft.WindowsAppRuntime.*`, `Microsoft.UI.Xaml.*`, `Microsoft.NET.Native.*`.

## Why

On a stripped / China / Store-disabled Windows there is no Store / App Installer to auto-acquire a missing framework package. In that situation `Add-AppxPackage` is doomed: it either errors outright, or registers a package that won't launch (the exact failure users hit). Today we only discover this *after* the fact via the post-install `verify_msix_health` check, then fall back. Pre-checking lets us skip the failed attempt entirely and go straight to the portable build, which ships its own runtime and needs none of these frameworks.

## How

**`crates/codex-win-engine/src/msix.rs`** — new cross-platform (pure) helpers, mirroring how `verify_msix_health` reads `Package.Dependencies.PackageDependency` but running against the staged package *before* install:
- `parse_appx_manifest_dependencies(xml)` — namespace-agnostic parse of `<PackageDependency>` entries.
- `read_msix_dependencies(path)` — same zip + `AppxManifest.xml` path as `read_msix_identity`.
- `is_framework_dependency(name)` / `framework_dependencies(&[..])` — classify by the framework prefixes above.

**`crates/codex-win-engine/src/sys.rs`** — new `MsixDependencyPrecheck` report + `precheck_msix_dependencies(path)` (`#[cfg(windows)]`) plus a non-windows stub. The windows impl reads the staged manifest, filters to framework deps, and asks `Get-AppxPackage` whether each is present. It is **conservative**: `should_route_portable()` only returns true when a framework is positively determined missing. If the manifest can't be read or the PowerShell probe can't run, it returns `checked = false` and does **not** block the sideload — the existing post-install health check + transparent portable fallback remain the backstop.

**`src-tauri/src/app/win_update.rs`** — call `precheck_msix_dependencies` in `perform_windows_update_with_install_mode` right before the sideload. On a missing framework it closes a running managed portable build first (since `install_portable_after_stage` overwrites in place and doesn't stop a running build), pushes a clear note, routes via `install_portable_after_stage`, and surfaces a new action label `portable-fallback-missing-framework`.

### C3 skipped (documented)
C3 (post-install launch confirmation) is intentionally **not** included. Any real launch confirmation would activate the app GUI in the middle of an update — explicitly out of scope ("do NOT pop a GUI in the user's face during an update"). There is no bounded, non-intrusive way to confirm an *actual* launch beyond what `verify_msix_health` already does (package registered + status Ok + AUMID resolvable + frameworks present), which is the runnable-without-launching signal we already rely on. Shipping C1 alone.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml` (host darwin): **pass**.
- `cargo test --manifest-path src-tauri/Cargo.toml -p codex-win-engine`: **pass** — 24 tests, incl. 6 new cross-platform tests (manifest dependency parsing, framework classification incl. case-insensitivity, empty/no-name edge cases, and the `should_route_portable` routing gate covering missing / present / unknown-probe / inconsistent inputs).
- `cargo check --manifest-path src-tauri/Cargo.toml -p codex-win-engine --target x86_64-pc-windows-gnu`: **pass** — confirms the new `#[cfg(windows)]` engine code (precheck body, PowerShell script formatting, exports) compiles for Windows.
- Frontend `npx tsc --noEmit`: **pass** (no frontend changes; sanity only).

## Residual risk

- **`#[cfg(windows)]` runtime behavior cannot be exercised on this macOS host.** The `Get-AppxPackage` probe, the PowerShell script's actual output, and the end-to-end install/route behavior need **CI + a real-Windows pass** (ideally on a genuinely stripped / Store-disabled box) to confirm. The Windows *compile* is verified via the cross-target check above, but not execution.
- The full-app cross-compile to `x86_64-pc-windows-gnu` could not finish in this environment due to a missing mingw C toolchain (a transitive build-script C dependency) — unrelated to these Rust changes; the `win_update.rs` wiring is plain cross-platform Rust and is fully covered by the host `cargo check`.
- Pre-existing `cargo fmt` diffs in untouched files (`mac_update.rs`, `commands.rs`, `provenance.rs`, and unrelated lines of `win_update.rs`) come from a local rustfmt version differing from the repo's; left untouched. PR-level CI does not run fmt.