### PR TITLE
ci: pin action SHAs, add SHA256SUMS + dependabot, document Windows signing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: cargo
+    directory: "/src-tauri"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 20
           cache: npm
@@ -42,15 +42,15 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 20
           cache: npm
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: src-tauri -> target
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,20 +40,20 @@ jobs:
           - { platform: windows-latest, target: x86_64-pc-windows-msvc, os: windows }
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 20
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: src-tauri -> target
 
@@ -185,7 +185,7 @@ jobs:
           fi
           ls -la "$DST"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: bundle-${{ matrix.target }}
           path: dist-artifacts/*
@@ -199,11 +199,11 @@ jobs:
       actions: write # dispatch winget.yml after publishing (release events from GITHUB_TOKEN don't cascade)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: dist
           merge-multiple: true
@@ -247,8 +247,20 @@ jobs:
             cp docs/releases/FALLBACK.md "$RUNNER_TEMP/release-notes.md"
           fi
 
+      - name: Generate SHA256SUMS
+        shell: bash
+        run: |
+          (
+            cd dist
+            sha256sum * | sort -k2
+          ) > SHA256SUMS
+          if [ ! -f dist/latest.json ]; then
+            sha256sum latest.json >> SHA256SUMS
+          fi
+          cat SHA256SUMS
+
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           tag_name: ${{ github.ref_name }}
           draft: false
@@ -262,6 +274,7 @@ jobs:
           files: |
             dist/*
             latest.json
+            SHA256SUMS
 
       # The release above is created with GITHUB_TOKEN, which by design does not
       # trigger other workflows — so winget.yml's `on: release` never fires.

--- a/.github/workflows/win-installer-check.yml
+++ b/.github/workflows/win-installer-check.yml
@@ -24,18 +24,18 @@ jobs:
   nsis:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 20
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: x86_64-pc-windows-msvc
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: src-tauri -> target
 
@@ -52,7 +52,7 @@ jobs:
         run: npm run tauri build -- --bundles nsis --target x86_64-pc-windows-msvc
 
       - name: Upload installer
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: nsis-installer
           path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,7 +1,7 @@
 name: Publish to winget
 
 # Submits each stable release to the Windows Package Manager community repo
-# (microsoft/winget-pkgs) so users can `winget install Wangnov.CodexAppManager`.
+# (microsoft/winget-pkgs) after the package has been bootstrapped there.
 #
 # Prerequisites (one-time):
 #   1. Secret WINGET_TOKEN — a *classic* Personal Access Token with the
@@ -24,6 +24,9 @@ on:
         description: "Release tag to publish (e.g. v0.1.10)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   winget:
     runs-on: ubuntu-latest
@@ -44,7 +47,7 @@ jobs:
 
       - name: Submit to winget-pkgs
         if: steps.gate.outputs.ok == 'true'
-        uses: vedantmgoyal9/winget-releaser@v2
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e  # v2
         with:
           identifier: Wangnov.CodexAppManager
           installers-regex: '_x64-setup\.exe$'

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 | 🌏 **国内可达** | 自更新与 payload 下载共用同一条镜像短链,按地域自动选路(国内 IHEP / 海外 R2),对用户透明 |
 | 🎨 **温润材质 UI** | OKLCH 配色、材质质感、明暗双主题精雕,GSAP 编排的入场与转场动效 |
 | 🌐 **11 种语言** | 跟随系统语言自动选择,含阿拉伯语 RTL |
-| 🍎 **已签名公证** | macOS 走 Developer ID 签名 + Apple 公证;Windows updater 产物以更新私钥签名 |
+| 🍎 **签名状态透明** | macOS 走 Developer ID 签名 + Apple 公证;Windows 安装器当前无 Authenticode 代码签名,自更新包有 Tauri updater 签名 |
 
 ## 下载与安装
 
@@ -88,7 +88,19 @@ brew install --cask wangnov/tap/codex-app-manager
 | Intel Mac | `CodexAppManager_x86_64.dmg` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
 | Windows x64 | `CodexAppManager_x64-setup.exe` | [⤓ 镜像下载](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
 
-macOS 版本经 **Developer ID 签名 + Apple 公证**,首次打开不会被 Gatekeeper 拦截。镜像直链恒指向**最新版**——`/manager/latest/` 由 Cloudflare Worker 自动解析到当前发布,无需随版本更新;装好后 Manager 还会通过**应用内自更新**保持最新(见下)。
+macOS 版本经 **Developer ID 签名 + Apple 公证**,首次打开不会被 Gatekeeper 拦截。Windows 安装器(`CodexAppManager_x64-setup.exe`)当前**没有 Authenticode 代码签名**,首次运行可能出现 SmartScreen 提示;应用内自更新使用的 Tauri updater 签名只校验下载字节,不代表 Windows 发行者信任。详情见 [Windows signing and verification](docs/windows-signing.md)。
+
+下载后建议用同一 GitHub Release 的 `SHA256SUMS` 核验文件。Windows 可用 PowerShell,macOS 可用 `shasum`:
+
+```powershell
+Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256
+```
+
+```bash
+shasum -a 256 CodexAppManager_aarch64.dmg
+```
+
+镜像直链恒指向**最新版**——`/manager/latest/` 由 Cloudflare Worker 自动解析到当前发布,无需随版本更新;装好后 Manager 还会通过**应用内自更新**保持最新(见下)。
 
 > 安装 Manager 后,真正的 Codex 桌面应用由 Manager 负责安装与更新——你不需要单独去下载 Codex 本体。
 
@@ -185,7 +197,7 @@ npm run tauri:build    # 本地构建(未签名)
 | 🌏 **Reachable in China** | Self-update and payload downloads share one mirror link, auto-routed by region (IHEP in China, R2 elsewhere) — transparent to users |
 | 🎨 **Warm material UI** | OKLCH palette, material depth, polished dark + light themes, GSAP-orchestrated entrances and transitions |
 | 🌐 **11 languages** | Auto-selected from the system locale, including Arabic RTL |
-| 🍎 **Signed & notarized** | macOS Developer ID signing + Apple notarization; the Windows updater artifact is signed with the updater key |
+| 🍎 **Transparent signing status** | macOS Developer ID signing + Apple notarization; the Windows installer is not Authenticode-signed yet, while self-update artifacts carry the Tauri updater signature |
 
 ## Download & install
 
@@ -205,7 +217,19 @@ Grab your platform's file from the [latest GitHub Release](https://github.com/Wa
 | Intel Mac | `CodexAppManager_x86_64.dmg` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
 | Windows x64 | `CodexAppManager_x64-setup.exe` | [⤓ mirror](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
 
-The macOS builds are **Developer ID signed + Apple notarized**, so Gatekeeper won't block first launch. The mirror links always resolve to the **latest** release — `/manager/latest/` is auto-resolved to the current version by the Cloudflare Worker, with no per-release edits; after install, the Manager also keeps **itself** up to date via in-app self-update (below).
+The macOS builds are **Developer ID signed + Apple notarized**, so Gatekeeper won't block first launch. The Windows installer (`CodexAppManager_x64-setup.exe`) is **not Authenticode-signed** yet, so SmartScreen may warn on first run; the Tauri updater signature used for in-app updates verifies bytes only and is not Windows publisher trust. See [Windows signing and verification](docs/windows-signing.md).
+
+After downloading, compare the file with `SHA256SUMS` from the same GitHub Release. Use PowerShell on Windows or `shasum` on macOS:
+
+```powershell
+Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256
+```
+
+```bash
+shasum -a 256 CodexAppManager_aarch64.dmg
+```
+
+The mirror links always resolve to the **latest** release — `/manager/latest/` is auto-resolved to the current version by the Cloudflare Worker, with no per-release edits; after install, the Manager also keeps **itself** up to date via in-app self-update (below).
 
 > Once the Manager is installed, it installs and updates the actual Codex desktop app for you — you don't need to download Codex separately.
 

--- a/docs/releases/FALLBACK.md
+++ b/docs/releases/FALLBACK.md
@@ -15,6 +15,12 @@
 | macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
 | Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
 
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` is not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
 ```bash
 # macOS · Homebrew
 brew install --cask wangnov/tap/codex-app-manager

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -41,6 +41,12 @@
 | macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
 | Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
 
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` is not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
 ```bash
 # macOS · Homebrew
 brew install --cask wangnov/tap/codex-app-manager

--- a/docs/windows-signing.md
+++ b/docs/windows-signing.md
@@ -1,0 +1,120 @@
+# Windows signing and verification
+
+This project currently ships a Windows NSIS installer without Authenticode code
+signing. The installer is still published through GitHub Releases and the
+agentsmirror download mirror, and every release includes `SHA256SUMS` so users
+can verify the bytes they downloaded.
+
+## 中文
+
+### 当前状态
+
+- macOS 构建已经使用 Developer ID 签名并完成 Apple 公证。
+- Windows 安装器 `CodexAppManager_x64-setup.exe` 当前没有 Authenticode 代码签名。
+- Windows 应用内自更新包带有 Tauri updater 签名,用于校验下载字节没有被篡改。
+- Windows 首次手动运行安装器时可能出现 SmartScreen 提示;这是预期风险,不是更新器签名失效。
+
+### 三个概念
+
+**Tauri updater 签名:** `latest.json` 里的 `signature` 对安装包字节签名。它保护应用内自更新下载,确保镜像或网络传输没有改包。它不参与 Windows 系统的发行者信任判断,也不能消除 SmartScreen 提示。
+
+**Authenticode 代码签名:** Windows 对 PE 文件和安装器使用的代码签名体系。拥有 OV 或 EV 证书后,安装器可以显示发行者身份,并更容易建立系统信任。本项目当前还没有给 Windows 安装器做 Authenticode 签名。
+
+**SmartScreen 信誉:** Microsoft Defender SmartScreen 会结合签名身份、下载量、历史信誉和风险信号做拦截判断。EV 证书通常能更快建立信誉;OV 证书和未签名分发都需要累积信誉,未签名安装器首次运行更容易被提示。
+
+### 如何核验下载
+
+1. 从 [GitHub Releases](https://github.com/Wangnov/Codex-App-Manager/releases/latest) 或 agentsmirror 镜像下载对应安装包。
+2. 从同一个 release 的 Assets 下载 `SHA256SUMS`。
+3. 在本机计算哈希并与 `SHA256SUMS` 中的同名文件比对。
+
+Windows PowerShell:
+
+```powershell
+Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256
+```
+
+macOS:
+
+```bash
+shasum -a 256 CodexAppManager_aarch64.dmg
+shasum -a 256 CodexAppManager_x86_64.dmg
+```
+
+如果哈希不一致,不要运行该文件,请重新下载或在 issue 中反馈下载来源和文件名。
+
+### 分发渠道与成本评估
+
+**GitHub Releases + agentsmirror + SHA256SUMS:** 这是当前主渠道。优点是透明、可回溯、可独立核验;缺点是 Windows 无 Authenticode 时仍可能触发 SmartScreen。
+
+**winget:** 仓库已有自动提交流程,但 `Wangnov.CodexAppManager` 只有在 microsoft/winget-pkgs 的首包 PR 合并后才真正可用。在那之前,文档不应提供 winget 安装命令。winget 可接受未签名 NSIS 安装器,但新发布者首包通常会有额外人工审查。
+
+**Microsoft Store / Partner Center:** 这是中期可选路径,需要开发者账号、MSIX 打包和商店审核。优点是用户信任更强,缺点是流程和维护成本更高。
+
+**OV / EV 代码签名证书:** 证书不是当前发布阻塞项。后续可在 Windows 下载量、企业用户需求或支持成本达到明确阈值后重新评估。EV 成本更高但信誉建立更快;OV 成本较低但仍需累积 SmartScreen 信誉。
+
+**不推荐的降本方式:** 不把私钥托管给不可信第三方,不合租硬件令牌,不把代码签名能力转交给无法审计的渠道。
+
+### 风险披露
+
+未签名 Windows 安装器意味着用户首次运行可能需要在 SmartScreen 中选择更多信息后继续。项目通过公开 release、镜像直链、`SHA256SUMS`、Tauri updater 签名和透明文档降低篡改与误解风险;这不能替代 Authenticode,但可以让用户在证书预算到位前做独立核验。
+
+## English
+
+### Current status
+
+- macOS builds are Developer ID signed and Apple notarized.
+- The Windows installer `CodexAppManager_x64-setup.exe` is not Authenticode-signed yet.
+- Windows in-app update artifacts carry the Tauri updater signature, which verifies the downloaded bytes.
+- SmartScreen may warn when users manually run the Windows installer for the first time; that is the known distribution risk, not an updater-signature failure.
+
+### Three separate concepts
+
+**Tauri updater signature:** The `signature` field in `latest.json` signs the installer bytes. It protects in-app self-update downloads from tampering across mirrors and network hops. It is not Windows publisher trust and does not remove SmartScreen warnings.
+
+**Authenticode code signing:** This is the Windows code-signing system for PE files and installers. With an OV or EV certificate, the installer can show a publisher identity and build operating-system trust. This project does not currently Authenticode-sign the Windows installer.
+
+**SmartScreen reputation:** Microsoft Defender SmartScreen combines signing identity, download volume, historical reputation, and risk signals. EV certificates usually establish reputation faster; OV certificates and unsigned distribution still need reputation to build, and unsigned installers are more likely to warn on first run.
+
+### How to verify downloads
+
+1. Download the installer from [GitHub Releases](https://github.com/Wangnov/Codex-App-Manager/releases/latest) or the agentsmirror mirror.
+2. Download `SHA256SUMS` from Assets on the same release.
+3. Compute the local hash and compare it with the matching filename in `SHA256SUMS`.
+
+Windows PowerShell:
+
+```powershell
+Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256
+```
+
+macOS:
+
+```bash
+shasum -a 256 CodexAppManager_aarch64.dmg
+shasum -a 256 CodexAppManager_x86_64.dmg
+```
+
+If the hash does not match, do not run the file. Download it again or open an
+issue with the source URL and filename.
+
+### Distribution channels and cost
+
+**GitHub Releases + agentsmirror + SHA256SUMS:** This is the current primary channel. It is transparent, traceable, and independently verifiable, but the unsigned Windows installer can still trigger SmartScreen.
+
+**winget:** The repository has an automated submission workflow, but `Wangnov.CodexAppManager` only exists after the first package PR is merged in microsoft/winget-pkgs. Until then, the docs should not publish a Windows Package Manager install command. winget accepts unsigned NSIS installers, but a new publisher's first package usually receives extra manual review.
+
+**Microsoft Store / Partner Center:** This is a medium-term option. It requires a developer account, MSIX packaging, and Store review. It improves user trust but adds process and maintenance cost.
+
+**OV / EV code-signing certificate:** A certificate is not a release blocker today. Re-evaluate when Windows download volume, enterprise demand, or support cost crosses a clear threshold. EV costs more but establishes reputation faster; OV costs less but still needs SmartScreen reputation to build.
+
+**Cost shortcuts to avoid:** Do not custody private keys with untrusted third parties, share hardware tokens, or hand signing capability to channels that cannot be audited.
+
+### Risk disclosure
+
+An unsigned Windows installer means users may need to choose more information
+and continue through SmartScreen on first run. The project reduces tampering and
+confusion risk with public releases, mirror permalinks, `SHA256SUMS`, Tauri
+updater signatures, and transparent documentation. Those mitigations do not
+replace Authenticode, but they let users verify downloads independently until
+certificate budget and demand justify Windows code signing.


### PR DESCRIPTION
PR-5 **第一批**:发布链路供应链加固 + Windows 签名文档——低风险、PR 阶段可充分验证的部分。

## 改动(#68 / #69)
- **action pin SHA**(#68):4 个 workflow 的全部第三方 action pin 到 40 位 commit SHA(保留 `# vX` 注释),`dtolnay/rust-toolchain@stable` 亦 pin。
- **dependabot.yml**(#68):github-actions + npm + cargo(src-tauri)weekly。
- **SHA256SUMS**(#68/#69):release.yml 在 Publish GitHub Release 前生成校验和清单并纳入 release assets。
- **winget.yml permissions**(#68):加 `contents: read`。
- **Windows 签名文档**(#69):README 标注 installer 无 Authenticode + SmartScreen 提示;新增 `docs/windows-signing.md`(中英,区分 updater 签名 / Authenticode / SmartScreen,渠道评估,风险披露);release TEMPLATE/FALLBACK 加签名状态 + 核验段落。

## 验收(Claude,非 GPT 自判)
- `actionlint` exit 0;无残留 `@vX`/`@stable` 可变引用。
- **8 个 action(20 处引用)的 pin SHA 已逐个 `gh api` 核对真实**。
- SHA256SUMS 步骤 / dependabot / winget permissions 审查通过;windows-signing.md 三概念准确。
- 未触及本批禁止项:`MIRROR_PHASE`、SBOM、attestation、`environment:`。

## 不在本 PR(留 PR-5 第二批,敏感 / 需真机验证)
- #67 updater manifest 完整矩阵校验 + 两阶段镜像晋升。
- #68 environment protection、SBOM、attestation/provenance、cargo audit/deny。

设计原则:全是新增 asset / pin / 文档 / 权限收紧,**不改发布行为、不破坏成功路径**。

Refs #68, #69