### PR TITLE
[codex] harden manager update flows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  actions: write # dispatch winget.yml after publishing (release events from GITHUB_TOKEN don't cascade)
+  contents: read
 
 jobs:
   build:
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +41,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -84,9 +88,6 @@ jobs:
       # ── Build WITHOUT a tauri signingIdentity; we sign inside-out after ────
       - name: Build (Tauri, unsigned)
         shell: bash
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         # Bundling downloads toolchains on the fly (e.g. the NSIS archive from
         # GitHub) which occasionally 504s and fails the whole release. Retry a
         # few times so a transient download hiccup doesn't sink the run — cargo
@@ -191,10 +192,16 @@ jobs:
           if-no-files-found: error
 
   release:
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
     needs: build
+    permissions:
+      contents: write
+      actions: write # dispatch winget.yml after publishing (release events from GITHUB_TOKEN don't cascade)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,24 +211,11 @@ jobs:
       - name: Generate updater manifest (latest.json)
         run: node scripts/gen-updater-manifest.mjs "${{ github.ref_name }}" dist
 
-      - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ github.ref_name }}
-          draft: false
-          # Tags carrying a pre-release identifier (e.g. v0.1.2-rc1) publish as a
-          # prerelease, so GitHub's `releases/latest` — and the updater endpoint
-          # pointing at it — keep resolving to the last stable build instead of
-          # serving a release-candidate to real users.
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          files: |
-            dist/*
-            latest.json
-
       # Mirror the release to the CDN so in-app self-update works without GitHub
       # (slow/blocked for the CN audience). Skips pre-releases so a -rc tag never
-      # overwrites the mirror's single latest.json. No-ops cleanly until the
-      # MANAGER_R2_* (and optionally MANAGER_IHEP_S3_*) secrets are configured.
+      # overwrites the mirror's single latest.json. For stable tags this runs
+      # before GitHub Release publication, so missing/failed R2 sync blocks the
+      # release instead of leaving the public release ahead of the updater mirror.
       - name: Sync to CDN mirror (R2 + IHEP S3)
         if: ${{ !contains(github.ref_name, '-') }}
         env:
@@ -244,6 +231,21 @@ jobs:
         run: |
           [ -f dist/latest.json ] || cp latest.json dist/latest.json
           bash scripts/sync-mirror.sh dist
+          rm -f dist/latest.mirror.json
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          # Tags carrying a pre-release identifier (e.g. v0.1.2-rc1) publish as a
+          # prerelease, so GitHub's `releases/latest` — and the updater endpoint
+          # pointing at it — keep resolving to the last stable build instead of
+          # serving a release-candidate to real users.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            dist/*
+            latest.json
 
       # The release above is created with GITHUB_TOKEN, which by design does not
       # trigger other workflows — so winget.yml's `on: release` never fires.

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -60,7 +60,11 @@ pub fn fetch_text_timeout(url: &str, max_secs: u64) -> Result<String, EngineErro
 pub fn installed_codex_build() -> Option<(String, u64)> {
     candidate_app_paths()
         .into_iter()
-        .find_map(|app| read_bundle_build(&app).map(|build| (app, build)))
+        .find_map(|app| installed_codex_build_at_path(&app))
+}
+
+pub fn installed_codex_build_at_path(app: &str) -> Option<(String, u64)> {
+    read_bundle_build(app).map(|build| (app.to_string(), build))
 }
 
 fn candidate_app_paths() -> Vec<String> {

--- a/crates/codex-win-engine/src/download.rs
+++ b/crates/codex-win-engine/src/download.rs
@@ -52,6 +52,39 @@ fn partial_path(dest: &Path) -> PathBuf {
     dest.with_file_name(format!("{file_name}.part"))
 }
 
+fn url_host(url: &str) -> &str {
+    url.split("://")
+        .nth(1)
+        .and_then(|rest| rest.split('/').next())
+        .unwrap_or("")
+}
+
+fn proxy_env_summary() -> String {
+    let vars = ["HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "NO_PROXY"];
+    let configured = vars
+        .iter()
+        .filter(|name| std::env::var_os(name).is_some())
+        .copied()
+        .collect::<Vec<_>>();
+    if configured.is_empty() {
+        "no curl proxy environment variables are set; Windows system proxy/PAC may not be used automatically".to_string()
+    } else {
+        format!("curl proxy environment variables set: {}", configured.join(", "))
+    }
+}
+
+fn curl_failure_message(url: &str, exit_code: Option<i32>, stderr: &str) -> String {
+    format!(
+        "curl failed for host={} exit={}: stderr='{}'; {}",
+        url_host(url),
+        exit_code
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "signal".to_string()),
+        stderr.trim(),
+        proxy_env_summary(),
+    )
+}
+
 fn run_curl(url: &str, dest: &Path, resume: bool, on_progress: &dyn Fn(u64)) -> Result<(), String> {
     let dest = dest.to_string_lossy().into_owned();
     let mut args = vec![
@@ -98,9 +131,10 @@ fn run_curl(url: &str, dest: &Path, resume: bool, on_progress: &dyn Fn(u64)) -> 
     };
 
     if !output.status.success() {
-        return Err(format!(
-            "curl failed for {url}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+        return Err(curl_failure_message(
+            url,
+            output.status.code(),
+            &String::from_utf8_lossy(&output.stderr),
         ));
     }
     let downloaded = std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0);

--- a/crates/codex-win-engine/src/msix.rs
+++ b/crates/codex-win-engine/src/msix.rs
@@ -25,7 +25,11 @@ pub struct MsixIdentity {
 pub struct MsixPackageDependency {
     pub name: String,
     #[serde(default)]
+    pub publisher: Option<String>,
+    #[serde(default)]
     pub min_version: Option<String>,
+    #[serde(default)]
+    pub processor_architecture: Option<String>,
 }
 
 /// Known framework-package name prefixes that an MSIX can take a runtime
@@ -109,9 +113,21 @@ pub fn parse_appx_manifest_dependencies(
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string);
+            let publisher = node
+                .attribute("Publisher")
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            let processor_architecture = node
+                .attribute("ProcessorArchitecture")
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
             Some(MsixPackageDependency {
                 name: name.to_string(),
+                publisher,
                 min_version,
+                processor_architecture,
             })
         })
         .collect();
@@ -249,7 +265,9 @@ mod tests {
         let deps = parse_appx_manifest_dependencies(xml).unwrap();
         assert_eq!(deps.len(), 3);
         assert_eq!(deps[0].name, "Microsoft.VCLibs.140.00");
+        assert_eq!(deps[0].publisher.as_deref(), Some("CN=Microsoft"));
         assert_eq!(deps[0].min_version.as_deref(), Some("14.0.30704.0"));
+        assert!(deps[0].processor_architecture.is_none());
 
         let frameworks = framework_dependencies(&deps);
         // Contoso.Helper is a non-framework dependency and is excluded.
@@ -285,5 +303,17 @@ mod tests {
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "Microsoft.UI.Xaml.2.8");
         assert!(deps[0].min_version.is_none());
+    }
+
+    #[test]
+    fn parses_package_dependency_architecture() {
+        let xml = r#"
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Dependencies>
+    <PackageDependency Name="Microsoft.VCLibs.140.00" Publisher="CN=Microsoft" MinVersion="14.0.0.0" ProcessorArchitecture="x64" />
+  </Dependencies>
+</Package>"#;
+        let deps = parse_appx_manifest_dependencies(xml).unwrap();
+        assert_eq!(deps[0].processor_architecture.as_deref(), Some("x64"));
     }
 }

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -27,6 +27,8 @@ pub struct PortableInstallReport {
 #[serde(rename_all = "camelCase")]
 pub struct PortableUninstallReport {
     pub success: bool,
+    #[serde(default)]
+    pub partial: bool,
     pub install_root: String,
     pub removed_files: bool,
     pub removed_shortcut: bool,
@@ -638,23 +640,43 @@ pub fn uninstall_portable(
         false
     };
 
-    let removed_shortcut = remove_start_menu_shortcut().unwrap_or(false);
-    let removed_uninstall_entry = remove_uninstall_entry().unwrap_or(false);
     let mut notes = Vec::new();
+    let removed_shortcut = match remove_start_menu_shortcut() {
+        Ok(removed) => removed,
+        Err(err) => {
+            notes.push(format!("Start Menu shortcut cleanup failed: {err}"));
+            false
+        }
+    };
+    let removed_uninstall_entry = match remove_uninstall_entry() {
+        Ok(removed) => removed,
+        Err(err) => {
+            notes.push(format!("Apps & Features uninstall entry cleanup failed: {err}"));
+            false
+        }
+    };
     let purged_user_data = if purge_user_data {
         purge_codex_user_data(&mut notes)?
     } else {
         false
     };
+    let partial = notes
+        .iter()
+        .any(|note| note.contains("cleanup failed"));
 
     Ok(PortableUninstallReport {
         success: true,
+        partial,
         install_root: install_root.to_string_lossy().into_owned(),
         removed_files,
         removed_shortcut,
         removed_uninstall_entry,
         purged_user_data,
-        message: "Portable Codex uninstall completed.".to_string(),
+        message: if partial {
+            "Portable Codex uninstall completed with cleanup warnings.".to_string()
+        } else {
+            "Portable Codex uninstall completed.".to_string()
+        },
         notes,
     })
 }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -51,6 +51,8 @@ pub struct MsixRemoveReport {
     pub success: bool,
     pub message: String,
     pub raw_error: Option<String>,
+    #[serde(default)]
+    pub notes: Vec<String>,
 }
 
 /// Post-install sanity check for a sideloaded MSIX. `Add-AppxPackage` returning
@@ -121,13 +123,47 @@ pub fn fetch_text(url: &str) -> Result<String, EngineError> {
         .map_err(|e| EngineError::Io(format!("spawn curl: {e}")))?;
 
     if !output.status.success() {
-        return Err(EngineError::Io(format!(
-            "curl failed for {url}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+        return Err(EngineError::Io(curl_failure_message(
+            url,
+            output.status.code(),
+            &String::from_utf8_lossy(&output.stderr),
         )));
     }
 
     String::from_utf8(output.stdout).map_err(|e| EngineError::Io(e.to_string()))
+}
+
+fn curl_failure_message(url: &str, exit_code: Option<i32>, stderr: &str) -> String {
+    format!(
+        "curl failed for host={} exit={}: stderr='{}'; {}",
+        url_host(url),
+        exit_code
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "signal".to_string()),
+        stderr.trim(),
+        proxy_env_summary(),
+    )
+}
+
+fn url_host(url: &str) -> &str {
+    url.split("://")
+        .nth(1)
+        .and_then(|rest| rest.split('/').next())
+        .unwrap_or("")
+}
+
+fn proxy_env_summary() -> String {
+    let vars = ["HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "NO_PROXY"];
+    let configured = vars
+        .iter()
+        .filter(|name| std::env::var_os(name).is_some())
+        .copied()
+        .collect::<Vec<_>>();
+    if configured.is_empty() {
+        "no curl proxy environment variables are set; Windows system proxy/PAC may not be used automatically".to_string()
+    } else {
+        format!("curl proxy environment variables set: {}", configured.join(", "))
+    }
 }
 
 pub fn detect_installed_codex(portable_root: &Path) -> Option<InstalledWindowsCodex> {
@@ -137,6 +173,11 @@ pub fn detect_installed_codex(portable_root: &Path) -> Option<InstalledWindowsCo
 #[cfg(windows)]
 fn ps_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(windows)]
+fn ps_nullable(value: Option<&str>) -> String {
+    value.map(ps_quote).unwrap_or_else(|| "$null".to_string())
 }
 
 #[cfg(windows)]
@@ -269,30 +310,88 @@ pub fn precheck_msix_dependencies(path: &Path) -> MsixDependencyPrecheck {
         };
     }
 
-    let names: Vec<String> = frameworks.iter().map(|d| d.name.clone()).collect();
-    let names_literal = names
+    let package_architecture = crate::msix::read_msix_identity(path)
+        .ok()
+        .map(|identity| identity.processor_architecture);
+    let deps_literal = frameworks
         .iter()
-        .map(|n| ps_quote(n))
+        .map(|dep| {
+            format!(
+                "[pscustomobject]@{{ Name = {name}; Publisher = {publisher}; MinVersion = {min_version}; ProcessorArchitecture = {arch} }}",
+                name = ps_quote(&dep.name),
+                publisher = ps_nullable(dep.publisher.as_deref()),
+                min_version = ps_nullable(dep.min_version.as_deref()),
+                arch = ps_nullable(dep.processor_architecture.as_deref()),
+            )
+        })
         .collect::<Vec<_>>()
         .join(", ");
-    // For each declared framework name, report whether ANY package with that
-    // name is registered. We deliberately check presence (not version) here: an
-    // outright-missing framework is the doomed case; version-floor mismatches
-    // are still caught by the post-install `verify_msix_health` check.
+    let package_arch_literal = ps_nullable(package_architecture.as_deref());
     let script = format!(
         r#"
-$ErrorActionPreference = 'SilentlyContinue'
-$names = @({names})
-$missing = @()
-foreach ($n in $names) {{
-  $present = @(Get-AppxPackage -Name $n -ErrorAction SilentlyContinue)
-  if ($present.Count -eq 0) {{ $missing += $n }}
-}}
-[pscustomobject]@{{
-  missing = ($missing -join ', ')
-}} | ConvertTo-Json -Compress
-"#,
-        names = names_literal
+	$ErrorActionPreference = 'SilentlyContinue'
+	$deps = @({deps})
+	$mainArch = {package_arch}
+	$missing = @()
+	function Convert-ToVersion($value) {{
+	  try {{
+	    $text = [string]$value
+	    if ([string]::IsNullOrWhiteSpace($text)) {{ return $null }}
+	    return [version]$text
+	  }} catch {{
+	    return $null
+	  }}
+	}}
+	function Same-Publisher($package, [string]$publisher) {{
+	  if ([string]::IsNullOrWhiteSpace($publisher)) {{ return $true }}
+	  return [string]$package.Publisher -eq $publisher
+	}}
+	function Same-Architecture($package, [string]$required) {{
+	  if ([string]::IsNullOrWhiteSpace($required) -or $required -eq 'neutral') {{ return $true }}
+	  $arch = [string]$package.Architecture
+	  return [string]::IsNullOrWhiteSpace($arch) -or $arch -eq 'Neutral' -or $arch -eq $required
+	}}
+	foreach ($d in $deps) {{
+	  $name = [string]$d.Name
+	  if ([string]::IsNullOrWhiteSpace($name)) {{ continue }}
+	  $publisher = [string]$d.Publisher
+	  $requiredArch = [string]$d.ProcessorArchitecture
+	  if ([string]::IsNullOrWhiteSpace($requiredArch)) {{ $requiredArch = $mainArch }}
+	  $candidates = @(Get-AppxPackage -Name $name -ErrorAction SilentlyContinue)
+	  if ($candidates.Count -eq 0) {{
+	    $missing += "$name not installed"
+	    continue
+	  }}
+	  $publisherCandidates = @($candidates | Where-Object {{ Same-Publisher $_ $publisher }})
+	  if ($candidates.Count -gt 0 -and $publisherCandidates.Count -eq 0) {{
+	    $missing += "$name publisher $publisher not installed"
+	    continue
+	  }}
+	  $archCandidates = @($publisherCandidates | Where-Object {{ Same-Architecture $_ $requiredArch }})
+	  if ($publisherCandidates.Count -gt 0 -and $archCandidates.Count -eq 0) {{
+	    $missing += "$name architecture $requiredArch not installed"
+	    continue
+	  }}
+	  $depPkg = $archCandidates |
+	    Sort-Object -Property @{{ Expression = {{ Convert-ToVersion $_.Version }}; Descending = $true }} |
+	    Select-Object -First 1
+	  if ($null -eq $depPkg) {{
+	    $missing += "$name not installed"
+	    continue
+	  }}
+	  $minText = [string]$d.MinVersion
+	  $min = Convert-ToVersion $minText
+	  $installedVersion = Convert-ToVersion $depPkg.Version
+	  if ($null -ne $min -and $null -ne $installedVersion -and $installedVersion -lt $min) {{
+	    $missing += "$name >= $minText required (installed $($depPkg.Version))"
+	  }}
+	}}
+	[pscustomobject]@{{
+	  missing = ($missing -join ', ')
+	}} | ConvertTo-Json -Compress
+	"#,
+        deps = deps_literal,
+        package_arch = package_arch_literal,
     );
 
     let parsed = run_powershell_json(&script)
@@ -354,32 +453,56 @@ pub fn precheck_msix_dependencies(_path: &Path) -> MsixDependencyPrecheck {
 pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
     let script = format!(
         r#"
-$ErrorActionPreference = 'Stop'
-try {{
-  $packages = Get-AppxPackage -Name {name} -ErrorAction SilentlyContinue
-  if (-not $packages) {{
-    [pscustomobject]@{{
-      success = $true
-      message = 'MSIX package was not installed'
-      rawError = $null
-    }} | ConvertTo-Json -Compress
-    exit 0
-  }}
-  foreach ($p in $packages) {{
-    Remove-AppxPackage -Package $p.PackageFullName -ErrorAction Stop
-  }}
-  [pscustomobject]@{{
-    success = $true
-    message = 'Remove-AppxPackage succeeded'
-    rawError = $null
-  }} | ConvertTo-Json -Compress
-}} catch {{
-  [pscustomobject]@{{
-    success = $false
-    message = [string]$_.Exception.Message
-    rawError = [string]$_
-  }} | ConvertTo-Json -Compress
-}}
+	$ErrorActionPreference = 'Stop'
+	$notes = @()
+	function Add-ResidualNotes {{
+	  try {{
+	    $allUsers = @(Get-AppxPackage -AllUsers -Name {name} -ErrorAction SilentlyContinue)
+	    if ($allUsers.Count -gt 0) {{
+	      $notes += 'MSIX package still exists for another user or elevated context: ' + (($allUsers | ForEach-Object {{ $_.PackageFullName }}) -join ', ')
+	    }}
+	  }} catch {{
+	    $notes += 'Could not query all-user MSIX registrations: ' + [string]$_.Exception.Message
+	  }}
+	  try {{
+	    $provisioned = @(Get-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue | Where-Object {{ $_.DisplayName -eq {name} }})
+	    if ($provisioned.Count -gt 0) {{
+	      $notes += 'Provisioned MSIX package remains and may be reinstalled for new users; remove it from an elevated shell with Remove-AppxProvisionedPackage if desired.'
+	    }}
+	  }} catch {{
+	    $notes += 'Could not query provisioned MSIX packages: ' + [string]$_.Exception.Message
+	  }}
+	}}
+	try {{
+	  $packages = Get-AppxPackage -Name {name} -ErrorAction SilentlyContinue
+	  if (-not $packages) {{
+	    Add-ResidualNotes
+	    [pscustomobject]@{{
+	      success = $true
+	      message = 'MSIX package was not installed'
+	      rawError = $null
+	      notes = $notes
+	    }} | ConvertTo-Json -Compress
+	    exit 0
+	  }}
+	  foreach ($p in $packages) {{
+	    Remove-AppxPackage -Package $p.PackageFullName -ErrorAction Stop
+	  }}
+	  Add-ResidualNotes
+	  [pscustomobject]@{{
+	    success = $true
+	    message = 'Remove-AppxPackage succeeded'
+	    rawError = $null
+	    notes = $notes
+	  }} | ConvertTo-Json -Compress
+	}} catch {{
+	  [pscustomobject]@{{
+	    success = $false
+	    message = [string]$_.Exception.Message
+	    rawError = [string]$_
+	    notes = $notes
+	  }} | ConvertTo-Json -Compress
+	}}
 "#,
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
     );
@@ -395,6 +518,7 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
         success: false,
         message: "MSIX removal is only available on Windows".to_string(),
         raw_error: None,
+        notes: vec![],
     })
 }
 
@@ -493,20 +617,19 @@ try {{
         .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok());
 
     let Some(value) = parsed else {
-        // The health probe itself could not run. Don't overturn a successful
-        // Add-AppxPackage on an unverifiable signal — keep the MSIX install.
-        // The keep-MSIX decision (healthy = true) is intentional, but mark the
-        // report unverified so callers don't mistake it for an observed clean
-        // bill of health.
+        // The health probe itself could not run. On managed/stripped Windows this
+        // is exactly the situation where an MSIX can register but fail to launch,
+        // so treat the verdict as degraded and let the caller fall back to the
+        // portable build instead of silently keeping an unverifiable package.
         return MsixHealthReport {
-            healthy: true,
+            healthy: false,
             verified: false,
             package_registered: true,
             status: "probe-failed".to_string(),
-            status_ok: true,
-            aumid_resolved: true,
+            status_ok: false,
+            aumid_resolved: false,
             missing_dependencies: vec![],
-            reason: "health probe could not run; keeping the MSIX install".to_string(),
+            reason: "health probe could not run; routed to portable fallback".to_string(),
         };
     };
 

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -454,23 +454,23 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
     let script = format!(
         r#"
 	$ErrorActionPreference = 'Stop'
-	$notes = @()
+	$script:notes = @()
 	function Add-ResidualNotes {{
 	  try {{
 	    $allUsers = @(Get-AppxPackage -AllUsers -Name {name} -ErrorAction SilentlyContinue)
 	    if ($allUsers.Count -gt 0) {{
-	      $notes += 'MSIX package still exists for another user or elevated context: ' + (($allUsers | ForEach-Object {{ $_.PackageFullName }}) -join ', ')
+	      $script:notes += 'MSIX package still exists for another user or elevated context: ' + (($allUsers | ForEach-Object {{ $_.PackageFullName }}) -join ', ')
 	    }}
 	  }} catch {{
-	    $notes += 'Could not query all-user MSIX registrations: ' + [string]$_.Exception.Message
+	    $script:notes += 'Could not query all-user MSIX registrations: ' + [string]$_.Exception.Message
 	  }}
 	  try {{
 	    $provisioned = @(Get-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue | Where-Object {{ $_.DisplayName -eq {name} }})
 	    if ($provisioned.Count -gt 0) {{
-	      $notes += 'Provisioned MSIX package remains and may be reinstalled for new users; remove it from an elevated shell with Remove-AppxProvisionedPackage if desired.'
+	      $script:notes += 'Provisioned MSIX package remains and may be reinstalled for new users; remove it from an elevated shell with Remove-AppxProvisionedPackage if desired.'
 	    }}
 	  }} catch {{
-	    $notes += 'Could not query provisioned MSIX packages: ' + [string]$_.Exception.Message
+	    $script:notes += 'Could not query provisioned MSIX packages: ' + [string]$_.Exception.Message
 	  }}
 	}}
 	try {{
@@ -481,7 +481,7 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
 	      success = $true
 	      message = 'MSIX package was not installed'
 	      rawError = $null
-	      notes = $notes
+	      notes = $script:notes
 	    }} | ConvertTo-Json -Compress
 	    exit 0
 	  }}
@@ -493,14 +493,14 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
 	    success = $true
 	    message = 'Remove-AppxPackage succeeded'
 	    rawError = $null
-	    notes = $notes
+	    notes = $script:notes
 	  }} | ConvertTo-Json -Compress
 	}} catch {{
 	  [pscustomobject]@{{
 	    success = $false
 	    message = [string]$_.Exception.Message
 	    rawError = [string]$_
-	    notes = $notes
+	    notes = $script:notes
 	  }} | ConvertTo-Json -Compress
 	}}
 "#,

--- a/scripts/sync-mirror.sh
+++ b/scripts/sync-mirror.sh
@@ -98,7 +98,12 @@ if [ -n "${MANAGER_R2_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_R2_ACCESS_KEY_ID:-}" 
   upload_all "$MANAGER_R2_S3_ENDPOINT" "${MANAGER_R2_BUCKET:-codex-app-manager}" "auto" \
     "$MANAGER_R2_ACCESS_KEY_ID" "$MANAGER_R2_SECRET_ACCESS_KEY"
 else
-  echo "::warning::MANAGER_R2_* not set — skipped R2 mirror sync (self-update mirror endpoint will go stale)"
+  if [ "${ALLOW_STALE_MIRROR:-}" = "1" ]; then
+    echo "::warning::MANAGER_R2_* not set — skipped R2 mirror sync because ALLOW_STALE_MIRROR=1"
+  else
+    echo "::error::MANAGER_R2_* not set — refusing stable release with stale self-update mirror (set ALLOW_STALE_MIRROR=1 only for an intentional manual/pre-release bypass)" >&2
+    exit 1
+  fi
 fi
 
 if [ -n "${MANAGER_IHEP_S3_ENDPOINT:-}" ] && [ -n "${MANAGER_IHEP_S3_BUCKET:-}" ] && [ -n "${MANAGER_IHEP_S3_ACCESS_KEY_ID:-}" ] && [ -n "${MANAGER_IHEP_S3_SECRET_ACCESS_KEY:-}" ]; then

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ description = "A cross-platform manager for installing and updating mirrored off
 authors = ["Wangnov"]
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/Wangnov/codex-app-mirror"
+repository = "https://github.com/Wangnov/Codex-App-Manager"
 
 [lib]
 name = "codex_app_manager_lib"
@@ -32,4 +32,4 @@ tauri-plugin-dialog = "2.7.1"
 tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 thiserror = "2.0"
-windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/examples/win_real_smoke.rs
+++ b/src-tauri/examples/win_real_smoke.rs
@@ -5,7 +5,7 @@ use codex_app_manager_lib::adapters::host;
 use codex_app_manager_lib::app::provenance::ProvenanceStore;
 use codex_app_manager_lib::app::win_update::{
     perform_windows_update, plan_windows_update, uninstall_windows_codex, win_adopt,
-    win_install_status, WinInstallStatus,
+    win_install_status, WinInstallStatus, WinPerformAction,
 };
 use codex_app_manager_lib::domain::manifest::MirrorEndpoints;
 use codex_app_manager_lib::domain::settings::AppSettings;
@@ -1129,7 +1129,7 @@ fn run_old_msix_to_latest_msix() -> Result<SmokeReport, String> {
     let upgraded = perform_windows_update(&endpoints, &settings, true)
         .map_err(|e| format!("upgrade old MSIX to latest: {e}"))?;
     step(&mut steps, "upgrade-old-msix-to-latest", &upgraded)?;
-    if upgraded.action != "msix-sideload" {
+    if upgraded.action != WinPerformAction::MsixSideload {
         return Err(format!(
             "expected MSIX sideload upgrade action, got {}",
             upgraded.action

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -204,28 +204,42 @@ fn effective_build(simulated_build: Option<u64>, installed: &Option<InstalledCod
         .unwrap_or(0)
 }
 
+fn installed_from_path_build(path: String, build: u64) -> InstalledCodex {
+    let arch = sys::app_arch(&path).unwrap_or_else(|| std::env::consts::ARCH.to_string());
+    let short_version = sys::read_bundle_short_version(&path).unwrap_or_default();
+    // Bundle mtime -> when this build landed on disk (install / in-place swap).
+    let installed_at = std::fs::metadata(Path::new(&path))
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs());
+    InstalledCodex {
+        path,
+        build,
+        short_version,
+        arch,
+        installed_at,
+    }
+}
+
 fn detect_installed() -> Option<InstalledCodex> {
-    sys::installed_codex_build().map(|(path, build)| {
-        let arch = sys::app_arch(&path).unwrap_or_else(|| std::env::consts::ARCH.to_string());
-        let short_version = sys::read_bundle_short_version(&path).unwrap_or_default();
-        // Bundle mtime → when this build landed on disk (install / in-place swap).
-        let installed_at = std::fs::metadata(Path::new(&path))
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs());
-        InstalledCodex {
-            path,
-            build,
-            short_version,
-            arch,
-            installed_at,
+    sys::installed_codex_build().map(|(path, build)| installed_from_path_build(path, build))
+}
+
+fn detect_managed_installed() -> Option<InstalledCodex> {
+    let store = ProvenanceStore::load();
+    for record in store.managed.iter().rev() {
+        if let Some((path, build)) = sys::installed_codex_build_at_path(&record.path) {
+            if store.is_managed_build(&path, build) {
+                return Some(installed_from_path_build(path, build));
+            }
         }
-    })
+    }
+    detect_installed()
 }
 
 pub fn plan_macos_update(simulated_build: Option<u64>) -> Result<MacUpdateReport, AppError> {
-    let installed = detect_installed();
+    let installed = detect_managed_installed();
     let (appcast_url, xml) = fetch_appcast_for_arch(arch_of(&installed))?;
     let appcast = parse_appcast(&xml).map_err(|e| AppError::Engine(e.to_string()))?;
     let plan = plan_update(&appcast, effective_build(simulated_build, &installed));
@@ -357,7 +371,7 @@ fn download_and_verify(
 }
 
 pub fn stage_macos_update(simulated_build: Option<u64>) -> Result<MacStageReport, AppError> {
-    let installed = detect_installed();
+    let installed = detect_managed_installed();
     let (_, xml) = fetch_appcast_for_arch(arch_of(&installed))?;
     let appcast = parse_appcast(&xml).map_err(|e| AppError::Engine(e.to_string()))?;
     let plan = plan_update(&appcast, effective_build(simulated_build, &installed))
@@ -533,7 +547,7 @@ pub fn perform_macos_update(
     // update against a Codex that is no longer there (deleted / moved between
     // confirm and execute). Route it through StaleExpectation so the UI
     // auto-re-checks (→ none/install) instead of looping on a dead error.
-    let installed = detect_installed().ok_or_else(|| {
+    let installed = detect_managed_installed().ok_or_else(|| {
         AppError::StaleExpectation(
             "未检测到 Codex（可能已被删除或移动）：请重新检查后再试".to_string(),
         )
@@ -653,8 +667,8 @@ pub fn perform_macos_update(
     }
 
     // 6) filesystem health check on the installed root.
-    let healthy = detect_installed()
-        .map(|i| i.build == plan.latest_build)
+    let healthy = sys::installed_codex_build_at_path(&installed.path)
+        .map(|(_, build)| build == plan.latest_build)
         .unwrap_or(false)
         && gate_reconstructed(&install_path).is_ok();
 
@@ -743,7 +757,7 @@ pub struct MacInstallStatus {
 
 /// Classify the installed Codex against our provenance store.
 pub fn mac_install_status() -> MacInstallStatus {
-    let installed = detect_installed();
+    let installed = detect_managed_installed();
     let store = ProvenanceStore::load();
     let status = match &installed {
         None => "none",
@@ -859,7 +873,7 @@ pub fn install_macos(progress: &dyn Fn(DownloadProgress)) -> Result<MacInstallSt
 /// action (we no longer auto-launch after a fresh install).
 pub fn launch_codex() -> Result<(), AppError> {
     let installed =
-        detect_installed().ok_or_else(|| AppError::Engine("没有可打开的 Codex".to_string()))?;
+        detect_managed_installed().ok_or_else(|| AppError::Engine("没有可打开的 Codex".to_string()))?;
     std::process::Command::new("open")
         .arg(&installed.path)
         .spawn()
@@ -881,7 +895,7 @@ pub struct MacUninstallReport {
 /// true by default at the UI: the user's `~/.codex` (sign-in, sessions, config)
 /// survives unless they explicitly opt out. Quits Codex first (never force-kills).
 pub fn uninstall_macos(keep_codex_home: bool) -> Result<MacUninstallReport, AppError> {
-    let installed = detect_installed()
+    let installed = detect_managed_installed()
         .ok_or_else(|| AppError::Engine("no Codex detected to uninstall".to_string()))?;
     let install_path = PathBuf::from(&installed.path);
 

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -575,13 +575,17 @@ pub fn perform_windows_update_with_install_mode(
         ));
     }
 
-    let store = ProvenanceStore::load();
-    let previous_installed = detect_managed_codex(settings, &store)
-        .or_else(|| detect_installed_codex(PathBuf::from(&settings.install_root).as_path()));
     let stage =
         stage_windows_update_with_install_mode(endpoints, settings, install_mode, progress)?;
+    // Staging can take long enough for Codex to self-update, be uninstalled, or
+    // move between the user's confirmation and our destructive work. Re-detect
+    // after staging and use this fresh snapshot for both consent validation and
+    // every close/provenance/install-root decision below.
+    let store = ProvenanceStore::load();
+    let current_installed = detect_managed_codex(settings, &store)
+        .or_else(|| detect_installed_codex(PathBuf::from(&settings.install_root).as_path()));
     if let Some(expected) = &expected {
-        validate_perform_expectation(expected, previous_installed.as_ref(), &stage)?;
+        validate_perform_expectation(expected, current_installed.as_ref(), &stage)?;
     }
     if stage.up_to_date {
         return Ok(WinPerformReport {
@@ -600,8 +604,8 @@ pub fn perform_windows_update_with_install_mode(
     }
 
     if stage.route == "portable-fallback" {
-        close_existing_codex_before_portable_fallback(settings, previous_installed.as_ref())?;
-        return install_portable_after_stage(settings, stage, None, None, previous_installed);
+        close_existing_codex_before_portable_fallback(settings, current_installed.as_ref())?;
+        return install_portable_after_stage(settings, stage, None, None, current_installed);
     }
 
     let staged_path = stage
@@ -623,14 +627,14 @@ pub fn perform_windows_update_with_install_mode(
     let precheck = precheck_msix_dependencies(PathBuf::from(&staged_path).as_path());
     if precheck.should_route_portable() {
         // We're switching to portable, but the running build must be stopped first.
-        close_existing_codex_before_portable_fallback(settings, previous_installed.as_ref())?;
+        close_existing_codex_before_portable_fallback(settings, current_installed.as_ref())?;
         let mut stage = stage;
         stage.notes.push(format!(
             "Skipped MSIX sideload before attempting it: {}. Routed to the portable build, which carries its own runtime and does not need these framework packages.",
             precheck.reason
         ));
         let mut report =
-            install_portable_after_stage(settings, stage, None, None, previous_installed)?;
+            install_portable_after_stage(settings, stage, None, None, current_installed)?;
         report.action = WinPerformAction::PortableFallbackMissingFramework;
         return Ok(report);
     }
@@ -644,9 +648,9 @@ pub fn perform_windows_update_with_install_mode(
     }
     // A managed portable build (possibly under a previous install root) is not
     // stopped by the MSIX sideload below, so close it first — otherwise it keeps
-    // running after we switch the user over to the MSIX package. `previous_installed`
+    // running after we switch the user over to the MSIX package. `current_installed`
     // comes from the provenance-aware detect_managed_codex above.
-    if let Some(previous) = &previous_installed {
+    if let Some(previous) = &current_installed {
         if previous.source == "portable" {
             close_codex_gracefully_for_root(30, PathBuf::from(&previous.path).as_path())
                 .map_err(engine_err)?;
@@ -668,7 +672,7 @@ pub fn perform_windows_update_with_install_mode(
                 stage,
                 Some(sideload),
                 Some(health),
-                previous_installed,
+                current_installed,
             )?;
             match remove_msix_package() {
                 Ok(remove) if remove.success => {
@@ -700,7 +704,7 @@ pub fn perform_windows_update_with_install_mode(
             .or_else(|| win_install_status(settings).installed);
         if let Some(installed) = &installed {
             let mut store = ProvenanceStore::load();
-            if let Some(previous) = &previous_installed {
+            if let Some(previous) = &current_installed {
                 store.remove(&previous.path);
             }
             store.record(
@@ -726,7 +730,7 @@ pub fn perform_windows_update_with_install_mode(
         });
     }
 
-    install_portable_after_stage(settings, stage, Some(sideload), None, previous_installed)
+    install_portable_after_stage(settings, stage, Some(sideload), None, current_installed)
 }
 
 fn install_portable_after_stage(

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -8,7 +8,7 @@
 
 use std::path::PathBuf;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use codex_win_engine::{
     cancel_active_download, close_codex_gracefully_for_root, detect_installed_codex,
@@ -45,6 +45,7 @@ pub struct WinStageReport {
     pub up_to_date: bool,
     pub route: String,
     pub latest_version: String,
+    pub package_moniker: String,
     pub download_size: u64,
     pub staged_path: Option<String>,
     pub sha256: String,
@@ -75,7 +76,7 @@ pub struct WinAutoStageReport {
 #[serde(rename_all = "camelCase")]
 pub struct WinPerformReport {
     pub success: bool,
-    pub action: String,
+    pub action: WinPerformAction,
     pub message: String,
     pub stage: WinStageReport,
     pub sideload: Option<MsixSideloadReport>,
@@ -85,6 +86,45 @@ pub struct WinPerformReport {
     pub fallback_available: bool,
     pub fallback_attempted: bool,
     pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WinPerformAction {
+    None,
+    MsixSideload,
+    PortableFallback,
+    PortableFallbackAfterMsixFailure,
+    PortableFallbackAfterMsixUnhealthy,
+    PortableFallbackMissingFramework,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WinPerformExpectation {
+    pub current_version: Option<String>,
+    pub latest_version: String,
+    pub package_moniker: String,
+    pub route: String,
+}
+
+impl WinPerformAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::MsixSideload => "msix-sideload",
+            Self::PortableFallback => "portable-fallback",
+            Self::PortableFallbackAfterMsixFailure => "portable-fallback-after-msix-failure",
+            Self::PortableFallbackAfterMsixUnhealthy => "portable-fallback-after-msix-unhealthy",
+            Self::PortableFallbackMissingFramework => "portable-fallback-missing-framework",
+        }
+    }
+}
+
+impl std::fmt::Display for WinPerformAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -159,6 +199,58 @@ fn route_label(plan: &WindowsUpdatePlan) -> String {
         codex_win_engine::WinInstallRoute::PortableFallback => "portable-fallback",
     }
     .to_string()
+}
+
+fn validate_perform_expectation(
+    expected: &WinPerformExpectation,
+    previous_installed: Option<&InstalledWindowsCodex>,
+    stage: &WinStageReport,
+) -> Result<(), AppError> {
+    let actual_current = previous_installed.map(|installed| installed.version.as_str());
+    if actual_current != expected.current_version.as_deref() {
+        return Err(AppError::StaleExpectation(format!(
+            "Windows Codex changed before install (expected current {:?}, found {:?}); please re-check and confirm again.",
+            expected.current_version, actual_current
+        )));
+    }
+    if stage.latest_version != expected.latest_version {
+        return Err(AppError::StaleExpectation(format!(
+            "Windows update target changed from {} to {}; please re-check and confirm again.",
+            expected.latest_version, stage.latest_version
+        )));
+    }
+    if stage.package_moniker != expected.package_moniker {
+        return Err(AppError::StaleExpectation(format!(
+            "Windows package changed from {} to {}; please re-check and confirm again.",
+            expected.package_moniker, stage.package_moniker
+        )));
+    }
+    if stage.route != expected.route {
+        return Err(AppError::StaleExpectation(format!(
+            "Windows install route changed from {} to {}; please re-check and confirm again.",
+            expected.route, stage.route
+        )));
+    }
+    Ok(())
+}
+
+fn close_existing_codex_before_portable_fallback(
+    settings: &AppSettings,
+    previous_installed: Option<&InstalledWindowsCodex>,
+) -> Result<(), AppError> {
+    if let Some(installed) = detect_installed_codex(PathBuf::from(&settings.install_root).as_path()) {
+        if installed.source == "msix" {
+            close_codex_gracefully_for_root(30, PathBuf::from(&installed.path).as_path())
+                .map_err(engine_err)?;
+        }
+    }
+    if let Some(previous) = previous_installed {
+        if previous.source == "portable" {
+            close_codex_gracefully_for_root(30, PathBuf::from(&previous.path).as_path())
+                .map_err(engine_err)?;
+        }
+    }
+    Ok(())
 }
 
 /// Detect the installed Codex, preferring a manager-managed PORTABLE build over
@@ -253,6 +345,7 @@ pub fn stage_windows_update_with_install_mode(
             up_to_date: true,
             route,
             latest_version: report.plan.latest_version,
+            package_moniker: report.plan.package_moniker,
             download_size: 0,
             staged_path: None,
             sha256: report.plan.sha256,
@@ -340,6 +433,7 @@ pub fn stage_windows_update_with_install_mode(
         up_to_date: false,
         route,
         latest_version: report.plan.latest_version,
+        package_moniker: report.plan.package_moniker,
         download_size: actual_size,
         staged_path: Some(dest.to_string_lossy().into_owned()),
         sha256: actual_sha,
@@ -464,7 +558,7 @@ pub fn perform_windows_update(
     settings: &AppSettings,
     confirm: bool,
 ) -> Result<WinPerformReport, AppError> {
-    perform_windows_update_with_install_mode(endpoints, settings, confirm, "msix", &no_progress)
+    perform_windows_update_with_install_mode(endpoints, settings, confirm, "msix", None, &no_progress)
 }
 
 pub fn perform_windows_update_with_install_mode(
@@ -472,6 +566,7 @@ pub fn perform_windows_update_with_install_mode(
     settings: &AppSettings,
     confirm: bool,
     install_mode: &str,
+    expected: Option<WinPerformExpectation>,
     progress: &dyn Fn(DownloadProgress),
 ) -> Result<WinPerformReport, AppError> {
     if !confirm {
@@ -485,10 +580,13 @@ pub fn perform_windows_update_with_install_mode(
         .or_else(|| detect_installed_codex(PathBuf::from(&settings.install_root).as_path()));
     let stage =
         stage_windows_update_with_install_mode(endpoints, settings, install_mode, progress)?;
+    if let Some(expected) = &expected {
+        validate_perform_expectation(expected, previous_installed.as_ref(), &stage)?;
+    }
     if stage.up_to_date {
         return Ok(WinPerformReport {
             success: true,
-            action: "none".to_string(),
+            action: WinPerformAction::None,
             message: "Windows Codex is already current.".to_string(),
             installed: win_install_status(settings).installed,
             sideload: None,
@@ -502,6 +600,7 @@ pub fn perform_windows_update_with_install_mode(
     }
 
     if stage.route == "portable-fallback" {
+        close_existing_codex_before_portable_fallback(settings, previous_installed.as_ref())?;
         return install_portable_after_stage(settings, stage, None, None, previous_installed);
     }
 
@@ -523,27 +622,8 @@ pub fn perform_windows_update_with_install_mode(
     // the post-install health check + transparent fallback remain the backstop.
     let precheck = precheck_msix_dependencies(PathBuf::from(&staged_path).as_path());
     if precheck.should_route_portable() {
-        // We're switching to portable, but the running build must be stopped
-        // first — `install_portable_after_stage` overwrites the portable install
-        // in place and does NOT stop a running instance. Close BOTH a still-present
-        // MSIX install (we're skipping the sideload that would otherwise replace it)
-        // and any managed portable build, exactly like the sideload path below —
-        // otherwise the old MSIX Codex keeps running and the user ends up on the
-        // stale build or with two instances side by side.
-        if let Some(installed) =
-            detect_installed_codex(PathBuf::from(&settings.install_root).as_path())
-        {
-            if installed.source == "msix" {
-                close_codex_gracefully_for_root(30, PathBuf::from(&installed.path).as_path())
-                    .map_err(engine_err)?;
-            }
-        }
-        if let Some(previous) = &previous_installed {
-            if previous.source == "portable" {
-                close_codex_gracefully_for_root(30, PathBuf::from(&previous.path).as_path())
-                    .map_err(engine_err)?;
-            }
-        }
+        // We're switching to portable, but the running build must be stopped first.
+        close_existing_codex_before_portable_fallback(settings, previous_installed.as_ref())?;
         let mut stage = stage;
         stage.notes.push(format!(
             "Skipped MSIX sideload before attempting it: {}. Routed to the portable build, which carries its own runtime and does not need these framework packages.",
@@ -551,7 +631,7 @@ pub fn perform_windows_update_with_install_mode(
         ));
         let mut report =
             install_portable_after_stage(settings, stage, None, None, previous_installed)?;
-        report.action = "portable-fallback-missing-framework".to_string();
+        report.action = WinPerformAction::PortableFallbackMissingFramework;
         return Ok(report);
     }
 
@@ -596,12 +676,14 @@ pub fn perform_windows_update_with_install_mode(
                         "Unhealthy MSIX package was removed after portable fallback succeeded."
                             .to_string(),
                     );
+                    report.notes.extend(remove.notes);
                 }
                 Ok(remove) => {
                     report.notes.push(format!(
                         "Portable fallback succeeded, but removing the unhealthy MSIX package failed: {}",
                         remove.message
                     ));
+                    report.notes.extend(remove.notes);
                 }
                 Err(err) => {
                     report.notes.push(format!(
@@ -631,7 +713,7 @@ pub fn perform_windows_update_with_install_mode(
 
         return Ok(WinPerformReport {
             success: true,
-            action: "msix-sideload".to_string(),
+            action: WinPerformAction::MsixSideload,
             message: sideload.message.clone(),
             installed,
             sideload: Some(sideload),
@@ -706,13 +788,12 @@ fn install_portable_after_stage(
     notes.extend(portable.notes.clone());
 
     let action = if msix_unhealthy {
-        "portable-fallback-after-msix-unhealthy"
+        WinPerformAction::PortableFallbackAfterMsixUnhealthy
     } else if sideload.is_some() {
-        "portable-fallback-after-msix-failure"
+        WinPerformAction::PortableFallbackAfterMsixFailure
     } else {
-        "portable-fallback"
-    }
-    .to_string();
+        WinPerformAction::PortableFallback
+    };
 
     Ok(WinPerformReport {
         success: true,
@@ -823,6 +904,7 @@ pub fn uninstall_windows_codex(
         if msix.success {
             store.remove(&installed_before.path);
             store.save()?;
+            notes.extend(msix.notes.clone());
             // Honor the user's "don't keep my data" choice on the MSIX path too,
             // exactly like the portable path — remove ~/.codex when asked.
             if purge_user_data {
@@ -865,4 +947,34 @@ pub fn uninstall_windows_codex(
         notes: portable.notes.clone(),
         portable: Some(portable),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WinPerformAction;
+
+    #[test]
+    fn serializes_win_perform_actions_as_frontend_contract() {
+        let cases = [
+            (WinPerformAction::None, "\"none\""),
+            (WinPerformAction::MsixSideload, "\"msix-sideload\""),
+            (WinPerformAction::PortableFallback, "\"portable-fallback\""),
+            (
+                WinPerformAction::PortableFallbackAfterMsixFailure,
+                "\"portable-fallback-after-msix-failure\"",
+            ),
+            (
+                WinPerformAction::PortableFallbackAfterMsixUnhealthy,
+                "\"portable-fallback-after-msix-unhealthy\"",
+            ),
+            (
+                WinPerformAction::PortableFallbackMissingFramework,
+                "\"portable-fallback-missing-framework\"",
+            ),
+        ];
+
+        for (action, expected) in cases {
+            assert_eq!(serde_json::to_string(&action).unwrap(), expected);
+        }
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -669,7 +669,7 @@ fn open_external_url(url: &str) -> Result<(), String> {
 fn open_external_url(url: &str) -> Result<(), String> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
-    use std::ptr::null;
+    use std::ptr::{null, null_mut};
     use windows_sys::Win32::UI::Shell::ShellExecuteW;
     use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
@@ -677,7 +677,7 @@ fn open_external_url(url: &str) -> Result<(), String> {
     let target: Vec<u16> = OsStr::new(url).encode_wide().chain([0]).collect();
     let result = unsafe {
         ShellExecuteW(
-            0,
+            null_mut(),
             operation.as_ptr(),
             target.as_ptr(),
             null(),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -16,7 +16,7 @@ use crate::app::win_update::{
     stage_windows_update_with_install_mode, uninstall_windows_codex,
     win_adopt as adopt_windows_install, win_install_status,
     DownloadProgress as WinDownloadProgress, WinAutoStageReport, WinInstallStatus,
-    WinPerformReport, WinStageReport, WinUninstallReport, WinUpdateReport,
+    WinPerformExpectation, WinPerformReport, WinStageReport, WinUninstallReport, WinUpdateReport,
 };
 use crate::domain::settings::AppSettings as DomainAppSettings;
 use crate::domain::target::OperatingSystem;
@@ -46,7 +46,8 @@ fn normalize_windows_source_base(raw: &str) -> Option<String> {
 fn windows_endpoints_for_settings(
     state: &ManagerState,
 ) -> Result<crate::domain::manifest::MirrorEndpoints, AppError> {
-    let saved = PersistedAppSettings::load();
+    let mut saved = PersistedAppSettings::load();
+    normalize_settings_for_target(&mut saved, &state.target);
     match saved.source.as_str() {
         "custom" => {
             let base = normalize_windows_source_base(&saved.custom_url)
@@ -61,6 +62,12 @@ fn windows_endpoints_for_settings(
         // official source exposes the same contract.
         "auto" | "mirror" => Ok(state.endpoints.clone()),
         _ => Ok(state.endpoints.clone()),
+    }
+}
+
+fn normalize_settings_for_target(settings: &mut PersistedAppSettings, target: &crate::domain::target::Target) {
+    if matches!(target.os, OperatingSystem::Windows) && settings.source == "official" {
+        settings.source = "auto".to_string();
     }
 }
 
@@ -440,15 +447,21 @@ pub async fn win_stage_update(
 
 /// Read persisted app settings (update source + general).
 #[tauri::command]
-pub fn get_settings() -> Result<PersistedAppSettings, CommandError> {
-    Ok(PersistedAppSettings::load())
+pub fn get_settings(state: State<'_, ManagerState>) -> Result<PersistedAppSettings, CommandError> {
+    let mut settings = PersistedAppSettings::load();
+    normalize_settings_for_target(&mut settings, &state.target);
+    Ok(settings)
 }
 
 /// Persist app settings. `signed_only` is forced on regardless of input.
 #[tauri::command]
-pub fn set_settings(settings: PersistedAppSettings) -> Result<PersistedAppSettings, CommandError> {
+pub fn set_settings(
+    state: State<'_, ManagerState>,
+    settings: PersistedAppSettings,
+) -> Result<PersistedAppSettings, CommandError> {
     let mut s = settings;
     s.normalize();
+    normalize_settings_for_target(&mut s, &state.target);
     s.save()?;
     Ok(s)
 }
@@ -615,26 +628,100 @@ pub fn set_autostart(app: tauri::AppHandle, enabled: bool) -> Result<(), Command
 /// http(s) so it can't be coerced into launching arbitrary local handlers.
 #[tauri::command]
 pub fn open_url(url: String) -> Result<(), CommandError> {
-    if !(url.starts_with("https://") || url.starts_with("http://")) {
-        return Err(AppError::Internal("仅支持 http(s) 链接".to_string()).into());
-    }
-    #[cfg(target_os = "macos")]
-    let spawned = std::process::Command::new("open").arg(&url).spawn();
-    #[cfg(target_os = "windows")]
-    let spawned = {
-        use std::os::windows::process::CommandExt;
+    validate_external_http_url(&url)?;
+    open_external_url(&url).map_err(|e| AppError::Internal(format!("打开链接失败: {e}")).into())
+}
 
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        std::process::Command::new("cmd")
-            .args(["/C", "start", "", url.as_str()])
-            .creation_flags(CREATE_NO_WINDOW)
-            .spawn()
+fn validate_external_http_url(url: &str) -> Result<(), AppError> {
+    if url
+        .chars()
+        .any(|ch| ch.is_control() || ch.is_whitespace() || ch == '\\')
+    {
+        return Err(AppError::Internal("链接包含非法字符".to_string()));
+    }
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return Err(AppError::Internal("仅支持 http(s) 链接".to_string()));
     };
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    let spawned = std::process::Command::new("xdg-open").arg(&url).spawn();
-    spawned
+    if !(scheme.eq_ignore_ascii_case("https") || scheme.eq_ignore_ascii_case("http")) {
+        return Err(AppError::Internal("仅支持 http(s) 链接".to_string()));
+    }
+    let host = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim_matches('.');
+    if host.is_empty() || host.contains('@') {
+        return Err(AppError::Internal("链接缺少有效主机名".to_string()));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn open_external_url(url: &str) -> Result<(), String> {
+    std::process::Command::new("open")
+        .arg(url)
+        .spawn()
         .map(|_| ())
-        .map_err(|e| AppError::Internal(format!("打开链接失败: {e}")).into())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn open_external_url(url: &str) -> Result<(), String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr::null;
+    use windows_sys::Win32::UI::Shell::ShellExecuteW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    let operation: Vec<u16> = OsStr::new("open").encode_wide().chain([0]).collect();
+    let target: Vec<u16> = OsStr::new(url).encode_wide().chain([0]).collect();
+    let result = unsafe {
+        ShellExecuteW(
+            0,
+            operation.as_ptr(),
+            target.as_ptr(),
+            null(),
+            null(),
+            SW_SHOWNORMAL,
+        )
+    } as isize;
+    if result <= 32 {
+        Err(format!("ShellExecuteW failed with code {result}"))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn open_external_url(url: &str) -> Result<(), String> {
+    std::process::Command::new("xdg-open")
+        .arg(url)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod open_url_tests {
+    use super::validate_external_http_url;
+
+    #[test]
+    fn accepts_http_urls_with_query_delimiters() {
+        assert!(validate_external_http_url("https://example.com/a?x=1&y=2").is_ok());
+    }
+
+    #[test]
+    fn rejects_non_http_and_shell_sensitive_url_shapes() {
+        for url in [
+            "file:///C:/Windows/notepad.exe",
+            "https://example.com/a b",
+            "https://example.com\\evil",
+            "https://user@example.com/",
+            "https://",
+        ] {
+            assert!(validate_external_http_url(url).is_err(), "{url} should be rejected");
+        }
+    }
 }
 
 /// Windows-only: classify the installed Codex (managed / external / none).
@@ -676,6 +763,7 @@ pub async fn win_perform_update(
     state: State<'_, ManagerState>,
     confirm: bool,
     install_root: Option<String>,
+    expected: Option<WinPerformExpectation>,
 ) -> Result<WinPerformReport, CommandError> {
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
@@ -704,6 +792,7 @@ pub async fn win_perform_update(
             &settings,
             confirm,
             &install_mode,
+            expected,
             &report,
         )
     })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://codexapp.agentsmirror.com https://github.com https://persistent.oaistatic.com"
+      "csp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://codexapp.agentsmirror.com https://github.com https://persistent.oaistatic.com"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://codexapp.agentsmirror.com https://github.com https://persistent.oaistatic.com"
     }
   },
   "bundle": {

--- a/src/app/views/Settings.tsx
+++ b/src/app/views/Settings.tsx
@@ -107,6 +107,7 @@ export function Settings({
   const portableDescKey: TKey = installRootIsDefault
     ? "settings.windows.portableDescDefault"
     : "settings.windows.portableDescCustom";
+  const availableSources = SOURCES.filter((src) => !(win && src.kind === "official"));
 
   return (
     <div className="pop">
@@ -123,7 +124,7 @@ export function Settings({
         <div className="group">
           <div className="group-h">{t("settings.source.header")}</div>
           <div className="list">
-            {SOURCES.map((src) => (
+            {availableSources.map((src) => (
               <button
                 key={src.kind}
                 className="row"

--- a/src/app/views/Uninstall.tsx
+++ b/src/app/views/Uninstall.tsx
@@ -33,10 +33,21 @@ export function Uninstall({ onBack }: { onBack: () => void }) {
     try {
       // mac keeps ~/.codex via keepCodexHome; win purges via purgeUserData (the
       // inverse) — both surface the backend message as the source of truth.
-      const r = win
-        ? await managerApi.winUninstall(true, !keepData)
-        : await managerApi.macUninstall(keepData);
-      setDone(r.message);
+      if (win) {
+        const r = await managerApi.winUninstall(true, !keepData);
+        if (!r.success) {
+          setError(r.message);
+          return;
+        }
+        setDone(r.message);
+      } else {
+        const r = await managerApi.macUninstall(keepData);
+        if (!r.removed) {
+          setError(r.message);
+          return;
+        }
+        setDone(r.message);
+      }
     } catch (cause) {
       setError(errorMessage(cause));
     } finally {

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 
-import { errorMessage, managerApi } from "../../services/managerApi";
+import { errorCode, errorMessage, managerApi } from "../../services/managerApi";
 import type {
   AppSettings,
   DownloadProgress,
@@ -39,6 +39,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [defaultInstallRoot, setDefaultInstallRoot] = useState(DEFAULT_SETTINGS.installRoot);
   const [busy, setBusy] = useState<"plan" | "perform" | "adopt" | "install" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [installDirOpen, setInstallDirOpen] = useState(false);
   const [installDirBusy, setInstallDirBusy] = useState(false);
@@ -81,11 +82,14 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const check = useCallback(async () => {
     setBusy("plan");
     setError(null);
+    setNotice(null);
     try {
       setReport(await managerApi.winPlanUpdate());
+      return true;
     } catch (cause) {
       setReport(null);
       setError(errorMessage(cause));
+      return false;
     } finally {
       setBusy(null);
     }
@@ -117,6 +121,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const adopt = useCallback(async () => {
     setBusy("adopt");
     setError(null);
+    setNotice(null);
     try {
       setStatus(await managerApi.winAdopt());
     } catch (cause) {
@@ -149,6 +154,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     async (mode: "perform" | "install", installRoot?: string) => {
       setBusy(mode);
       setError(null);
+      setNotice(null);
       // For an in-place update (not a fresh install) capture the human-facing
       // versions before the swap, so the outcome strip can show "X → Y".
       // Prefer the report (one atomic snapshot of installed + plan) so the
@@ -158,7 +164,15 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       const toVersion = report?.plan?.latestVersion ?? "";
       const unlisten = await startDlListen();
       try {
-        const result = await managerApi.winPerformUpdate(true, installRoot);
+        const expected = report?.plan
+          ? {
+              currentVersion: report.plan.currentVersion,
+              latestVersion: report.plan.latestVersion,
+              packageMoniker: report.plan.packageMoniker,
+              route: report.plan.route,
+            }
+          : undefined;
+        const result = await managerApi.winPerformUpdate(true, expected, installRoot);
         setPerform(result);
         setUpdatedVer(
           mode === "perform" && fromVersion && toVersion
@@ -170,16 +184,22 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
         await refreshStatus();
         await check();
       } catch (cause) {
-        setError(errorMessage(cause));
         setConfirmOpen(false);
         setInstallDirOpen(false);
+        if (errorCode(cause) === "stale_expectation") {
+          if (await check()) {
+            setNotice(t("home.stale.rechecked"));
+          }
+        } else {
+          setError(errorMessage(cause));
+        }
       } finally {
         unlisten();
         setBusy(null);
         setDl(null);
       }
     },
-    [status, report, refreshStatus, check, startDlListen],
+    [status, report, refreshStatus, check, startDlListen, t],
   );
 
   const freshInstallNeedsLocation = useCallback(async () => {
@@ -371,6 +391,12 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
               setUpdatedVer(null);
             }}
           />
+        ) : null}
+        {notice ? (
+          <div className="banner info">
+            <Icon name="info" />
+            <span>{notice}</span>
+          </div>
         ) : null}
         {error ? (
           <div className="banner err">

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -187,6 +187,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
         setConfirmOpen(false);
         setInstallDirOpen(false);
         if (errorCode(cause) === "stale_expectation") {
+          await refreshStatus();
           if (await check()) {
             setNotice(t("home.stale.rechecked"));
           }
@@ -261,8 +262,11 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   }, [runPerform]);
 
   const plan = report?.plan ?? null;
-  const installed = status?.installed ?? report?.installed ?? null;
-  const isManaged = status?.status === "managed";
+  const installed = report?.installed ?? status?.installed ?? null;
+  const statusMatchesInstalled = Boolean(
+    installed && status?.installed && samePath(installed.path, status.installed.path),
+  );
+  const isManaged = statusMatchesInstalled && status?.status === "managed";
   const updateAvailable = Boolean(plan) && !plan?.upToDate;
   const routeNote =
     plan?.route === "portable-fallback" ? t("win.route.portable") : t("win.route.msix");
@@ -281,13 +285,23 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       return "none";
     }
     if (!statusLoaded) return "loading";
-    if (status?.status === "external") return "external";
+    if (statusMatchesInstalled && status?.status === "external") return "external";
     if (busy === "plan" && !report) return "loading";
     if (error && !report) return "error";
     if (!report) return "idle";
     if (updateAvailable) return "update";
     return "uptodate";
-  }, [busy, report, error, installed, updateAvailable, status, statusLoaded, statusFailed]);
+  }, [
+    busy,
+    report,
+    error,
+    installed,
+    updateAvailable,
+    status,
+    statusMatchesInstalled,
+    statusLoaded,
+    statusFailed,
+  ]);
 
   const version = installed?.version || plan?.latestVersion || "";
   const sourceLabel = t(`source.${settings.source}` as TKey);

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -262,9 +262,12 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   }, [runPerform]);
 
   const plan = report?.plan ?? null;
-  const installed = report?.installed ?? status?.installed ?? null;
+  const installed = report ? report.installed : status?.installed ?? null;
   const statusMatchesInstalled = Boolean(
-    installed && status?.installed && samePath(installed.path, status.installed.path),
+    installed &&
+      status?.installed &&
+      samePath(installed.path, status.installed.path) &&
+      installed.version === status.installed.version,
   );
   const isManaged = statusMatchesInstalled && status?.status === "managed";
   const updateAvailable = Boolean(plan) && !plan?.upToDate;

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -159,6 +159,7 @@ const WIN_FALLBACK_STAGE: WinStageReport = {
   upToDate: false,
   route: "msix-sideload",
   latestVersion: "26.602.3474.0",
+  packageMoniker: "OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0",
   downloadSize: 566504666,
   stagedPath: "(browser-dev mock) …/OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.msix",
   sha256: "6dc2e05ac2b760bbc77ce3f8a992efdb327363512c9c4744b9a146c41bc4d55a",
@@ -224,6 +225,7 @@ const WIN_FALLBACK_UNINSTALL: WinUninstallReport = {
   msix: null,
   portable: {
     success: true,
+    partial: false,
     installRoot: "%LOCALAPPDATA%\\Programs\\Codex",
     removedFiles: true,
     removedShortcut: true,
@@ -435,7 +437,16 @@ export const managerApi = {
     }
     return invoke<WinUpdateReport>("win_plan_update");
   },
-  winPerformUpdate(confirm: boolean, installRoot?: string): Promise<WinPerformReport> {
+  winPerformUpdate(
+    confirm: boolean,
+    expected?: {
+      currentVersion: string | null;
+      latestVersion: string;
+      packageMoniker: string;
+      route: string;
+    },
+    installRoot?: string,
+  ): Promise<WinPerformReport> {
     if (!hasTauriRuntime()) {
       return confirm
         ? Promise.resolve(WIN_FALLBACK_PERFORM)
@@ -444,6 +455,7 @@ export const managerApi = {
     return invoke<WinPerformReport>("win_perform_update", {
       confirm,
       installRoot: installRoot ?? null,
+      expected: expected ?? null,
     });
   },
   winUninstall(confirm: boolean, purgeUserData: boolean): Promise<WinUninstallReport> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -213,6 +213,7 @@ export interface WinStageReport {
   upToDate: boolean;
   route: WinInstallRoute;
   latestVersion: string;
+  packageMoniker: string;
   downloadSize: number;
   stagedPath: string | null;
   sha256: string;
@@ -262,13 +263,16 @@ export interface MsixHealthReport {
  *   - "portable-fallback-after-msix-failure"   — sideload failed, fell back.
  *   - "portable-fallback-after-msix-unhealthy" — sideload registered but the
  *                                                package failed its health check.
+ *   - "portable-fallback-missing-framework"    — staged MSIX declared framework
+ *                                                dependencies absent locally.
  */
 export type WinPerformAction =
   | "none"
   | "msix-sideload"
   | "portable-fallback"
   | "portable-fallback-after-msix-failure"
