### PR TITLE
chore(release): bump version to 0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.12"
+version = "0.1.13"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
发布 0.1.13，打包本轮三个已合并修复：

- #43 — release.yml 在 build 前 vendor Sparkle BinaryDelta + build 后断言 bundle 含 universal 二进制，让 macOS 增量更新真正生效（此前所有发布包都缺该 helper，静默回退全量）。
- #44 — 更新时 Codex 弹出的退出确认框被带到前台，不再静默超时；超时错误改为可操作提示；11 语言确认框预先提示。
- #45 — 更新卡片与同意 expectation 统一走单一快照；新增 stale_expectation 错误码，前端自动重检并显示绿色信息条，不再卡死错误。

版本号已同步五处（package.json / package-lock×2 / tauri.conf.json / Cargo.toml / Cargo.lock），均 0.1.12 → 0.1.13，已逐一用 git diff / grep 验证无残留。合并后在 main 打 v0.1.13 tag 触发 release.yml。