### PR TITLE
fix: add a minimize button to the frameless window

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-close",
+    "core:window:allow-minimize",
     "dialog:allow-open",
     "updater:default",
     "process:default"

--- a/src/app/components.tsx
+++ b/src/app/components.tsx
@@ -39,6 +39,24 @@ function CloseButton() {
   );
 }
 
+/** Self-drawn minimize control, sitting left of the close button (the window is
+ *  frameless, so it's self-drawn too). Only meaningful in the desktop app; the
+ *  browser preview has no window to minimize, so it's a no-op there. */
+function MinimizeButton() {
+  const { t } = useI18n();
+  return (
+    <button
+      className="winmin"
+      title={t("nav.minimize")}
+      onClick={() => {
+        if (isTauri()) void getCurrentWindow().minimize();
+      }}
+    >
+      <Icon name="minimize" />
+    </button>
+  );
+}
+
 /** The one close-confirm dialog. Raised by the backend close/exit guard (which
  *  covers the ✕, Alt+F4 and Cmd+Q alike) via app://confirm-quit, or by the
  *  browser-preview fallback. Mounted once at the app root so it overlays
@@ -101,6 +119,7 @@ export function TopBar({ children }: { children?: ReactNode }) {
       </div>
       <div className="spacer" data-tauri-drag-region />
       {children}
+      <MinimizeButton />
       <CloseButton />
     </div>
   );
@@ -129,6 +148,7 @@ export function NavBar({
       </div>
       <div className="spacer" style={{ flex: 1 }} data-tauri-drag-region />
       {children}
+      <MinimizeButton />
       <CloseButton />
     </div>
   );

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -30,6 +30,7 @@ const ZH = {
   "nav.back": "返回",
   "nav.settings": "设置",
   "nav.config": "Codex 配置管理",
+  "nav.minimize": "最小化",
   "nav.close": "关闭",
 
   "home.checking": "正在检查…",
@@ -191,6 +192,7 @@ const EN: Record<Key, string> = {
   "nav.back": "Back",
   "nav.settings": "Settings",
   "nav.config": "Codex configuration",
+  "nav.minimize": "Minimize",
   "nav.close": "Close",
 
   "home.checking": "Checking…",
@@ -349,6 +351,7 @@ const FR: Record<Key, string> = {
   "nav.back": "Retour",
   "nav.settings": "Réglages",
   "nav.config": "Configuration Codex",
+  "nav.minimize": "Réduire",
   "nav.close": "Fermer",
 
   "home.checking": "Vérification…",
@@ -507,6 +510,7 @@ const ZH_TW: Record<Key, string> = {
   "nav.back": "返回",
   "nav.settings": "設定",
   "nav.config": "Codex 設定管理",
+  "nav.minimize": "最小化",
   "nav.close": "關閉",
 
   "home.checking": "檢查中…",
@@ -676,6 +680,7 @@ const DE: Record<Key, string> = {
   "nav.back": "Zurück",
   "nav.settings": "Einstellungen",
   "nav.config": "Codex-Konfiguration",
+  "nav.minimize": "Minimieren",
   "nav.close": "Schließen",
 
   "home.checking": "Wird geprüft…",
@@ -845,6 +850,7 @@ const KO: Record<Key, string> = {
   "nav.back": "뒤로",
   "nav.settings": "설정",
   "nav.config": "Codex 구성 관리",
+  "nav.minimize": "최소화",
   "nav.close": "닫기",
 
   "home.checking": "확인 중…",
@@ -1012,6 +1018,7 @@ const JA: Record<Key, string> = {
   "nav.back": "戻る",
   "nav.settings": "設定",
   "nav.config": "Codex 設定管理",
+  "nav.minimize": "最小化",
   "nav.close": "閉じる",
   "home.checking": "確認中…",
   "home.idle.title": "Codex インストール済み",
@@ -1161,6 +1168,7 @@ const RU: Record<Key, string> = {
   "nav.back": "Назад",
   "nav.settings": "Настройки",
   "nav.config": "Настройки Codex",
+  "nav.minimize": "Свернуть",
   "nav.close": "Закрыть",
   "home.checking": "Проверка…",
   "home.idle.title": "Codex установлен",
@@ -1310,6 +1318,7 @@ const AR: Record<Key, string> = {
   "nav.back": "رجوع",
   "nav.settings": "الإعدادات",
   "nav.config": "إعدادات Codex",
+  "nav.minimize": "تصغير",
   "nav.close": "إغلاق",
   "home.checking": "جارٍ التحقق…",
   "home.idle.title": "Codex مثبّت",
@@ -1459,6 +1468,7 @@ const ES: Record<Key, string> = {
   "nav.back": "Atrás",
   "nav.settings": "Ajustes",
   "nav.config": "Configuración de Codex",
+  "nav.minimize": "Minimizar",
   "nav.close": "Cerrar",
   "home.checking": "Comprobando…",
   "home.idle.title": "Codex instalado",
@@ -1608,6 +1618,7 @@ const PT_BR: Record<Key, string> = {
   "nav.back": "Voltar",
   "nav.settings": "Configurações",
   "nav.config": "Configuração do Codex",
+  "nav.minimize": "Minimizar",
   "nav.close": "Fechar",
   "home.checking": "Verificando…",
   "home.idle.title": "Codex instalado",

--- a/src/app/icons.tsx
+++ b/src/app/icons.tsx
@@ -23,6 +23,7 @@ export type IconName =
   | "message"
   | "globe"
   | "external"
+  | "minimize"
   | "close";
 
 const PATHS: Record<IconName, ReactNode> = {
@@ -106,6 +107,7 @@ const PATHS: Record<IconName, ReactNode> = {
       <path d="M18 14v4.5A1.5 1.5 0 0 1 16.5 20h-11A1.5 1.5 0 0 1 4 18.5v-11A1.5 1.5 0 0 1 5.5 6H10" />
     </>
   ),
+  minimize: <line x1="6" y1="12" x2="18" y2="12" />,
   close: (
     <>
       <line x1="6" y1="6" x2="18" y2="18" />

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -401,6 +401,31 @@ input {
   width: 16px;
   height: 16px;
 }
+/* Self-drawn minimize — sits left of close; neutral hover (close is danger). */
+.winmin {
+  width: 30px;
+  height: 30px;
+  border-radius: var(--r-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-faint);
+  display: grid;
+  place-items: center;
+  transition: background 0.18s var(--ease), color 0.18s var(--ease),
+    border-color 0.18s var(--ease), transform 0.08s var(--ease);
+}
+.winmin:hover {
+  background: var(--surface-2);
+  border-color: var(--line);
+  color: var(--text);
+}
+.winmin:active {
+  transform: scale(0.94);
+}
+.winmin svg {
+  width: 16px;
+  height: 16px;
+}
 .spinicon {
   animation: spin 0.8s linear infinite;
   transform-box: fill-box;


### PR DESCRIPTION
## What

The frameless main window (`decorations: false` + `transparent: true`) self-draws its window controls, but only had a close button — there was no way to minimize it (#56).

This adds a self-drawn minimize button:

- **`MinimizeButton`** in the shared `TopBar` / `NavBar`, mirroring `CloseButton`; `onClick` guards on `isTauri()` then calls `getCurrentWindow().minimize()` (no-op in the browser preview).
- **`minimize` icon** (centered horizontal line) in the icon set.
- **`.winmin`** style reusing the `.winclose` skeleton, but with a neutral hover (close stays danger-red).
- **`nav.minimize`** copy across all 11 locales.
- **`core:window:allow-minimize`** permission (Tauri v2 silently no-ops without it).

Because the button lives in the shared `TopBar`/`NavBar`, it appears on both the macOS (`MacHome`) and Windows (`WinHome`) homes and every sub-view, in the standard order: settings → minimize → close.

## Verification

- `tsc --noEmit && vite build` ✓ (type system enforces all 11 locales are covered)
- `vitest` — 14/14 ✓
- `codex review --uncommitted` → **No actionable defects** (it also ran a full `cargo check`)
- Built a release `.app` and confirmed minimize/restore on macOS hardware

Refs #56