-  | "portable-fallback-after-msix-unhealthy";
+  | "portable-fallback-after-msix-unhealthy"
+  | "portable-fallback-missing-framework";
 
 export interface WinPerformReport {
   success: boolean;
@@ -301,10 +305,12 @@ export interface MsixRemoveReport {
   success: boolean;
   message: string;
   rawError: string | null;
+  notes: string[];
 }
 
 export interface PortableUninstallReport {
   success: boolean;
+  partial: boolean;
   installRoot: string;
   removedFiles: boolean;
   removedShortcut: boolean;


### PR DESCRIPTION
## Summary
- Guard Windows perform installs with a confirmed plan snapshot and re-check stale confirmations before destructive work.
- Harden Windows install/uninstall lifecycle diagnostics: MSIX dependency version/publisher/arch checks, probe-failure fallback, portable cleanup warnings, and residual MSIX notes.
- Replace Windows URL opening via shell with validated system API launch, tighten CSP, normalize unsupported Windows official source settings, and harden release/mirror sync gates.
- Make macOS managed install detection path-aware so a system install cannot mask the app-managed target.

## Validation
- npm run check
- npm run test --if-present
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml --workspace
- cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml --workspace --no-run
- cargo test --manifest-path crates/codex-win-engine/Cargo.toml
- cargo test --manifest-path crates/codex-mac-engine/Cargo.toml
- npm audit --audit-level=moderate
- bash -n scripts/sync-mirror.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release yaml ok"'
- git diff --check