### PR TITLE
fix(ui): drive the update card + consent from one atomic snapshot (stale-expectation recovery)

### DIFF
--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -514,20 +514,27 @@ pub fn perform_macos_update(
     expected: PerformExpectation,
     progress: &dyn Fn(DownloadProgress),
 ) -> Result<MacPerformReport, AppError> {
-    let installed = detect_installed()
-        .ok_or_else(|| AppError::Engine("no Codex detected to update".to_string()))?;
+    // A vanished install is itself a stale snapshot: the user confirmed an
+    // update against a Codex that is no longer there (deleted / moved between
+    // confirm and execute). Route it through StaleExpectation so the UI
+    // auto-re-checks (→ none/install) instead of looping on a dead error.
+    let installed = detect_installed().ok_or_else(|| {
+        AppError::StaleExpectation(
+            "未检测到 Codex（可能已被删除或移动）：请重新检查后再试".to_string(),
+        )
+    })?;
 
     // Consent integrity: the destructive swap must target exactly what the user
     // saw + confirmed. If Codex self-updated (Sparkle), moved, or staging is
     // stale, refuse rather than act on a stale consent.
     if installed.path != expected.install_path {
-        return Err(AppError::Engine(format!(
+        return Err(AppError::StaleExpectation(format!(
             "安装位置已变化（确认时 {}，现在 {}）：请重新检查后再试",
             expected.install_path, installed.path
         )));
     }
     if installed.build != expected.from_build {
-        return Err(AppError::Engine(format!(
+        return Err(AppError::StaleExpectation(format!(
             "已装版本已变化（确认时 build {}，现在 build {}）：请重新检查后再试",
             expected.from_build, installed.build
         )));
@@ -542,7 +549,7 @@ pub fn perform_macos_update(
 
     // The appcast must still point at the build the user confirmed.
     if plan.latest_build != expected.to_build {
-        return Err(AppError::Engine(format!(
+        return Err(AppError::StaleExpectation(format!(
             "更新目标已变化（确认时 build {}，现在 build {}）：请重新检查后再试",
             expected.to_build, plan.latest_build
         )));

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -7,6 +7,12 @@ pub enum AppError {
     UnsupportedPlatform,
     #[error("update engine error: {0}")]
     Engine(String),
+    /// Reality (installed bundle / feed target) no longer matches the snapshot
+    /// the user confirmed — the TOCTOU guard before a destructive step. The
+    /// message is already user-facing; the UI reacts to the code by silently
+    /// re-checking and asking the user to confirm the fresh plan.
+    #[error("{0}")]
+    StaleExpectation(String),
     #[error("{0}")]
     Internal(String),
 }
@@ -16,6 +22,7 @@ impl AppError {
         match self {
             Self::UnsupportedPlatform => "unsupported_platform",
             Self::Engine(_) => "engine_error",
+            Self::StaleExpectation(_) => "stale_expectation",
             Self::Internal(_) => "internal_error",
         }
     }

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -57,6 +57,7 @@ const ZH = {
   "home.error.title": "检查失败",
   "home.error.sub": "请稍后重试,或在设置里更换更新源。",
   "home.source": "更新源:{source}",
+  "home.stale.rechecked": "安装状态已变化,已重新检查——请再次确认。",
 
   "prov.managed": "已托管",
   "prov.external": "未管理",
@@ -207,6 +208,7 @@ const EN: Record<Key, string> = {
   "home.error.title": "Check failed",
   "home.error.sub": "Try again later, or switch the update source in Settings.",
   "home.source": "Source: {source}",
+  "home.stale.rechecked": "The installed state changed — re-checked; please confirm again.",
 
   "prov.managed": "Managed",
   "prov.external": "Unmanaged",
@@ -354,6 +356,7 @@ const FR: Record<Key, string> = {
   "home.error.title": "Vérification échouée",
   "home.error.sub": "Réessayez plus tard ou changez la source dans les Réglages.",
   "home.source": "Source : {source}",
+  "home.stale.rechecked": "L'état installé a changé — nouvelle vérification effectuée ; veuillez confirmer à nouveau.",
 
   "prov.managed": "Géré",
   "prov.external": "Non géré",
@@ -502,6 +505,7 @@ const ZH_TW: Record<Key, string> = {
   "home.error.title": "檢查失敗",
   "home.error.sub": "請稍後再試，或在設定中更換更新來源。",
   "home.source": "來源：{source}",
+  "home.stale.rechecked": "安裝狀態已變更，已重新檢查——請再次確認。",
 
   "prov.managed": "已管理",
   "prov.external": "未管理",
@@ -660,6 +664,7 @@ const DE: Record<Key, string> = {
   "home.error.title": "Prüfung fehlgeschlagen",
   "home.error.sub": "Später erneut versuchen oder in den Einstellungen eine andere Updatequelle wählen.",
   "home.source": "Quelle: {source}",
+  "home.stale.rechecked": "Der Installationszustand hat sich geändert — erneut geprüft; bitte noch einmal bestätigen.",
 
   "prov.managed": "Verwaltet",
   "prov.external": "Nicht verwaltet",
@@ -818,6 +823,7 @@ const KO: Record<Key, string> = {
   "home.error.title": "확인 실패",
   "home.error.sub": "잠시 후 다시 시도하거나, 설정에서 업데이트 소스를 변경해 보세요.",
   "home.source": "소스: {source}",
+  "home.stale.rechecked": "설치 상태가 변경되어 다시 확인했습니다 — 다시 한번 확인해 주세요.",
 
   "prov.managed": "관리됨",
   "prov.external": "미관리",
@@ -972,6 +978,7 @@ const JA: Record<Key, string> = {
   "home.error.title": "確認に失敗しました",
   "home.error.sub": "しばらくしてから再試行するか、設定でアップデート元を変更してください。",
   "home.source": "ソース: {source}",
+  "home.stale.rechecked": "インストール状態が変わったため再チェックしました — もう一度ご確認ください。",
   "prov.managed": "管理済み",
   "prov.external": "未管理",
   "confirm.title": "{version} にアップデートしますか？",
@@ -1110,6 +1117,7 @@ const RU: Record<Key, string> = {
   "home.error.title": "Ошибка проверки",
   "home.error.sub": "Повторите позже или смените источник обновлений в настройках.",
   "home.source": "Источник: {source}",
+  "home.stale.rechecked": "Состояние установки изменилось — проверка выполнена заново; подтвердите ещё раз.",
   "prov.managed": "Управляется",
   "prov.external": "Не управляется",
   "confirm.title": "Обновить до {version}?",
@@ -1248,6 +1256,7 @@ const AR: Record<Key, string> = {
   "home.error.title": "فشل التحقق",
   "home.error.sub": "حاول مجدداً لاحقاً، أو غيِّر مصدر التحديث في الإعدادات.",
   "home.source": "المصدر: {source}",
+  "home.stale.rechecked": "تغيّرت حالة التثبيت — أُعيد الفحص؛ يُرجى التأكيد مرة أخرى.",
   "prov.managed": "مُدار",
   "prov.external": "غير مُدار",
   "confirm.title": "تحديث إلى {version}؟",
@@ -1386,6 +1395,7 @@ const ES: Record<Key, string> = {
   "home.error.title": "Error al comprobar",
   "home.error.sub": "Inténtalo más tarde o cambia la fuente de actualización en Ajustes.",
   "home.source": "Fuente: {source}",
+  "home.stale.rechecked": "El estado de instalación cambió — se volvió a comprobar; confírmalo de nuevo.",
   "prov.managed": "Gestionado",
   "prov.external": "No gestionado",
   "confirm.title": "¿Actualizar a {version}?",
@@ -1524,6 +1534,7 @@ const PT_BR: Record<Key, string> = {
   "home.error.title": "Falha na verificação",
   "home.error.sub": "Tente novamente mais tarde ou troque a fonte de atualização nas Configurações.",
   "home.source": "Fonte: {source}",
+  "home.stale.rechecked": "O estado da instalação mudou — verificado novamente; confirme mais uma vez.",
   "prov.managed": "Gerenciado",
   "prov.external": "Não gerenciado",
   "confirm.title": "Atualizar para {version}?",

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 
-import { errorMessage, managerApi } from "../../services/managerApi";
+import { errorCode, errorMessage, managerApi } from "../../services/managerApi";
 import type {
   AppSettings,
   DownloadProgress,
@@ -37,6 +37,11 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const [busy, setBusy] = useState<"plan" | "perform" | "adopt" | "install" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // A non-error, transient heads-up (e.g. "we re-checked because the install
+  // changed"). Kept SEPARATE from `error` on purpose: `error` drives the
+  // "检查失败" hero in the `!installed` branch, so reusing it for an info note
+  // would strand a now-uninstalled user on an error screen with no install CTA.
+  const [notice, setNotice] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   // Whether the status request has finished (success OR failure) — distinct from
   // the value, so a failed macStatus doesn't leave the home stuck on "loading".
@@ -83,21 +88,6 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     }
   }, [onDlProgress]);
 
-  const check = useCallback(async () => {
-    setBusy("plan");
-    setError(null);
-    try {
-      setReport(await managerApi.macPlanUpdate());
-    } catch (cause) {
-      // Drop any stale plan so a failed re-check can't keep driving "立即更新"
-      // off an outdated currentBuild/latestBuild.
-      setReport(null);
-      setError(errorMessage(cause));
-    } finally {
-      setBusy(null);
-    }
-  }, []);
-
   const refreshStatus = useCallback(async () => {
     try {
       setStatus(await managerApi.macStatus());
@@ -110,6 +100,30 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     }
   }, []);
 
+  // Re-plan AND re-detect in the same breath: everything on screen (and the
+  // perform expectation) must come from one coherent moment. Refreshing only
+  // one of the two is how "当前 X → 新版 X" cards and doomed expectations happen
+  // after an out-of-band install change. Returns whether the check succeeded,
+  // so a caller can layer a notice on top without masking a check failure.
+  const check = useCallback(async (): Promise<boolean> => {
+    setBusy("plan");
+    setError(null);
+    setNotice(null);
+    try {
+      const [r] = await Promise.all([managerApi.macPlanUpdate(), refreshStatus()]);
+      setReport(r);
+      return true;
+    } catch (cause) {
+      // Drop any stale plan so a failed re-check can't keep driving "立即更新"
+      // off an outdated currentBuild/latestBuild.
+      setReport(null);
+      setError(errorMessage(cause));
+      return false;
+    } finally {
+      setBusy(null);
+    }
+  }, [refreshStatus]);
+
   useEffect(() => {
     void (async () => {
       const s = await managerApi.getSettings().catch(() => DEFAULT_SETTINGS);
@@ -121,6 +135,72 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       }
     })();
   }, [check, refreshStatus]);
+
+  // The snapshot/busy values the focus listener (a long-lived subscription)
+  // reads — refs so the subscription doesn't tear down on every state change.
+  const reportRef = useRef<MacUpdateReport | null>(null);
+  useEffect(() => {
+    reportRef.current = report;
+  }, [report]);
+  const busyRef = useRef(busy);
+  useEffect(() => {
+    busyRef.current = busy;
+  }, [busy]);
+
+  // Window focus → silently re-detect the local install (milliseconds, no
+  // network). If it no longer matches the snapshot on screen (Codex was
+  // updated / downgraded out-of-band while we weren't looking), re-run the
+  // full check so the card corrects itself instead of waiting to fail the
+  // perform-time guard.
+  useEffect(() => {
+    let last = 0;
+    let un: (() => void) | undefined;
+    void (async () => {
+      try {
+        un = await listen("tauri://focus", () => {
+          const now = Date.now();
+          if (busyRef.current || now - last < 3000) return;
+          last = now;
+          void (async () => {
+            try {
+              const st = await managerApi.macStatus();
+              setStatus(st);
+              setStatusLoaded(true);
+              setStatusFailed(false);
+              // Re-check whenever the install identity (build OR path) differs
+              // from the last checked snapshot — in EITHER direction, so a
+              // fresh external install (snapshot had none), a removal, a
+              // version change, and a same-build move to a new path all
+              // re-plan. Gate on `checked` (we have planned at least once), not
+              // on a non-null installed, or the none→installed transition is
+              // missed. The perform expectation pins build+path, so a stale
+              // plan here would only fail the backend guard or mislead the card.
+              const checked = reportRef.current;
+              const snap = checked?.installed ?? null;
+              const fresh = st.installed ?? null;
+              const identityChanged =
+                (snap?.build ?? null) !== (fresh?.build ?? null) ||
+                (snap?.path ?? null) !== (fresh?.path ?? null);
+              if (checked && identityChanged) {
+                // Drop any open confirm sheet first: it was built for the OLD
+                // target, and the install may now be external/gone. Leaving it
+                // up would let a click run perform against a snapshot the user
+                // never saw — bypassing the external→adopt boundary. The user
+                // re-confirms against the freshly-checked card.
+                setConfirmOpen(false);
+                void check();
+              }
+            } catch {
+              // Transient/unsupported — the next explicit check will surface it.
+            }
+          })();
+        });
+      } catch {
+        // Non-Tauri (web preview): no event bus — nothing to clean up.
+      }
+    })();
+    return () => un?.();
+  }, [check]);
 
   const adopt = useCallback(async () => {
     setBusy("adopt");
@@ -152,7 +232,12 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   }, [check, startDlListen]);
 
   const runPerform = useCallback(async () => {
-    const installed = status?.installed;
+    // ONE atomic snapshot (the report carries installed + plan detected
+    // together) drives both the labels and the consent expectation — never mix
+    // it with the separately-fetched `status`, which can lag an out-of-band
+    // install change. The backend re-verifies reality against exactly this
+    // expectation before the destructive swap.
+    const installed = report?.installed;
     const plan = report?.plan;
     if (!installed || !plan || plan.upToDate) return;
     setBusy("perform");
@@ -172,20 +257,35 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       setPerform(result);
       setUpdatedVer({ from: fromVersion, to: toVersion });
       setConfirmOpen(false);
-      await refreshStatus();
       await check();
     } catch (cause) {
-      setError(errorMessage(cause));
       setConfirmOpen(false);
+      if (errorCode(cause) === "stale_expectation") {
+        // Reality moved between confirm and execute (the backend's TOCTOU
+        // guard). Refresh the snapshot and post a NOTICE (not an error) so the
+        // card can settle into whatever it now is — update / up-to-date / none
+        // (Codex was removed) — without the `error`-driven "检查失败" hero
+        // hijacking the none case. A failed re-check keeps its own error.
+        if (await check()) {
+          setNotice(t("home.stale.rechecked"));
+        }
+      } else {
+        setError(errorMessage(cause));
+      }
     } finally {
       un();
       setBusy(null);
       setDl(null);
     }
-  }, [status, report, refreshStatus, check, startDlListen]);
+  }, [report, check, startDlListen, t]);
 
   const plan = report?.plan ?? null;
-  const installed = status?.installed ?? report?.installed ?? null;
+  // The report is one atomic backend snapshot (installed detected together
+  // with the plan) — when it exists, it is the truth the card paints and the
+  // expectation signs. `status` (local-only, loads before the first network
+  // check and refreshes on focus) fills in until then and drives the
+  // managed/external badge.
+  const installed = (report ? report.installed : status?.installed) ?? null;
   const isManaged = status?.status === "managed";
   const updateAvailable = Boolean(plan) && !plan?.upToDate;
 
@@ -366,6 +466,14 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
               setPerform(null);
               setUpdatedVer(null);
             }}
+          />
+        ) : null}
+        {notice ? (
+          <ResultBanner
+            tone="ok"
+            title={notice}
+            autoDismissMs={6000}
+            onClose={() => setNotice(null)}
           />
         ) : null}
         {error ? (

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -151,8 +151,10 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       setError(null);
       // For an in-place update (not a fresh install) capture the human-facing
       // versions before the swap, so the outcome strip can show "X → Y".
+      // Prefer the report (one atomic snapshot of installed + plan) so the
+      // strip can't pair a stale installed version with a fresh plan.
       const fromVersion =
-        mode === "perform" ? status?.installed?.version ?? report?.installed?.version ?? "" : "";
+        mode === "perform" ? report?.installed?.version ?? status?.installed?.version ?? "" : "";
       const toVersion = report?.plan?.latestVersion ?? "";
       const unlisten = await startDlListen();
       try {

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -88,6 +88,14 @@ export function errorMessage(cause: unknown): string {
   return String(cause);
 }
 
+/** Stable machine code from a backend `CommandError`, or null for other throwables. */
+export function errorCode(cause: unknown): string | null {
+  if (isCommandError(cause) && typeof cause.code === "string" && cause.code.trim()) {
+    return cause.code;
+  }
+  return null;
+}
+
 // Browser-dev fallbacks (no Tauri runtime) — a simulated "one version behind"
 // so the UI renders meaningfully outside the desktop shell.
 const FALLBACK_PLAN: MacUpdateReport = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,7 +7,11 @@ export type Architecture = "x64" | "arm64" | "unknown";
  * `#[serde(rename_all = "camelCase")]` from `AppError`.
  */
 export interface CommandError {
-  /** Stable machine code, e.g. "unsupported_platform" | "engine_error" | "internal_error". */
+  /**
+   * Stable machine code, e.g. "unsupported_platform" | "engine_error" |
+   * "stale_expectation" | "internal_error". `stale_expectation` means reality
+   * no longer matches the snapshot the user confirmed — re-check, re-confirm.
+   */
   code: string;
   /** Human-facing message (the `Display` of the underlying `AppError`). */
   message: string;


### PR DESCRIPTION
## 问题（用户实测截图）

手动把已装 Codex 降级到旧版后，Manager 能识别"有新版本"，但点「立即更新」报错 `update engine error: 已装版本已变化（确认时 build 3722，现在 build 3685）：请重新检查后再试`，且卡片出现「当前 26.608.12217 → 新版 26.608.12217」这种自相矛盾的显示。

**根因**：主界面持有两份独立刷新的状态——`status`（macStatus：本地检测 + 托管状态）和 `report`（macPlanUpdate：检测 + plan）。「重新检查」只刷新 `report`，但渲染和 perform 的 expectation 都优先从 `status` 读 `installed`。带外安装变更后，卡片把过期的 installed 版本和新的 plan 配在一起，点更新发出的 `from/to/path` 是跨两个时刻拼凑的，被后端的同意完整性护栏正确拒绝——但用户撞上的是一个无法操作的死错误。

## 修复：把 plan 当作「对单一快照的租约」

- **Home.tsx 单快照**：`report` 存在时，它是卡片和 perform expectation 的唯一来源（installed 与 plan 同时检测）；`status` 只在首次检查前兜底、并驱动 managed/external 徽章。`check()` 现在用 `Promise.all` 同时刷新 plan 和检测。
- **errors.rs**：新增 `AppError::StaleExpectation`（code `stale_expectation`），覆盖 perform 期的 TOCTOU 护栏——路径变、from-build 变、to-build 变，以及**安装消失**（原先是裸 engine_error）。这是"现实已变，请重检"的机器信号。
- **Home.tsx stale 自动恢复**：收到 `stale_expectation` → 自动重检 + 发一条 **notice**（独立 `notice` 状态走 ResultBanner，**不复用 `error`**）。这样卡片能落到 update / 已最新 / none（Codex 被删）任一态，而不会被 `error` 驱动的「检查失败」页劫持。
- **Home.tsx 焦点刷新**：窗口聚焦时静默重新检测；若安装 identity（build 或 path，任一方向）与快照不同 → 重检并关闭任何打开的确认弹窗（弹窗是为旧目标构建的，留着可能让点击对未见过的快照执行 perform，绕过 external→adopt 边界）。
- **managerApi.ts**：新增 `errorCode()` 读取稳定的 CommandError code。
- **WinHome.tsx**：同理优先 `report.installed`（一致性；Windows 暂无 stale-code 路径）。
- **i18n**：`home.stale.rechecked` 11 语言。

## 真机验证（arm64）

带外降级 Codex → adopt → 在 Manager 眼皮底下把磁盘换回最新 → 点「立即更新」→ 后端返回 `stale_expectation` → **UI 自动重检，显示绿色信息条（而非红色错误），卡片正确落位**，不再卡在过期 plan。同时 delta 成功路径与「已是最新」态均回归正常。

## 关系说明

本 PR 与 [#43](https://github.com/Wangnov/Codex-App-Manager/pull/43)（vendor BinaryDelta）、[#44](https://github.com/Wangnov/Codex-App-Manager/pull/44)（quit 确认框）独立但相关：#44 也改 `mac_update.rs`（quit 调用点），本 PR 改的是 expectation 校验点与 `detect_installed`，位置不同。建议合并顺序 #43 → #44 → 本 PR，本 PR 如遇 `mac_update.rs` 冲突仅为相邻 import/函数，易解。

`codex review --uncommitted` 迭代 5 轮至无意见；`cargo clippy --workspace --all-targets -- -D warnings`、`cargo test --workspace`、`npm run check`、`npm run test`（11）全部通过。