### PR TITLE
feat(mirror): permanent /manager/latest/* links (Worker resolver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ brew install --cask wangnov/tap/codex-app-manager
 
 | 平台 | 文件 | 镜像直链 |
 |---|---|---|
-| Apple Silicon Mac | `CodexAppManager_aarch64.dmg` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/0.1.11/CodexAppManager_aarch64.dmg) |
-| Intel Mac | `CodexAppManager_x86_64.dmg` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/0.1.11/CodexAppManager_x86_64.dmg) |
-| Windows x64 | `CodexAppManager_0.1.11_x64-setup.exe` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/0.1.11/CodexAppManager_0.1.11_x64-setup.exe) |
+| Apple Silicon Mac | `CodexAppManager_aarch64.dmg` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| Intel Mac | `CodexAppManager_x86_64.dmg` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows x64 | `CodexAppManager_x64-setup.exe` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
 
-macOS 版本经 **Developer ID 签名 + Apple 公证**,首次打开不会被 Gatekeeper 拦截。镜像直链对应 **v0.1.11**;装好后 Manager 会通过**应用内自更新**保持最新(见下),首次安装无需手动追最新版本号。
+macOS 版本经 **Developer ID 签名 + Apple 公证**,首次打开不会被 Gatekeeper 拦截。镜像直链恒指向**最新版**——`/manager/latest/` 由 Cloudflare Worker 自动解析到当前发布,无需随版本更新;装好后 Manager 还会通过**应用内自更新**保持最新(见下)。
 
 > 安装 Manager 后,真正的 Codex 桌面应用由 Manager 负责安装与更新——你不需要单独去下载 Codex 本体。
 
@@ -196,11 +196,11 @@ Grab your platform's file from the [latest GitHub Release](https://github.com/Wa
 
 | Platform | File | Mirror link |
 |---|---|---|
-| Apple Silicon Mac | `CodexAppManager_aarch64.dmg` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/0.1.11/CodexAppManager_aarch64.dmg) |
-| Intel Mac | `CodexAppManager_x86_64.dmg` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/0.1.11/CodexAppManager_x86_64.dmg) |
-| Windows x64 | `CodexAppManager_0.1.11_x64-setup.exe` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/0.1.11/CodexAppManager_0.1.11_x64-setup.exe) |
+| Apple Silicon Mac | `CodexAppManager_aarch64.dmg` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| Intel Mac | `CodexAppManager_x86_64.dmg` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows x64 | `CodexAppManager_x64-setup.exe` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
 
-The macOS builds are **Developer ID signed + Apple notarized**, so Gatekeeper won't block first launch. The mirror links point at **v0.1.11**; after install, the Manager keeps **itself** up to date via in-app self-update (below), so you don't need to chase the latest version number by hand.
+The macOS builds are **Developer ID signed + Apple notarized**, so Gatekeeper won't block first launch. The mirror links always resolve to the **latest** release — `/manager/latest/` is auto-resolved to the current version by the Cloudflare Worker, with no per-release edits; after install, the Manager also keeps **itself** up to date via in-app self-update (below).
 
 > Once the Manager is installed, it installs and updates the actual Codex desktop app for you — you don't need to download Codex separately.
 

--- a/cloudflare/manager-download-router/src/index.js
+++ b/cloudflare/manager-download-router/src/index.js
@@ -18,9 +18,22 @@ export default {
     if (!url.pathname.startsWith(PREFIX)) {
       return new Response("Not found", { status: 404 });
     }
-    const key = decodeURIComponent(url.pathname.slice(PREFIX.length));
+    let key = decodeURIComponent(url.pathname.slice(PREFIX.length));
     if (!key || key.endsWith("/") || key.includes("..")) {
       return new Response("Not found", { status: 404 });
+    }
+
+    // /manager/latest/<file> → rewrite to the current immutable versioned key
+    // (latest/CodexAppManager_aarch64.dmg → 0.1.12/CodexAppManager_aarch64.dmg)
+    // so the README can link a permanent URL that never needs a version bump.
+    // The rewrite is IN-PLACE (no redirect): still ONE Worker invocation, and
+    // the resolved versioned object keeps its hard cache. Cost is one cheap R2
+    // GET of latest.json per first-install click; self-update traffic (which
+    // fetches latest.json + the .app.tar.gz directly) never reaches this path.
+    if (key.startsWith("latest/")) {
+      const version = await currentVersion(env);
+      if (!version) return new Response("Not found", { status: 404 });
+      key = `${version}/${withVersion(key.slice("latest/".length), version)}`;
     }
 
     const country = request.cf?.country || request.headers.get("CF-IPCountry") || "";
@@ -99,6 +112,29 @@ function redirect(location) {
 function objectKeyForKey(key, prefix) {
   const cleanPrefix = prefix.replace(/^\/+|\/+$/g, "");
   return cleanPrefix ? `${cleanPrefix}/${key}` : key;
+}
+
+// Resolve the current release version from latest.json (root object on R2).
+// Used only to rewrite /manager/latest/* — returns null on any miss so the
+// caller 404s instead of guessing a version.
+async function currentVersion(env) {
+  try {
+    const object = await env.BUCKET.get("latest.json");
+    if (!object) return null;
+    const manifest = await object.json();
+    return typeof manifest.version === "string" && manifest.version ? manifest.version : null;
+  } catch {
+    return null;
+  }
+}
+
+// Installers live under <version>/. The macOS .dmg names are version-less and
+// pass straight through; the Windows NSIS .exe embeds the version in its file
+// name, so insert it so a stable "latest" link resolves to the real object.
+function withVersion(file, version) {
+  return file === "CodexAppManager_x64-setup.exe"
+    ? `CodexAppManager_${version}_x64-setup.exe`
+    : file;
 }
 
 // ── AWS SigV4 presigner (GET/HEAD), identical scheme to codex-app-mirror ─────


### PR DESCRIPTION
## What
The Cloudflare download-router (`cloudflare/manager-download-router`) now resolves `/manager/latest/<file>` in-place to the current immutable versioned object, so the README mirror links can be **permanent** and never need a per-release version bump.

## How
- Worker reads `version` from `latest.json` (already on R2), rewrites the key to `<ver>/<file>` (inserting the version into the Windows `.exe` name), then runs the existing global-R2 / China-IHEP routing on the resolved key. **No redirect to another `/manager/` path → still one Worker invocation**; one extra cheap R2 GET of `latest.json` per first-install click. Self-update traffic (latest.json + .app.tar.gz) never touches this path, so Workers quota is unaffected.
- README 中/英 download tables → `…/manager/latest/CodexAppManager_*`; the version-less display name for the `.exe`; the "points at v0.1.11" note now says the links auto-follow the latest release.

## Status
- Worker **already deployed** (Version `8ba3b8dd`). Verified live: `latest/CodexAppManager_aarch64.dmg` → `0.1.12/…aarch64.dmg` (206), `latest/CodexAppManager_x64-setup.exe` → `0.1.12/CodexAppManager_0.1.12_x64-setup.exe` (206), and `latest/nonexistent.bin` → 404. This PR just syncs the repo with what's deployed + flips the README links.