### PR TITLE
docs(release): bilingual release-notes pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,20 @@ jobs:
           bash scripts/sync-mirror.sh dist
           rm -f dist/latest.mirror.json
 
+      # ── release notes: the hand-written file from the version-bump PR
+      #    (docs/releases/<tag>.md, see docs/releases/TEMPLATE.md) wins;
+      #    otherwise the minimal install table keeps the body from ever being
+      #    empty. GitHub's auto "What's Changed" section is appended either way.
+      - name: Prepare release notes
+        run: |
+          NOTES="docs/releases/${{ github.ref_name }}.md"
+          if [ -f "$NOTES" ]; then
+            cp "$NOTES" "$RUNNER_TEMP/release-notes.md"
+          else
+            echo "::warning::$NOTES not found — publishing with fallback notes"
+            cp docs/releases/FALLBACK.md "$RUNNER_TEMP/release-notes.md"
+          fi
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -243,6 +257,8 @@ jobs:
           # pointing at it — keep resolving to the last stable build instead of
           # serving a release-candidate to real users.
           prerelease: ${{ contains(github.ref_name, '-') }}
+          body_path: ${{ runner.temp }}/release-notes.md
+          generate_release_notes: true
           files: |
             dist/*
             latest.json

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,12 @@
 # Release & code-signing
 
+## Release notes
+
+每个版本的 release note 写在 `docs/releases/v<X.Y.Z>.md`,随版本号 bump 一起进发版 PR;
+tag 推送后 `release.yml` 按 tag 名取用该文件作为 GitHub Release 正文,并自动追加
+"What's Changed" 与 Full Changelog。文件缺失时回退到 `docs/releases/FALLBACK.md`
+(安装表 + 升级说明),正文永远不会为空。写法与双语风格见 `docs/releases/TEMPLATE.md`。
+
 Cross-platform release is tag-driven via [`.github/workflows/release.yml`](../.github/workflows/release.yml).
 Push a `v*` tag and CI builds, signs, notarizes, and publishes a GitHub Release
 with the Tauri updater manifest.

--- a/docs/releases/FALLBACK.md
+++ b/docs/releases/FALLBACK.md
@@ -1,0 +1,24 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+  Release-notes template. Copy to docs/releases/v<X.Y.Z>.md inside the
+  version-bump PR; release.yml picks it up by tag name when the tag is pushed
+  (and appends GitHub's auto-generated "What's Changed" + Full Changelog).
+  If the file is missing the workflow falls back to a minimal install table,
+  so a release is never published with an empty body.
+
+  Style (融合 Deck 的双语成对行 + 我们自己的分发重点):
+  - zh 在前,en 紧随成对出现;不堆营销词,写用户可感知的变化。
+  - 要点 3-6 条;patch 版可以只有「修复」一组。
+  - 不要写未核实的渠道/数字;镜像直链恒指向最新版,历史版本读者请用页面下方 Assets。
+-->
+
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 一句话概括这一版(zh)。
+> One line on what this release does (en).
+
+## ✨ 亮点 · Highlights
+
+- **要点标题**:中文说明,落在用户可感知的行为变化上。
+  English counterpart, written natively — not a translation artifact.
+
+## 🐛 修复 · Fixes
+
+- **修了什么**:之前的症状 → 现在的行为。
+  What was broken → what happens now.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/docs/releases/v0.1.13.md
+++ b/docs/releases/v0.1.13.md
@@ -1,0 +1,41 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> macOS 增量更新从这一版起真正生效:BinaryDelta 助手随包出厂,更新卡片改由单一原子快照驱动,镜像 `/manager/latest/*` 永久直链上线。
+> Delta updates on macOS actually work starting this release: the BinaryDelta helper now ships in the bundle, the update card is driven by one atomic snapshot, and the mirror's `/manager/latest/*` permalinks go live.
+
+## ✨ 亮点 · Highlights
+
+- **macOS 增量更新真正可用**(#43):BinaryDelta 助手现在随 macOS 包出厂。此前的 0.1.x 版本缺少它,每次更新都会静默回退整包下载——从这一版起,更新只下载版本之间的差量。
+  The BinaryDelta helper finally ships inside the macOS bundle. Earlier 0.1.x builds silently fell back to full-package downloads; from this release on, updates pull only the delta between versions.
+- **镜像永久直链上线**(#42):`/manager/latest/*` 恒指向当前最新版本,README 与官网的下载链接从此永不过期。
+  `/manager/latest/*` permalinks always resolve to the current release, so download links in the README and on the website never go stale.
+
+## 🐛 修复 · Fixes
+
+- **更新卡片与确认弹窗共用一份原子快照**(#45):杜绝"当前 X → 新版 X"这类自相矛盾的卡片,确认时看到的就是将要执行的。
+  The update card and the consent sheet are driven by one atomic snapshot — no more self-contradictory "now X → new X" cards; what you confirm is what runs.
+- **不再卡在 Codex 的退出确认上**(#44):更新需要退出 Codex 时,把它的退出确认弹窗浮到前台,而不是让更新停在原地。
+  When an update needs Codex to quit, its quit-confirm dialog is surfaced instead of the update silently stalling.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/docs/releases/v0.1.14.md
+++ b/docs/releases/v0.1.14.md
@@ -1,0 +1,40 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 一版纯加固:Windows 更新全生命周期防竞态、MSIX 健康探针降级回退,发布流水线把镜像同步提为发布前置——应用内更新源永远不会落后于公开 Release。
+> A pure hardening release: the Windows update lifecycle is now race-safe with MSIX health-probe fallback, and the release pipeline gates publication on the mirror sync — the in-app update feed can never lag a public release.
+
+## 🛡️ 加固 · Hardening
+
+- **Windows 更新不再信任过期快照**:下载与暂存期间,Codex 可能自更新、被卸载或被移动。现在执行前会重新检测本机状态,确认校验与每一步破坏性操作都基于最新快照进行。
+  The Windows updater re-detects the local install after staging — consent checks and every destructive step run against a fresh snapshot, not the one from before the download.
+- **MSIX 装得上但起不来?自动回退便携版**:在受管/精简的 Windows 上,MSIX 可能注册成功却无法启动。健康探针无法运行时按"降级"处理,自动回退到便携版,而不是留下一个无法验证的安装。
+  On managed or stripped-down Windows an MSIX can register yet fail to launch. When the health probe can't run, the updater degrades gracefully and falls back to the portable build instead of keeping an unverifiable package.
+- **切换便携版前先收尾**:回退便携版之前会先关闭运行中的 Codex,不会因文件占用留下半成品安装。
+  Running Codex is closed before a portable-fallback switch — no half-finished installs from locked files.
+- **下载失败一眼可诊断**:失败信息现在带上目标主机与代理环境摘要,网络问题不再靠猜。
+  Download failures now report the target host and a proxy-environment summary, so network issues are diagnosable at a glance.
+- **发布门禁**:R2 + IHEP 镜像同步成为发布的前置阻塞步骤——同步失败会阻断发版,公开 Release 不再可能领先于应用内更新源。
+  Release gating: the R2 + IHEP mirror sync now blocks publication, so a public release can never run ahead of the in-app update feed.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.


### PR DESCRIPTION
Release 正文此前一直为空。本 PR 建立 release notes 体系:

- `docs/releases/v<X.Y.Z>.md`:随发版 PR 手写的双语 note(模板见 `TEMPLATE.md`,风格:banner 头图 + 一句话主旨 + 双语成对要点 + 安装升级表)
- `release.yml`:发布时按 tag 取用对应文件,缺失时回退 `FALLBACK.md`(安装表),并始终追加 GitHub 自动 What's Changed
- 补写 v0.1.13 / v0.1.14 的正式 note(将同步回填到已发布 Release)
- `docs/release.md` 记录流程