### PR TITLE
chore(release): bump version to 0.1.16

### DIFF
--- a/docs/releases/v0.1.16.md
+++ b/docs/releases/v0.1.16.md
@@ -1,0 +1,37 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版让下载更新像个正常的下载器:能暂停、能取消;Windows 启动时检查更新也不再卡住界面。
+> This release makes downloads behave like a real downloader — pause and cancel — and stops the Windows update check from freezing the window.
+
+## ✨ 亮点 · Highlights
+
+- **下载可暂停 / 取消**:下载更新时新增「暂停」和「取消」。暂停会保留已下载的部分,下次更新从断点继续;取消则放弃。两个按钮只在下载阶段可用,进入校验 / 安装这类不可中断的环节后自动禁用,停止后回到更新卡片并给出平和提示,而不是红色报错。
+  Downloads now have **Pause** and **Cancel**. Pause keeps the bytes already fetched so the next update resumes from there; Cancel discards them. Both are offered only while bytes are downloading and disable once the non-interruptible verify / install phase begins — a stopped transfer settles back to the update card with a calm notice, not a red error.
+
+## 🐛 修复 · Fixes
+
+- **Windows 检查更新不再卡住主界面**:之前启动时的检查更新把网络请求和系统能力探测跑在主线程上,窗口会短暂进入"未响应"(动画还在转、却点不动)。现在这部分挪到后台线程执行,检查期间界面全程可操作。macOS 这条路径本就在后台,所以不受影响。
+  On Windows, the on-launch update check no longer freezes the window. The manifest fetch and capability probes used to run on the main thread, leaving the UI briefly unresponsive (the spinner kept turning but nothing was clickable); they now run off the main thread. macOS already worked this way and was never affected.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.15"
+version = "0.1.16"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump Codex App Manager to **0.1.16** across npm, Tauri, and Cargo metadata (6 places, Cargo.lock limited to the `codex-app-manager` block).
- Add bilingual release notes `docs/releases/v0.1.16.md`.

Ships the work merged in [#54](https://github.com/Wangnov/Codex-App-Manager/pull/54): pausable/cancelable downloads + the non-blocking Windows update check.

## Verification
- `npm run build`, `npm test` (14), `cargo check --manifest-path src-tauri/Cargo.toml` (Cargo.lock consistent)
- No `0.1.15` residue; `git diff` is version strings + the new notes file only