### PR TITLE
chore(release): bump version to 0.1.15

### DIFF
--- a/docs/releases/v0.1.15.md
+++ b/docs/releases/v0.1.15.md
@@ -1,0 +1,43 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版把官网、双语发布说明和检查失败恢复体验补齐:下载入口更清楚,网络失败也不再像坏掉一样吓人。
+> This release adds the official website, bilingual release notes, and a calmer recovery path when update checks fail.
+
+## ✨ 亮点 · Highlights
+
+- **官网上线**:codexapp.agentsmirror.com 现在集中展示下载入口、镜像链路、校验方式和项目边界,不用再从 README 里翻线索。
+  The official website now gathers downloads, the mirror pipeline, verification details, and project scope in one place.
+- **发布页更可读**:发布页面开始使用双语说明、固定安装表和项目首页同款横幅,历史版本也能直接找到对应安装包。
+  Release pages now ship with bilingual notes, a stable install table, and the same banner as the README, so older versions are easier to inspect and download.
+
+## 🐛 修复 · Fixes
+
+- **检查失败不再卡住**:更新服务器连不上时,界面会明确提示检查网络,把原始下载与安全握手细节收进"查看详情",并保留重新检查入口。
+  When the update server cannot be reached, the app now shows a clear connection message, keeps raw curl/TLS details behind "Show details", and leaves retry one click away.
+- **已安装用户仍可启动 Codex**:即使更新检查失败,已安装的 Codex 仍会显示"启动"按钮,不会被失败页挡住。
+  If Codex is already installed, a failed update check still leaves the Launch button available instead of trapping the user on an error state.
+- **操作错误不再被检查错误吞掉**:启动、安装或接管失败会走独立错误提示;成功接管外部安装后,旧的检查失败状态也会清掉。
+  Launch, install, and adoption failures now surface separately from check failures; after a successful adoption, stale check errors are cleared.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.14"
+version = "0.1.15"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Codex App Manager to 0.1.15 across npm, Tauri, and Cargo metadata
- add bilingual release notes for v0.1.15

## Verification
- npm run check
- npm test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- codex review --uncommitted
