### PR TITLE
fix(release): ship BinaryDelta in macOS bundles so delta updates actually run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,15 @@ jobs:
 
       - run: npm ci
 
+      # ── macOS: vendor the Sparkle BinaryDelta helper BEFORE the build so it
+      #    ships in Resources/. Without it the manager can't apply deltas and
+      #    every macOS update silently falls back to the full-package download
+      #    (the 0.1.x releases up to 0.1.12 shipped without it). The script
+      #    pins Sparkle 2.9.1 by SHA-256; see scripts/vendor-binary-delta.sh.
+      - name: Vendor Sparkle BinaryDelta (macOS delta updates)
+        if: matrix.os == 'macos'
+        run: bash scripts/vendor-binary-delta.sh
+
       # ── macOS: import the Developer ID cert into a throwaway keychain ──────
       - name: Import Apple Developer ID certificate
         if: matrix.os == 'macos'
@@ -90,6 +99,21 @@ jobs:
           done
           echo "::error::tauri build failed after 3 attempts"
           exit 1
+
+      # Regression gate: losing the helper is otherwise SILENT — updates still
+      # succeed, they just always download the full ~400MB package instead of
+      # the ~40MB delta. Fail the release loudly instead.
+      - name: Assert BinaryDelta inside the bundle
+        if: matrix.os == 'macos'
+        run: |
+          APP="$(find "src-tauri/target/${{ matrix.target }}/release/bundle/macos" -maxdepth 1 -name '*.app' | head -1)"
+          BD="$APP/Contents/Resources/resources/BinaryDelta"
+          [ -x "$BD" ] || { echo "::error::BinaryDelta missing or not executable at $BD — macOS delta updates would silently fall back to full downloads"; exit 1; }
+          arches="$(lipo -archs "$BD")"
+          case "$arches" in
+            *x86_64*arm64*|*arm64*x86_64*) echo "BinaryDelta OK ($arches): $BD" ;;
+            *) echo "::error::BinaryDelta is not universal (arches: $arches)"; exit 1 ;;
+          esac
 
       # ── macOS: adaptive icon → sign → notarize → staple → repackage ───────
       - name: Finalize macOS bundle

--- a/src-tauri/examples/mac_delta_e2e.rs
+++ b/src-tauri/examples/mac_delta_e2e.rs
@@ -1,0 +1,161 @@
+//! `mac_delta_e2e` — REAL end-to-end macOS **delta** update against the live
+//! `/Applications/Codex.app`, through the exact production path
+//! (`plan_macos_update` → `perform_macos_update`) with the vendored
+//! `BinaryDelta` from `src-tauri/resources/` (the same file release bundles
+//! ship). Lives in `examples/` so it is never built into the .app (see the
+//! Cargo.toml note); `win_real_smoke.rs` is the Windows counterpart.
+//!
+//! DESTRUCTIVE — it gracefully quits Codex and atomically swaps the installed
+//! bundle (that IS the behavior under test), so it refuses to run without
+//! `CAM_MAC_DELTA_E2E=1`. The installed build must be one the appcast still
+//! publishes a delta FROM (downgrade first by unpacking an older full zip):
+//!
+//! ```sh
+//! CAM_MAC_DELTA_E2E=1 cargo run --example mac_delta_e2e
+//! ```
+//!
+//! Pass/fail is decided by:
+//!   * the plan strategy is `delta-from-<installed>` — NOT full;
+//!   * every download progress callback reports the DELTA's byte size as its
+//!     total — the moment a full-package fallback kicks in, the total flips to
+//!     the full size and the run fails;
+//!   * the perform report is verified, not rolled back, strategy still delta
+//!     (a fallback rewrites it to `full (…回退…)`);
+//!   * the installed bundle ends at the appcast's latest build.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use codex_app_manager_lib::app::mac_update::{
+    perform_macos_update, plan_macos_update, DownloadProgress, PerformExpectation,
+};
+use codex_mac_engine::UpdateStrategy;
+
+fn fail(msg: &str) -> ExitCode {
+    eprintln!("FAIL: {msg}");
+    ExitCode::FAILURE
+}
+
+fn main() -> ExitCode {
+    if std::env::var("CAM_MAC_DELTA_E2E").as_deref() != Ok("1") {
+        eprintln!(
+            "refusing to run: set CAM_MAC_DELTA_E2E=1 — this quits Codex and swaps \
+             /Applications/Codex.app (the real production update)"
+        );
+        return ExitCode::FAILURE;
+    }
+
+    // The vendored helper exactly as the release bundle ships it.
+    let tool = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/BinaryDelta");
+    if !tool.is_file() {
+        return fail("missing src-tauri/resources/BinaryDelta — run scripts/vendor-binary-delta.sh");
+    }
+
+    let report = match plan_macos_update(None) {
+        Ok(r) => r,
+        Err(e) => return fail(&format!("plan: {e}")),
+    };
+    let Some(installed) = report.installed else {
+        return fail("no Codex installed");
+    };
+    let Some(plan) = report.plan else {
+        return fail("appcast had no items");
+    };
+    println!(
+        "installed: build {} ({}) at {}",
+        installed.build, installed.short_version, installed.path
+    );
+    println!(
+        "plan: latest build {} ({}) | download {} B | full {} B | saves {:.1}%",
+        plan.latest_build, plan.latest_short_version, plan.download_size, plan.full_size, plan.savings_pct
+    );
+
+    if plan.up_to_date {
+        return fail("already up to date — downgrade Codex to a delta-covered build first");
+    }
+    let UpdateStrategy::Delta { from_build } = plan.strategy.clone() else {
+        return fail(&format!(
+            "plan strategy is FULL — the appcast has no delta from build {}",
+            installed.build
+        ));
+    };
+    if from_build != installed.build {
+        return fail("delta from_build != installed build");
+    }
+    let delta_size = plan.download_size;
+    if delta_size == 0 || delta_size * 2 >= plan.full_size {
+        return fail("delta is not meaningfully smaller than the full package — wrong plan?");
+    }
+
+    // Every callback's `total` must equal the delta size; a fallback download
+    // (full zip) would report the full size and trip this.
+    let bad_total = AtomicU64::new(0);
+    let last_logged = AtomicU64::new(0);
+    let progress = |p: DownloadProgress| {
+        if p.total != delta_size {
+            bad_total.store(p.total, Ordering::SeqCst);
+        }
+        // Log at most every ~4 MiB so a slow link doesn't spam.
+        let prev = last_logged.load(Ordering::SeqCst);
+        if p.downloaded >= prev + 4 * 1024 * 1024 || p.downloaded == p.total {
+            last_logged.store(p.downloaded, Ordering::SeqCst);
+            println!("  ↓ {}/{} bytes from {}", p.downloaded, p.total, p.source);
+        }
+    };
+
+    let perf = match perform_macos_update(
+        Some(tool),
+        PerformExpectation {
+            from_build: installed.build,
+            to_build: plan.latest_build,
+            install_path: installed.path.clone(),
+        },
+        &progress,
+    ) {
+        Ok(r) => r,
+        Err(e) => return fail(&format!("perform: {e}")),
+    };
+
+    println!(
+        "perform: strategy={} verified={} rolled_back={} relaunched={} warning={:?}",
+        perf.strategy, perf.verified, perf.rolled_back, perf.relaunched, perf.warning
+    );
+    println!("perform message: {}", perf.message);
+
+    let expected_strategy = format!("delta-from-{from_build}");
+    if perf.strategy != expected_strategy {
+        return fail(&format!(
+            "strategy was '{}' (expected '{expected_strategy}') — delta fell back to full",
+            perf.strategy
+        ));
+    }
+    if !perf.verified || perf.rolled_back {
+        return fail("update not verified or rolled back");
+    }
+    let bad = bad_total.load(Ordering::SeqCst);
+    if bad != 0 {
+        return fail(&format!(
+            "a download reported total {bad} B (expected the delta's {delta_size} B) — full package was fetched"
+        ));
+    }
+
+    // Reality check on disk: the installed bundle must now BE the new build.
+    match plan_macos_update(None) {
+        Ok(after) => match after.installed {
+            Some(i) if i.build == plan.latest_build => {
+                println!(
+                    "OK — delta update applied on the real install: build {} → {} ({} B delta, full would be {} B)",
+                    from_build, i.build, delta_size, plan.full_size
+                );
+                ExitCode::SUCCESS
+            }
+            Some(i) => fail(&format!(
+                "installed build is {} after update (expected {})",
+                i.build, plan.latest_build
+            )),
+            None => fail("no Codex detected after update"),
+        },
+        Err(e) => fail(&format!("post-update plan: {e}")),
+    }
+}


