### PR TITLE
fix(win): report MSIX health honestly when the probe cannot run

### DIFF
--- a/crates/codex-win-engine/src/capability.rs
+++ b/crates/codex-win-engine/src/capability.rs
@@ -52,6 +52,12 @@ pub struct WinCapabilityReport {
     pub appx_service: CapabilityCheck,
     pub sideload_policy: CapabilityCheck,
     pub app_installer: CapabilityCheck,
+    /// Can the WinRT `PackageManager` (the COM class `Add-AppxPackage` deploys
+    /// through) actually be activated? Unlike the checks above, this exercises
+    /// the deployment runtime itself — so it catches the "registered but broken"
+    /// machines where MSIX install dies with `0x80040154 REGDB_E_CLASSNOTREG`
+    /// ("没有注册类") even though the cmdlet, service and policy all look present.
+    pub msix_deployment: CapabilityCheck,
     pub metered_network: CapabilityCheck,
     pub recommendation: SideloadRecommendation,
     pub notes: Vec<String>,
@@ -63,17 +69,29 @@ impl WinCapabilityReport {
         appx_service: CapabilityCheck,
         sideload_policy: CapabilityCheck,
         app_installer: CapabilityCheck,
+        msix_deployment: CapabilityCheck,
         metered_network: CapabilityCheck,
         mut notes: Vec<String>,
     ) -> Self {
         let msix_blocked = add_appx_package.state == CapabilityState::Unavailable
             || appx_service.state == CapabilityState::Unavailable
-            || sideload_policy.state == CapabilityState::Unavailable;
+            || sideload_policy.state == CapabilityState::Unavailable
+            || msix_deployment.state == CapabilityState::Unavailable;
         let recommendation = if msix_blocked {
-            notes.push(
-                "MSIX sideloading appears blocked; use the portable fallback when available."
-                    .to_string(),
-            );
+            if msix_deployment.state == CapabilityState::Unavailable {
+                // The deployment runtime itself is broken — the exact 0x80040154
+                // case. Sideloading cannot possibly succeed, so go straight to
+                // portable instead of letting the user hit a failed MSIX attempt.
+                notes.push(
+                    "MSIX deployment is broken on this machine (the PackageManager COM class is not registered, e.g. 0x80040154); using the portable build."
+                        .to_string(),
+                );
+            } else {
+                notes.push(
+                    "MSIX sideloading appears blocked; use the portable fallback when available."
+                        .to_string(),
+                );
+            }
             SideloadRecommendation::PortableFallback
         } else {
             if sideload_policy.state == CapabilityState::Unknown {
@@ -90,6 +108,7 @@ impl WinCapabilityReport {
             appx_service,
             sideload_policy,
             app_installer,
+            msix_deployment,
             metered_network,
             recommendation,
             notes,
@@ -98,6 +117,7 @@ impl WinCapabilityReport {
 
     pub fn unknown_for_non_windows() -> Self {
         Self::from_checks(
+            CapabilityCheck::unknown("not running on Windows"),
             CapabilityCheck::unknown("not running on Windows"),
             CapabilityCheck::unknown("not running on Windows"),
             CapabilityCheck::unknown("not running on Windows"),
@@ -119,6 +139,7 @@ mod tests {
             CapabilityCheck::available("running"),
             CapabilityCheck::unknown("policy absent"),
             CapabilityCheck::available("installed"),
+            CapabilityCheck::available("PackageManager activates"),
             CapabilityCheck::unknown("not probed"),
             vec![],
         );
@@ -132,6 +153,7 @@ mod tests {
             CapabilityCheck::available("running"),
             CapabilityCheck::unavailable("AllowAllTrustedApps=0"),
             CapabilityCheck::available("installed"),
+            CapabilityCheck::available("PackageManager activates"),
             CapabilityCheck::unknown("not probed"),
             vec![],
         );
@@ -139,5 +161,27 @@ mod tests {
             report.recommendation,
             SideloadRecommendation::PortableFallback
         );
+    }
+
+    #[test]
+    fn recommends_portable_when_msix_deployment_is_broken() {
+        // The 0x80040154 case: cmdlet, service and policy all look fine, but the
+        // deployment runtime itself cannot activate, so sideloading cannot work.
+        let report = WinCapabilityReport::from_checks(
+            CapabilityCheck::available("present"),
+            CapabilityCheck::available("running"),
+            CapabilityCheck::available("AllowAllTrustedApps=1"),
+            CapabilityCheck::available("installed"),
+            CapabilityCheck::unavailable(
+                "PackageManager activation failed: 没有注册类 (HRESULT=0x80040154)",
+            ),
+            CapabilityCheck::unknown("not probed"),
+            vec![],
+        );
+        assert_eq!(
+            report.recommendation,
+            SideloadRecommendation::PortableFallback
+        );
+        assert!(report.notes.iter().any(|note| note.contains("0x80040154")));
     }
 }

--- a/crates/codex-win-engine/src/plan.rs
+++ b/crates/codex-win-engine/src/plan.rs
@@ -89,6 +89,7 @@ mod tests {
             CapabilityCheck::available("running"),
             CapabilityCheck::available("AllowAllTrustedApps=1"),
             CapabilityCheck::available("installed"),
+            CapabilityCheck::available("PackageManager activates"),
             CapabilityCheck::unknown("not probed"),
             vec![],
         );
@@ -119,6 +120,7 @@ mod tests {
             CapabilityCheck::available("running"),
             CapabilityCheck::unavailable("policy blocks trusted apps"),
             CapabilityCheck::available("installed"),
+            CapabilityCheck::available("PackageManager activates"),
             CapabilityCheck::unknown("not probed"),
             vec![],
         );

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -556,6 +556,25 @@ try {
   }
 } catch {}
 
+$msixDeploymentKnown = $false
+$msixDeploymentOk = $false
+$msixDeploymentError = ''
+try {
+  $pm = New-Object -TypeName Windows.Management.Deployment.PackageManager -ErrorAction Stop
+  $msixDeploymentKnown = $true
+  $msixDeploymentOk = ($null -ne $pm)
+} catch {
+  $msixDeploymentKnown = $true
+  $msixDeploymentOk = $false
+  $hr = 0
+  try { $hr = [int]$_.Exception.HResult } catch {}
+  if ($hr -ne 0) {
+    $msixDeploymentError = ('{0} (HRESULT=0x{1:X8})' -f $_.Exception.Message, $hr)
+  } else {
+    $msixDeploymentError = [string]$_.Exception.Message
+  }
+}
+
 [pscustomobject]@{
   addAppxPackage = [bool]$add
   appxSvcExists = [bool]$svc
@@ -568,6 +587,9 @@ try {
   meteredKnown = $meteredKnown
   metered = $metered
   networkCostType = $costType
+  msixDeploymentKnown = $msixDeploymentKnown
+  msixDeploymentOk = $msixDeploymentOk
+  msixDeploymentError = $msixDeploymentError
 } | ConvertTo-Json -Compress
 "#;
 
@@ -577,6 +599,7 @@ try {
     {
         Some(value) => capabilities_from_probe_json(&value),
         None => WinCapabilityReport::from_checks(
+            CapabilityCheck::unknown("PowerShell capability probe failed"),
             CapabilityCheck::unknown("PowerShell capability probe failed"),
             CapabilityCheck::unknown("PowerShell capability probe failed"),
             CapabilityCheck::unknown("PowerShell capability probe failed"),
@@ -681,11 +704,38 @@ fn capabilities_from_probe_json(value: &serde_json::Value) -> WinCapabilityRepor
         CapabilityCheck::available(format!("current connection is not metered ({cost})"))
     };
 
+    // The functional probe: did the WinRT PackageManager actually activate? Only
+    // an explicit activation failure (known && !ok) flips this to Unavailable —
+    // an unrun probe stays Unknown so a good machine is never steered to portable
+    // on a signal we couldn't read. This is the check that catches 0x80040154.
+    let msix_deployment = if !value
+        .get("msixDeploymentKnown")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        CapabilityCheck::unknown("MSIX deployment (PackageManager) could not be probed")
+    } else if value
+        .get("msixDeploymentOk")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        CapabilityCheck::available("PackageManager (MSIX deployment runtime) activates")
+    } else {
+        let err = value
+            .get("msixDeploymentError")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        CapabilityCheck::unavailable(format!(
+            "PackageManager (MSIX deployment runtime) cannot activate: {err}"
+        ))
+    };
+
     WinCapabilityReport::from_checks(
         add,
         appx_service,
         sideload_policy,
         app_installer,
+        msix_deployment,
         metered_network,
         vec!["Certificate trust is verified after the MSIX is staged.".to_string()],
     )
@@ -710,12 +760,48 @@ mod tests {
             "allowAllTrustedAppsSource": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Appx",
             "meteredKnown": true,
             "metered": false,
-            "networkCostType": "Unrestricted"
+            "networkCostType": "Unrestricted",
+            "msixDeploymentKnown": true,
+            "msixDeploymentOk": true,
+            "msixDeploymentError": ""
         });
         let report = capabilities_from_probe_json(&value);
         assert_eq!(
             report.recommendation,
             crate::capability::SideloadRecommendation::PortableFallback
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parses_probe_json_into_portable_when_deployment_broken() {
+        // Every existence check looks fine, but the functional PackageManager
+        // probe failed (0x80040154). The recommendation must be portable and the
+        // deployment check must read Unavailable — this is the issue #13 machine.
+        let value = serde_json::json!({
+            "addAppxPackage": true,
+            "appxSvcExists": true,
+            "appxSvcStatus": "Running",
+            "appxSvcStartType": "Manual",
+            "appInstallerInstalled": true,
+            "appInstallerVersion": "1.0.0.0",
+            "allowAllTrustedApps": 1,
+            "allowAllTrustedAppsSource": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
+            "meteredKnown": true,
+            "metered": false,
+            "networkCostType": "Unrestricted",
+            "msixDeploymentKnown": true,
+            "msixDeploymentOk": false,
+            "msixDeploymentError": "没有注册类 (HRESULT=0x80040154)"
+        });
+        let report = capabilities_from_probe_json(&value);
+        assert_eq!(
+            report.recommendation,
+            crate::capability::SideloadRecommendation::PortableFallback
+        );
+        assert_eq!(
+            report.msix_deployment.state,
+            crate::capability::CapabilityState::Unavailable
         );
     }
 }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -64,6 +64,12 @@ pub struct MsixRemoveReport {
 #[serde(rename_all = "camelCase")]
 pub struct MsixHealthReport {
     pub healthy: bool,
+    /// Whether the health probe actually ran and the `healthy` verdict reflects
+    /// real checks. `false` means the probe could not run and `healthy` is a
+    /// conservative "keep the MSIX" default, not a clean bill of health that was
+    /// observed. Callers/UI/notes use this to tell "verified healthy" apart from
+    /// "kept because unverifiable".
+    pub verified: bool,
     pub package_registered: bool,
     /// Raw `Get-AppxPackage` Status string (e.g. "Ok", "Modified").
     pub status: String,
@@ -342,8 +348,12 @@ try {{
     let Some(value) = parsed else {
         // The health probe itself could not run. Don't overturn a successful
         // Add-AppxPackage on an unverifiable signal — keep the MSIX install.
+        // The keep-MSIX decision (healthy = true) is intentional, but mark the
+        // report unverified so callers don't mistake it for an observed clean
+        // bill of health.
         return MsixHealthReport {
             healthy: true,
+            verified: false,
             package_registered: true,
             status: "probe-failed".to_string(),
             status_ok: true,
@@ -399,6 +409,8 @@ try {{
 
     MsixHealthReport {
         healthy,
+        // The probe ran and produced a real verdict.
+        verified: true,
         package_registered,
         status,
         status_ok,
@@ -411,9 +423,11 @@ try {{
 #[cfg(not(windows))]
 pub fn verify_msix_health() -> MsixHealthReport {
     // Non-Windows builds never sideload, so there is nothing to verify; report
-    // healthy so this can never be the thing that blocks a (non-existent) path.
+    // healthy so this can never be the thing that blocks a (non-existent) path,
+    // but leave verified = false since no real check was performed.
     MsixHealthReport {
         healthy: true,
+        verified: false,
         package_registered: false,
         status: "not-windows".to_string(),
         status_ok: true,

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -131,6 +131,7 @@ const WIN_FALLBACK_PLAN: WinUpdateReport = {
     appxService: { state: "available", detail: "browser-dev mock" },
     sideloadPolicy: { state: "unknown", detail: "browser-dev mock" },
     appInstaller: { state: "available", detail: "browser-dev mock" },
+    msixDeployment: { state: "available", detail: "browser-dev mock" },
     meteredNetwork: { state: "unknown", detail: "browser-dev mock" },
     recommendation: "msix-preferred",
     notes: ["Certificate trust is verified after the MSIX is staged."],

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -209,7 +209,7 @@ const WIN_FALLBACK_PERFORM: WinPerformReport = {
     rawError: null,
   },
   portable: null,
-  msixHealth: { healthy: true, packageRegistered: true, status: "Ok", statusOk: true, aumidResolved: true, missingDependencies: [], reason: "" },
+  msixHealth: { healthy: true, verified: true, packageRegistered: true, status: "Ok", statusOk: true, aumidResolved: true, missingDependencies: [], reason: "" },
   installed: {
     path: "C:\\Program Files\\WindowsApps\\OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0",
     version: "26.602.3474.0",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -242,6 +242,13 @@ export interface MsixSideloadReport {
 
 export interface MsixHealthReport {
   healthy: boolean;
+  /**
+   * Whether the health probe actually ran. When false, `healthy` is a
+   * conservative "keep the MSIX" default (the probe could not run), not an
+   * observed clean bill of health. Use this to tell "verified healthy" apart
+   * from "kept because unverifiable".
+   */
+  verified: boolean;
   packageRegistered: boolean;
   /** Raw Get-AppxPackage Status string (e.g. "Ok", "Modified"). */
   status: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -155,6 +155,9 @@ export interface WinCapabilityReport {
   appxService: CapabilityCheck;
   sideloadPolicy: CapabilityCheck;
   appInstaller: CapabilityCheck;
+  /** Can the WinRT PackageManager actually activate? Catches the "registered but
+   * broken" machines where MSIX deploy dies with 0x80040154 (没有注册类). */
+  msixDeployment: CapabilityCheck;
   meteredNetwork: CapabilityCheck;
   recommendation: SideloadRecommendation;
   notes: string[];


### PR DESCRIPTION
Re-opens the change from #35, which GitHub auto-closed when its stacked base branch (feat/win-msix-deployment-probe, #31) was deleted on merge. Same commit, already passed Codex review + the full CI matrix as #35.

Adds a distinct `verified` signal to MsixHealthReport so an unrunnable post-install probe reads as 'unverified' rather than asserting healthy=true — without changing the conservative keep-MSIX decision.