### PR TITLE
chore(release): bump version to 0.1.17

### DIFF
--- a/docs/releases/v0.1.17.md
+++ b/docs/releases/v0.1.17.md
@@ -1,0 +1,32 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版补上了窗口缺失的最小化按钮——无边框窗口此前只能关闭、没法收起,现在能最小化到 Dock / 任务栏了。
+> This release adds the window's missing minimize button — the frameless window could only be closed, never tucked away; now it minimizes to the Dock / taskbar.
+
+## 🐛 修复 · Fixes
+
+- **补上缺失的最小化按钮**:主窗口是无边框设计,窗口控制按钮全部自绘,此前只有关闭按钮,没法把窗口最小化。现在标题栏在关闭键左侧新增最小化按钮,点击即可收进 Dock(macOS)/ 任务栏(Windows);两端表现一致,11 种界面语言均已覆盖。
+  The frameless main window self-draws its window controls and previously only had a close button — there was no way to minimize it. The title bar now has a minimize button to the left of close that tucks the window into the Dock (macOS) / taskbar (Windows). Consistent across both platforms, localized in all 11 UI languages.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.16"
+version = "0.1.17"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release **v0.1.17**.

Bumps the version `0.1.16 → 0.1.17` across the 5 manifest files (6 sites) and adds the release note at `docs/releases/v0.1.17.md`.

### What ships
- **fix**: the frameless window's missing minimize button (#56) — the title bar now has a minimize control (left of close) that tucks the window into the Dock (macOS) / taskbar (Windows). Consistent across both platforms, localized in all 11 UI locales. Merged via #57.

Squash-merge, then tag `v0.1.17` to trigger the release workflow.