### PR DESCRIPTION
## 问题

用户在 macOS 上更新 Codex 时，UI 显示「增量更新约 40MB」，实际却下载了 ~428MB 全量包。

**根因**：`src-tauri/resources/BinaryDelta` 被 .gitignore 排除（设计如此，应由 `scripts/vendor-binary-delta.sh` 在构建时获取），但 `release.yml` 从未调用该脚本。因此所有已发布的 .app 都缺这个 helper，`resolve_binary_delta()` 返回 `None`，`perform_macos_update()` 静默走「delta 工具缺失，回退全量」分支——计划阶段承诺 40MB，执行阶段下了 428MB。

## 修复

- **release.yml**：macOS matrix 在 `tauri build` 前运行 `scripts/vendor-binary-delta.sh`（SHA-256 双重锁定的 Sparkle 2.9.1 universal 二进制）。
- **release.yml**：build 后新增回归闸——bundle 内缺少可执行 universal BinaryDelta 则 fail。没有这道闸，丢失 helper 是不可见的（更新照样成功，只是永远全量）。
- **examples/mac_delta_e2e.rs**：真机 delta E2E harness（`CAM_MAC_DELTA_E2E=1` 门禁），走完整生产路径 plan → perform。

签名链无需改动：`sign-macos-app.sh` 本就 inside-out 签所有嵌套 Mach-O（包括 BinaryDelta）。

## 真机验证（本机 arm64）

1. **Harness E2E**：降级到 build 3685 → `cargo run --example mac_delta_e2e` → 下载恰好 40,408,266 B delta（省 90.6%），EdDSA + codesign 闸全绿，原子替换至 3722，无回退。
2. **打包断言**：本地 `tauri build` 产物含可执行 universal BinaryDelta（与新 CI 闸同款检查）。
3. **GUI 验收**：将含 BinaryDelta 的 0.1.12 包替换本机 manager，再次降级到 3685，通过真实 UI 完成更新——8 秒完成（delta 缓存命中 + apply），staging 的全量解压目录 mtime 未变，证明全量路径未运行。

`codex review --uncommitted` 无意见；`cargo clippy --workspace --all-targets -- -D warnings` 与 `cargo test --workspace` 本地通过（与 CI 同款命令）。