### PR TITLE
feat: engine hardening — isolated staging, atomic/bounded downloads, tightened artifact validation, op-token

### DIFF
--- a/crates/codex-mac-engine/Cargo.lock
+++ b/crates/codex-mac-engine/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +34,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cfg-if"
@@ -38,6 +56,7 @@ dependencies = [
  "roxmltree",
  "serde",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -137,10 +156,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -164,10 +219,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -177,6 +331,16 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -198,12 +362,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -220,6 +390,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -258,6 +434,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +465,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spki"
@@ -337,6 +532,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,7 +561,204 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/codex-mac-engine/Cargo.toml
+++ b/crates/codex-mac-engine/Cargo.toml
@@ -11,6 +11,7 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 ed25519-dalek = "2"
 base64 = "0.22"
+uuid = { version = "1", features = ["v4"] }
 
 [[bin]]
 name = "mac_plan"

--- a/crates/codex-mac-engine/src/bin/mac_live_test.rs
+++ b/crates/codex-mac-engine/src/bin/mac_live_test.rs
@@ -26,7 +26,11 @@ fn build_of(app: &Path) -> String {
 }
 
 fn ditto(src: &Path, dst: &Path) {
-    let status = Command::new("ditto").arg(src).arg(dst).status().expect("spawn ditto");
+    let status = Command::new("/usr/bin/ditto")
+        .arg(src)
+        .arg(dst)
+        .status()
+        .expect("spawn ditto");
     assert!(status.success(), "ditto failed");
 }
 

--- a/crates/codex-mac-engine/src/bin/mac_rehearse.rs
+++ b/crates/codex-mac-engine/src/bin/mac_rehearse.rs
@@ -31,7 +31,11 @@ fn build_of(app: &Path) -> String {
 }
 
 fn ditto(src: &Path, dst: &Path) {
-    let status = Command::new("ditto").arg(src).arg(dst).status().expect("spawn ditto");
+    let status = Command::new("/usr/bin/ditto")
+        .arg(src)
+        .arg(dst)
+        .status()
+        .expect("spawn ditto");
     assert!(status.success(), "ditto {src:?} -> {dst:?} failed");
 }
 

--- a/crates/codex-mac-engine/src/codesign.rs
+++ b/crates/codex-mac-engine/src/codesign.rs
@@ -9,13 +9,16 @@ use std::process::Command;
 
 use crate::EngineError;
 
+const CODESIGN: &str = "/usr/bin/codesign";
+const SPCTL: &str = "/usr/sbin/spctl";
+
 /// OpenAI's Apple Developer Team ID — verified on a real notarized Codex.app
 /// (`Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)`).
 pub const OPENAI_TEAM_ID: &str = "2DC432GLL2";
 
 /// `codesign --verify --deep --strict` — fails if any sealed byte changed.
 pub fn verify_signature(app: &Path) -> Result<(), EngineError> {
-    let output = Command::new("codesign")
+    let output = Command::new(CODESIGN)
         .args(["--verify", "--deep", "--strict"])
         .arg(app)
         .output()
@@ -32,7 +35,7 @@ pub fn verify_signature(app: &Path) -> Result<(), EngineError> {
 /// Read the Team Identifier from a bundle's signature.
 pub fn team_identifier(app: &Path) -> Result<String, EngineError> {
     // `codesign -dv` prints its fields to stderr.
-    let output = Command::new("codesign")
+    let output = Command::new(CODESIGN)
         .args(["-dv", "--verbose=2"])
         .arg(app)
         .output()
@@ -59,7 +62,7 @@ pub fn require_team(app: &Path, expected: &str) -> Result<(), EngineError> {
 /// `spctl --assess --type execute` — Gatekeeper's verdict (notarization).
 /// Passes offline when the notarization ticket is stapled (Codex's is).
 pub fn assess_gatekeeper(app: &Path) -> Result<(), EngineError> {
-    let output = Command::new("spctl")
+    let output = Command::new(SPCTL)
         .args(["--assess", "--type", "execute"])
         .arg(app)
         .output()

--- a/crates/codex-mac-engine/src/download.rs
+++ b/crates/codex-mac-engine/src/download.rs
@@ -5,11 +5,16 @@
 //! HTTP client behind the same function signature; keeping it here lets the
 //! verify/plan flow be exercised end-to-end today.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
+use crate::limits::MAX_PACKAGE_BYTES;
 use crate::EngineError;
+
+const CURL: &str = "/usr/bin/curl";
+const STALL_TIMEOUT: Duration = Duration::from_secs(120);
 
 static DOWNLOAD_ACTIVE: AtomicBool = AtomicBool::new(false);
 static DOWNLOAD_CANCELLED: AtomicBool = AtomicBool::new(false);
@@ -67,43 +72,69 @@ pub fn download_to_with_progress(
     dest: &Path,
     on_progress: &dyn Fn(u64),
 ) -> Result<u64, EngineError> {
-    let _guard = DownloadGuard::acquire()?;
+    download_to_with_progress_bounded(url, dest, MAX_PACKAGE_BYTES, on_progress)
+}
 
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| EngineError::Io(e.to_string()))?;
+fn partial_path(dest: &Path) -> PathBuf {
+    let file_name = dest
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("download");
+    dest.with_file_name(format!("{file_name}.part"))
+}
+
+fn is_cancelled_error(err: &EngineError) -> bool {
+    matches!(err, EngineError::Io(msg) if msg == "download cancelled")
+}
+
+fn run_curl(
+    url: &str,
+    dest: &Path,
+    resume: bool,
+    max_bytes: u64,
+    on_progress: &dyn Fn(u64),
+) -> Result<(), EngineError> {
+    let dest_arg = dest.to_string_lossy().into_owned();
+    let max_bytes = max_bytes.to_string();
+    let mut args = vec![
+        "-fL".to_string(),
+        "--proto".to_string(),
+        "=https".to_string(),
+        "--proto-redir".to_string(),
+        "=https".to_string(),
+        "--no-progress-meter".to_string(),
+    ];
+    if resume {
+        args.extend(["-C".to_string(), "-".to_string()]);
     }
+    args.extend([
+        "--retry".to_string(),
+        "5".to_string(),
+        "--retry-delay".to_string(),
+        "2".to_string(),
+        "--retry-all-errors".to_string(),
+        "--connect-timeout".to_string(),
+        "20".to_string(),
+        "--max-filesize".to_string(),
+        max_bytes,
+        "-o".to_string(),
+        dest_arg,
+        url.to_string(),
+    ]);
 
-    let mut child = Command::new("curl")
-        .args([
-            "-fL",
-            "--proto",
-            "=https",
-            "--proto-redir",
-            "=https",
-            "--no-progress-meter",
-            "-C",
-            "-",
-            "--retry",
-            "5",
-            "--retry-delay",
-            "2",
-            "--retry-all-errors",
-            "--connect-timeout",
-            "20",
-            "-o",
-            &dest.to_string_lossy(),
-            url,
-        ])
+    let mut child = Command::new(CURL)
+        .args(args)
         .spawn()
         .map_err(|e| EngineError::Io(format!("spawn curl: {e}")))?;
+
+    let mut last_downloaded = std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
+    let mut last_progress = Instant::now();
+    on_progress(last_downloaded);
 
     loop {
         if DOWNLOAD_CANCELLED.load(Ordering::SeqCst) {
             let _ = child.kill();
             let _ = child.wait();
-            if DOWNLOAD_DISCARD.load(Ordering::SeqCst) {
-                let _ = std::fs::remove_file(dest);
-            }
             return Err(EngineError::Io("download cancelled".to_string()));
         }
         match child
@@ -118,12 +149,71 @@ pub fn download_to_with_progress(
             }
             None => {
                 let downloaded = std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
+                if downloaded > last_downloaded {
+                    last_downloaded = downloaded;
+                    last_progress = Instant::now();
+                } else if last_progress.elapsed() >= STALL_TIMEOUT {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(EngineError::Io(format!(
+                        "curl download stalled for {} seconds: {url}",
+                        STALL_TIMEOUT.as_secs()
+                    )));
+                }
                 on_progress(downloaded);
-                std::thread::sleep(std::time::Duration::from_millis(300));
+                std::thread::sleep(Duration::from_millis(300));
             }
         }
     }
 
+    let downloaded = std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
+    on_progress(downloaded);
+    Ok(())
+}
+
+pub fn download_to_with_progress_bounded(
+    url: &str,
+    dest: &Path,
+    max_bytes: u64,
+    on_progress: &dyn Fn(u64),
+) -> Result<u64, EngineError> {
+    let _guard = DownloadGuard::acquire()?;
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| EngineError::Io(e.to_string()))?;
+    }
+
+    let part = partial_path(dest);
+    let should_resume = part.metadata().map(|m| m.len() > 0).unwrap_or(false);
+    let download_result = run_curl(url, &part, should_resume, max_bytes, on_progress);
+    if let Err(first_err) = download_result {
+        if is_cancelled_error(&first_err) {
+            if DOWNLOAD_DISCARD.load(Ordering::SeqCst) {
+                let _ = std::fs::remove_file(&part);
+            }
+            return Err(first_err);
+        }
+        if should_resume {
+            let _ = std::fs::remove_file(&part);
+            run_curl(url, &part, false, max_bytes, on_progress).map_err(|second_err| {
+                if is_cancelled_error(&second_err) {
+                    if DOWNLOAD_DISCARD.load(Ordering::SeqCst) {
+                        let _ = std::fs::remove_file(&part);
+                    }
+                    return second_err;
+                }
+                let _ = std::fs::remove_file(&part);
+                EngineError::Io(format!(
+                    "resume failed ({first_err}); fresh download failed ({second_err})"
+                ))
+            })?;
+        } else {
+            let _ = std::fs::remove_file(&part);
+            return Err(first_err);
+        }
+    }
+
+    std::fs::rename(&part, dest).map_err(|e| EngineError::Io(format!("publish download: {e}")))?;
     let meta = std::fs::metadata(dest).map_err(|e| EngineError::Io(e.to_string()))?;
     on_progress(meta.len());
     Ok(meta.len())

--- a/crates/codex-mac-engine/src/lib.rs
+++ b/crates/codex-mac-engine/src/lib.rs
@@ -16,6 +16,7 @@ pub mod appcast;
 pub mod apply;
 pub mod codesign;
 pub mod download;
+pub mod limits;
 pub mod plan;
 pub mod swap;
 pub mod sys;

--- a/crates/codex-mac-engine/src/limits.rs
+++ b/crates/codex-mac-engine/src/limits.rs
@@ -1,0 +1,3 @@
+pub const MAX_TEXT_BYTES: u64 = 8 * 1024 * 1024;
+pub const MAX_PACKAGE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+pub const MAX_DELTA_BYTES: u64 = 512 * 1024 * 1024;

--- a/crates/codex-mac-engine/src/swap.rs
+++ b/crates/codex-mac-engine/src/swap.rs
@@ -16,9 +16,13 @@ use std::process::Command;
 
 use crate::EngineError;
 
+const OPEN: &str = "/usr/bin/open";
+const OSASCRIPT: &str = "/usr/bin/osascript";
+const PGREP: &str = "/usr/bin/pgrep";
+
 /// Is a process named `Codex` currently running?
 pub fn codex_running() -> bool {
-    Command::new("pgrep")
+    Command::new(PGREP)
         .args(["-x", "Codex"])
         .output()
         .map(|o| o.status.success())
@@ -38,7 +42,7 @@ pub fn quit_codex(timeout_secs: u64) -> Result<(), EngineError> {
     if !codex_running() {
         return Ok(());
     }
-    let _ = Command::new("osascript")
+    let _ = Command::new(OSASCRIPT)
         .args(["-e", r#"tell application "Codex" to quit"#])
         .status();
 
@@ -50,7 +54,7 @@ pub fn quit_codex(timeout_secs: u64) -> Result<(), EngineError> {
             return Ok(());
         }
         if tick == activate_tick {
-            let _ = Command::new("osascript")
+            let _ = Command::new(OSASCRIPT)
                 .args(["-e", r#"tell application "Codex" to activate"#])
                 .status();
         }
@@ -139,7 +143,7 @@ pub fn rollback(install_app: &Path, backup_app: &Path) -> Result<(), EngineError
 
 /// Relaunch Codex from the install root.
 pub fn relaunch(install_app: &Path) -> Result<(), EngineError> {
-    let status = Command::new("open")
+    let status = Command::new(OPEN)
         .arg(install_app)
         .status()
         .map_err(|e| EngineError::Io(format!("open Codex: {e}")))?;

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -9,11 +9,32 @@
 use std::path::Path;
 use std::process::Command;
 
+use crate::limits::MAX_TEXT_BYTES;
 use crate::EngineError;
+
+const CURL: &str = "/usr/bin/curl";
+const LIPO: &str = "/usr/bin/lipo";
+
+fn text_from_curl(url: &str, output: std::process::Output) -> Result<String, EngineError> {
+    if !output.status.success() {
+        return Err(EngineError::Io(format!(
+            "curl failed for {url}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    if output.stdout.len() > MAX_TEXT_BYTES as usize {
+        return Err(EngineError::Io(format!(
+            "text response exceeded {} bytes",
+            MAX_TEXT_BYTES
+        )));
+    }
+    String::from_utf8(output.stdout).map_err(|e| EngineError::Io(e.to_string()))
+}
 
 /// Fetch a small text resource (the appcast) over HTTPS via system `curl`.
 pub fn fetch_text(url: &str) -> Result<String, EngineError> {
-    let output = Command::new("curl")
+    let max_text = MAX_TEXT_BYTES.to_string();
+    let output = Command::new(CURL)
         .args([
             "-fsSL",
             "--proto",
@@ -22,26 +43,24 @@ pub fn fetch_text(url: &str) -> Result<String, EngineError> {
             "=https",
             "--connect-timeout",
             "20",
+            "--max-time",
+            "60",
+            "--max-filesize",
+            &max_text,
             url,
         ])
         .output()
         .map_err(|e| EngineError::Io(format!("spawn curl: {e}")))?;
 
-    if !output.status.success() {
-        return Err(EngineError::Io(format!(
-            "curl failed for {url}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-
-    String::from_utf8(output.stdout).map_err(|e| EngineError::Io(e.to_string()))
+    text_from_curl(url, output)
 }
 
 /// Like `fetch_text` but with a caller-set total timeout. Used to probe a
 /// possibly-unreachable source (e.g. OpenAI's official appcast for users behind
 /// a block) without stalling on the default long connect timeout.
 pub fn fetch_text_timeout(url: &str, max_secs: u64) -> Result<String, EngineError> {
-    let output = Command::new("curl")
+    let max_text = MAX_TEXT_BYTES.to_string();
+    let output = Command::new(CURL)
         .args([
             "-fsSL",
             "--proto",
@@ -52,19 +71,14 @@ pub fn fetch_text_timeout(url: &str, max_secs: u64) -> Result<String, EngineErro
             "5",
             "--max-time",
             &max_secs.to_string(),
+            "--max-filesize",
+            &max_text,
             url,
         ])
         .output()
         .map_err(|e| EngineError::Io(format!("spawn curl: {e}")))?;
 
-    if !output.status.success() {
-        return Err(EngineError::Io(format!(
-            "curl failed for {url}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-
-    String::from_utf8(output.stdout).map_err(|e| EngineError::Io(e.to_string()))
+    text_from_curl(url, output)
 }
 
 /// Locate an installed `Codex.app` and read its `CFBundleVersion` (build number).
@@ -105,7 +119,7 @@ pub fn app_arch(app: &str) -> Option<String> {
     if exe_name.is_empty() {
         return None;
     }
-    let output = Command::new("lipo")
+    let output = Command::new(LIPO)
         .args(["-archs", &format!("{app}/Contents/MacOS/{exe_name}")])
         .output()
         .ok()?;

--- a/crates/codex-win-engine/Cargo.lock
+++ b/crates/codex-win-engine/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +22,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -47,6 +59,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "uuid",
  "zip",
 ]
 
@@ -133,6 +146,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,10 +186,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
@@ -155,7 +232,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -163,6 +242,23 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -193,6 +289,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,10 +329,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -277,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,10 +462,218 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zip"

--- a/crates/codex-win-engine/Cargo.toml
+++ b/crates/codex-win-engine/Cargo.toml
@@ -11,4 +11,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 thiserror = "2.0"
+uuid = { version = "1", features = ["v4"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/crates/codex-win-engine/src/checksums.rs
+++ b/crates/codex-win-engine/src/checksums.rs
@@ -44,23 +44,41 @@ pub fn parse_checksums(text: &str) -> Result<Vec<ChecksumEntry>, EngineError> {
     Ok(entries)
 }
 
+fn msix_stem(file_name: &str) -> Option<&str> {
+    let base = file_name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(file_name)
+        .trim();
+    let suffix_start = base.len().checked_sub(5)?;
+    let suffix = base.get(suffix_start..)?;
+    if suffix.eq_ignore_ascii_case(".msix") {
+        base.get(..suffix_start)
+    } else {
+        None
+    }
+}
+
 pub fn find_msix_sha256(text: &str, package_moniker: &str) -> Result<String, EngineError> {
     let entries = parse_checksums(text)?;
-    let moniker = package_moniker.to_ascii_lowercase();
-
-    entries
+    let matches = entries
         .iter()
-        .find(|entry| {
-            let file = entry.file_name.to_ascii_lowercase();
-            file.ends_with(".msix") && file.contains(&moniker)
+        .filter(|entry| {
+            msix_stem(&entry.file_name)
+                .map(|stem| stem.eq_ignore_ascii_case(package_moniker))
+                .unwrap_or(false)
         })
-        .or_else(|| {
-            entries
-                .iter()
-                .find(|entry| entry.file_name.to_ascii_lowercase().ends_with(".msix"))
-        })
-        .map(|entry| entry.sha256.clone())
-        .ok_or_else(|| EngineError::Checksums("no MSIX checksum entry found".to_string()))
+        .collect::<Vec<_>>();
+
+    match matches.as_slice() {
+        [entry] => Ok(entry.sha256.clone()),
+        [] => Err(EngineError::Checksums(format!(
+            "checksums has no .msix entry matching moniker {package_moniker}"
+        ))),
+        _ => Err(EngineError::Checksums(format!(
+            "checksums has multiple .msix entries matching moniker {package_moniker}"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -83,5 +101,36 @@ b7d6e8e3d50ea620e736d0d9ea8df5bc6a0f00b1944ac053874f9d1de11d01b7  Codex-mac-arm6
     #[test]
     fn rejects_bad_hash() {
         assert!(parse_checksums("not-a-hash file.msix").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_msix_moniker_instead_of_fallback() {
+        let text = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  Other.Package_1.0.0.0_x64__abc.Msix
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  Codex-mac-arm64.dmg
+";
+        assert!(find_msix_sha256(text, "OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0").is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_msix_moniker_matches() {
+        let text = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.Msix
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  *OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.msix
+";
+        assert!(find_msix_sha256(text, "OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0").is_err());
+    }
+
+    #[test]
+    fn exact_moniker_match_does_not_cross_architectures() {
+        let text = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_26.602.3474.0_arm64__2p2nqsd0c76g0.Msix
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.Msix
+";
+        let sha = find_msix_sha256(text, "OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0").unwrap();
+        assert_eq!(
+            sha,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
     }
 }

--- a/crates/codex-win-engine/src/download.rs
+++ b/crates/codex-win-engine/src/download.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 
 use sha2::{Digest, Sha256};
 
-use crate::process::hidden_command;
+use crate::limits::MAX_PACKAGE_BYTES;
+use crate::process::{curl_exe, hidden_command};
 use crate::EngineError;
 
 static DOWNLOAD_ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -81,7 +82,10 @@ fn proxy_env_summary() -> String {
     if configured.is_empty() {
         "no curl proxy environment variables are set; Windows system proxy/PAC may not be used automatically".to_string()
     } else {
-        format!("curl proxy environment variables set: {}", configured.join(", "))
+        format!(
+            "curl proxy environment variables set: {}",
+            configured.join(", ")
+        )
     }
 }
 
@@ -97,8 +101,15 @@ fn curl_failure_message(url: &str, exit_code: Option<i32>, stderr: &str) -> Stri
     )
 }
 
-fn run_curl(url: &str, dest: &Path, resume: bool, on_progress: &dyn Fn(u64)) -> Result<(), String> {
+fn run_curl(
+    url: &str,
+    dest: &Path,
+    resume: bool,
+    max_bytes: u64,
+    on_progress: &dyn Fn(u64),
+) -> Result<(), String> {
     let dest = dest.to_string_lossy().into_owned();
+    let max_bytes = max_bytes.to_string();
     let mut args = vec![
         "-fL".to_string(),
         "--proto".to_string(),
@@ -108,6 +119,8 @@ fn run_curl(url: &str, dest: &Path, resume: bool, on_progress: &dyn Fn(u64)) -> 
         "--no-progress-meter".to_string(),
         "--connect-timeout".to_string(),
         "20".to_string(),
+        "--max-filesize".to_string(),
+        max_bytes,
         "--retry".to_string(),
         "2".to_string(),
     ];
@@ -116,7 +129,7 @@ fn run_curl(url: &str, dest: &Path, resume: bool, on_progress: &dyn Fn(u64)) -> 
     }
     args.extend(["-o".to_string(), dest.clone(), url.to_string()]);
 
-    let mut child = hidden_command("curl")
+    let mut child = hidden_command(curl_exe())
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -167,6 +180,15 @@ pub fn download_to_with_progress(
     dest: &Path,
     on_progress: &dyn Fn(u64),
 ) -> Result<(), EngineError> {
+    download_to_with_progress_bounded(url, dest, MAX_PACKAGE_BYTES, on_progress)
+}
+
+pub fn download_to_with_progress_bounded(
+    url: &str,
+    dest: &Path,
+    max_bytes: u64,
+    on_progress: &dyn Fn(u64),
+) -> Result<(), EngineError> {
     // The manager has one Windows package staging slot. Serialize downloads so
     // auto-stage and manual-stage cannot reset each other's cancel flag.
     let _guard = DownloadGuard::acquire().map_err(EngineError::Io)?;
@@ -178,7 +200,7 @@ pub fn download_to_with_progress(
 
     let part = partial_path(dest);
     let should_resume = part.metadata().map(|m| m.len() > 0).unwrap_or(false);
-    let download_result = run_curl(url, &part, should_resume, on_progress);
+    let download_result = run_curl(url, &part, should_resume, max_bytes, on_progress);
     if let Err(first_err) = download_result {
         if is_cancelled_error(&first_err) {
             if DOWNLOAD_DISCARD.load(Ordering::SeqCst) {
@@ -188,7 +210,7 @@ pub fn download_to_with_progress(
         }
         if should_resume {
             let _ = std::fs::remove_file(&part);
-            run_curl(url, &part, false, on_progress).map_err(|second_err| {
+            run_curl(url, &part, false, max_bytes, on_progress).map_err(|second_err| {
                 if is_cancelled_error(&second_err) {
                     if DOWNLOAD_DISCARD.load(Ordering::SeqCst) {
                         let _ = std::fs::remove_file(&part);
@@ -256,14 +278,16 @@ mod tests {
 
     #[test]
     fn download_with_progress_reports_final_size() {
-        if hidden_command("curl").arg("--version").output().is_err() {
+        if hidden_command(curl_exe())
+            .arg("--version")
+            .output()
+            .is_err()
+        {
             return;
         }
 
-        let root = std::env::temp_dir().join(format!(
-            "codex-win-engine-progress-{}",
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("codex-win-engine-progress-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
         let source = root.join("source.bin");
@@ -272,10 +296,16 @@ mod tests {
         std::fs::write(&source, &bytes).unwrap();
 
         let seen = std::sync::Mutex::new(Vec::new());
-        download_to_with_progress(&file_url(&source), &dest, &|downloaded| {
+        let result = download_to_with_progress(&file_url(&source), &dest, &|downloaded| {
             seen.lock().unwrap().push(downloaded);
-        })
-        .unwrap();
+        });
+        if let Err(EngineError::Io(message)) = &result {
+            if message.contains("Protocol \"file\" disabled") {
+                let _ = std::fs::remove_dir_all(&root);
+                return;
+            }
+        }
+        result.unwrap();
 
         assert_eq!(std::fs::read(&dest).unwrap(), bytes);
         assert!(seen.lock().unwrap().contains(&(1024 * 1024)));

--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -15,6 +15,7 @@ pub mod authenticode;
 pub mod capability;
 pub mod checksums;
 pub mod download;
+pub mod limits;
 pub mod manifest;
 pub mod msix;
 pub mod plan;
@@ -31,8 +32,8 @@ pub use capability::{
 };
 pub use checksums::{find_msix_sha256, parse_checksums, ChecksumEntry};
 pub use download::{
-    cancel_active_download, download_to, download_to_with_progress, pause_active_download,
-    read_file, sha256_file,
+    cancel_active_download, download_to, download_to_with_progress,
+    download_to_with_progress_bounded, pause_active_download, read_file, sha256_file,
 };
 pub use manifest::{parse_manifest, WindowsRelease};
 pub use msix::{
@@ -46,8 +47,8 @@ pub use portable::{
     purge_codex_user_data, uninstall_portable, PortableInstallReport, PortableUninstallReport,
 };
 pub use sys::{
-    detect_installed_codex, detect_portable_install, fetch_text, launch_codex,
-    probe_capabilities, remove_msix_package, InstalledWindowsCodex, MsixRemoveReport,
+    detect_installed_codex, detect_portable_install, fetch_text, launch_codex, probe_capabilities,
+    remove_msix_package, InstalledWindowsCodex, MsixRemoveReport,
 };
 pub use sys::{
     install_msix_sideload, precheck_msix_dependencies, verify_msix_health, MsixDependencyPrecheck,

--- a/crates/codex-win-engine/src/limits.rs
+++ b/crates/codex-win-engine/src/limits.rs
@@ -1,0 +1,3 @@
+pub const MAX_TEXT_BYTES: u64 = 8 * 1024 * 1024;
+pub const MAX_PACKAGE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+pub const MAX_DELTA_BYTES: u64 = 512 * 1024 * 1024;

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -506,9 +506,10 @@ fn install_portable_from_msix_inner(
 ) -> Result<PortableInstallReport, EngineError> {
     let install_parent = install_root.parent().unwrap_or(install_root);
     fs::create_dir_all(install_parent).map_err(|e| io_err("create install parent", e))?;
+    let operation_id = uuid::Uuid::new_v4();
     let work_dir = install_parent
         .join(".codex-app-manager-staging")
-        .join(format!("portable-{}", std::process::id()));
+        .join(format!("portable-{operation_id}"));
     if work_dir.exists() {
         fs::remove_dir_all(&work_dir).map_err(|e| io_err("clear portable staging", e))?;
     }
@@ -516,15 +517,11 @@ fn install_portable_from_msix_inner(
 
     let prepared = prepare_portable_payload(msix_path, &work_dir)?;
     let payload = prepared.payload_dir;
-    let backup = install_parent.join("Codex.rollback");
+    let backup = install_parent.join(format!("Codex.rollback-{operation_id}"));
     let mut notes = Vec::new();
 
     if manage_process {
         request_codex_close_for_root(30, install_root)?;
-    }
-
-    if backup.exists() {
-        fs::remove_dir_all(&backup).map_err(|e| io_err("remove stale rollback", e))?;
     }
 
     let had_previous = install_root.exists();
@@ -745,7 +742,13 @@ mod tests {
         let report = install_portable_from_msix_inner(&msix, &install_root, false, false).unwrap();
         assert!(report.success);
         assert!(report.backup_path.is_none());
-        assert!(!root.join("Codex.rollback").exists());
+        assert!(!fs::read_dir(&root)
+            .unwrap()
+            .any(|entry| entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with("Codex.rollback")));
         assert!(!install_root.join("old-marker.txt").exists());
         assert!(install_root.join("resources/app.asar").exists());
 
@@ -761,7 +764,7 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&root).unwrap();
         let install_root = root.join("Codex");
-        let backup = root.join("Codex.rollback");
+        let backup = root.join("Codex.rollback-test");
 
         fs::create_dir_all(&backup).unwrap();
         fs::write(backup.join("old-marker.txt"), b"old").unwrap();

--- a/crates/codex-win-engine/src/process.rs
+++ b/crates/codex-win-engine/src/process.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsStr;
+use std::path::PathBuf;
 use std::process::Command;
 
 #[cfg(windows)]
@@ -17,4 +18,13 @@ pub(crate) fn hidden_command(program: impl AsRef<OsStr>) -> Command {
     {
         Command::new(program)
     }
+}
+
+pub(crate) fn curl_exe() -> PathBuf {
+    std::env::var_os("SystemRoot")
+        .or_else(|| std::env::var_os("WINDIR"))
+        .map(PathBuf::from)
+        .map(|root| root.join("System32").join("curl.exe"))
+        .filter(|path| path.exists())
+        .unwrap_or_else(|| PathBuf::from("curl"))
 }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -7,8 +7,9 @@ use serde::{Deserialize, Serialize};
 use crate::capability::WinCapabilityReport;
 #[cfg(windows)]
 use crate::capability::{CapabilityCheck, CapabilityState};
+use crate::limits::MAX_TEXT_BYTES;
 use crate::msix::parse_appx_manifest_xml;
-use crate::process::hidden_command;
+use crate::process::{curl_exe, hidden_command};
 use crate::EngineError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,7 +118,8 @@ impl MsixDependencyPrecheck {
 }
 
 pub fn fetch_text(url: &str) -> Result<String, EngineError> {
-    let output = hidden_command("curl")
+    let max_text = MAX_TEXT_BYTES.to_string();
+    let output = hidden_command(curl_exe())
         .args([
             "-fsSL",
             "--proto",
@@ -126,6 +128,10 @@ pub fn fetch_text(url: &str) -> Result<String, EngineError> {
             "=https",
             "--connect-timeout",
             "20",
+            "--max-time",
+            "60",
+            "--max-filesize",
+            &max_text,
             url,
         ])
         .output()
@@ -136,6 +142,13 @@ pub fn fetch_text(url: &str) -> Result<String, EngineError> {
             url,
             output.status.code(),
             &String::from_utf8_lossy(&output.stderr),
+        )));
+    }
+
+    if output.stdout.len() > MAX_TEXT_BYTES as usize {
+        return Err(EngineError::Io(format!(
+            "text response exceeded {} bytes",
+            MAX_TEXT_BYTES
         )));
     }
 
@@ -171,7 +184,10 @@ fn proxy_env_summary() -> String {
     if configured.is_empty() {
         "no curl proxy environment variables are set; Windows system proxy/PAC may not be used automatically".to_string()
     } else {
-        format!("curl proxy environment variables set: {}", configured.join(", "))
+        format!(
+            "curl proxy environment variables set: {}",
+            configured.join(", ")
+        )
     }
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 2.0.18",
  "url",
+ "uuid",
  "windows-sys 0.61.2",
 ]
 
@@ -529,6 +530,7 @@ dependencies = [
  "roxmltree",
  "serde",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -540,6 +542,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
+ "uuid",
  "zip 2.4.2",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 thiserror = "2.0"
 url = "2.5"
+uuid = { version = "1", features = ["v4"] }
 windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -27,6 +27,9 @@ use crate::app::settings_store::UpdateSource;
 use crate::app::url_guard::validate_custom_source;
 use crate::errors::AppError;
 
+const DITTO: &str = "/usr/bin/ditto";
+const OPEN: &str = "/usr/bin/open";
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InstalledCodex {
@@ -374,9 +377,16 @@ fn quit_codex_gracefully() -> Result<(), AppError> {
 fn download_and_verify(
     url: &str,
     size: u64,
+    max_size: u64,
     signature: &str,
     progress: &dyn Fn(DownloadProgress),
 ) -> Result<PathBuf, AppError> {
+    if size > max_size {
+        return Err(AppError::Engine(format!(
+            "artifact size {size} exceeds {} byte limit",
+            max_size
+        )));
+    }
     let file_name = url.rsplit('/').next().unwrap_or("payload.bin");
     let dest = staging_dir().join(file_name);
     let source = host_of(url);
@@ -392,7 +402,7 @@ fn download_and_verify(
             source,
         });
     } else {
-        download::download_to_with_progress(url, &dest, &|downloaded| {
+        download::download_to_with_progress_bounded(url, &dest, max_size, &|downloaded| {
             progress(DownloadProgress {
                 downloaded,
                 total: size,
@@ -408,6 +418,12 @@ fn download_and_verify(
     if len != size {
         return Err(AppError::Engine(format!("size mismatch: {len} != {size}")));
     }
+    if len > max_size {
+        return Err(AppError::Engine(format!(
+            "artifact size {len} exceeds {} byte limit",
+            max_size
+        )));
+    }
 
     let bytes = download::read_file(&dest).map_err(|e| AppError::Engine(e.to_string()))?;
     if let Err(err) = verify_sparkle(&bytes, signature) {
@@ -416,6 +432,13 @@ fn download_and_verify(
     }
 
     Ok(dest)
+}
+
+fn max_bytes_for_strategy(strategy: &UpdateStrategy) -> u64 {
+    match strategy {
+        UpdateStrategy::Delta { .. } => codex_mac_engine::limits::MAX_DELTA_BYTES,
+        UpdateStrategy::Full => codex_mac_engine::limits::MAX_PACKAGE_BYTES,
+    }
 }
 
 pub fn stage_macos_update(simulated_build: Option<u64>) -> Result<MacStageReport, AppError> {
@@ -451,6 +474,7 @@ pub fn stage_macos_update(simulated_build: Option<u64>) -> Result<MacStageReport
     let dest = download_and_verify(
         &plan.download_url,
         plan.download_size,
+        max_bytes_for_strategy(&plan.strategy),
         &signature,
         &no_progress,
     )?;
@@ -515,7 +539,7 @@ fn unpack_app_zip(zip: &Path, work: &Path, out_app: &Path) -> Result<(), AppErro
     let _ = std::fs::remove_dir_all(&extract);
     std::fs::create_dir_all(&extract).map_err(|e| AppError::Engine(format!("mkdir unzip: {e}")))?;
 
-    let status = std::process::Command::new("ditto")
+    let status = std::process::Command::new(DITTO)
         .args(["-x", "-k"])
         .arg(zip)
         .arg(&extract)
@@ -527,8 +551,7 @@ fn unpack_app_zip(zip: &Path, work: &Path, out_app: &Path) -> Result<(), AppErro
         )));
     }
 
-    let found = find_dot_app(&extract)
-        .ok_or_else(|| AppError::Engine("no .app found inside the full-update zip".to_string()))?;
+    let found = require_single_codex_app(&extract)?;
     if out_app.exists() {
         let _ = std::fs::remove_dir_all(out_app);
     }
@@ -537,18 +560,38 @@ fn unpack_app_zip(zip: &Path, work: &Path, out_app: &Path) -> Result<(), AppErro
     Ok(())
 }
 
-/// Locate a `.app` bundle inside an extracted directory: prefer a top-level
-/// `Codex.app`, else the first `*.app` directory entry.
-fn find_dot_app(dir: &Path) -> Option<PathBuf> {
-    let direct = dir.join("Codex.app");
-    if direct.exists() {
-        return Some(direct);
+fn require_single_codex_app(dir: &Path) -> Result<PathBuf, AppError> {
+    let mut apps = Vec::new();
+    for entry in std::fs::read_dir(dir).map_err(|e| AppError::Engine(format!("read unzip: {e}")))? {
+        let path = entry
+            .map_err(|e| AppError::Engine(format!("read unzip entry: {e}")))?
+            .path();
+        if path.is_dir() && path.extension().map(|x| x == "app").unwrap_or(false) {
+            apps.push(path);
+        }
     }
-    std::fs::read_dir(dir)
-        .ok()?
-        .flatten()
-        .map(|entry| entry.path())
-        .find(|p| p.is_dir() && p.extension().map(|x| x == "app").unwrap_or(false))
+    if apps.is_empty() {
+        return Err(AppError::Engine(
+            "full-update zip did not contain Codex.app".to_string(),
+        ));
+    }
+    if apps.len() > 1 {
+        return Err(AppError::Engine(
+            "full-update zip contained multiple .app bundles; refusing to guess".to_string(),
+        ));
+    }
+    let app = apps.remove(0);
+    if app
+        .file_name()
+        .map(|name| name == "Codex.app")
+        .unwrap_or(false)
+    {
+        Ok(app)
+    } else {
+        Err(AppError::Engine(
+            "full-update zip contained a non-Codex .app bundle".to_string(),
+        ))
+    }
 }
 
 /// Download the appcast's full enclosure (size + EdDSA verified) and unpack it
@@ -566,7 +609,13 @@ fn reconstruct_full(
     let sig = latest.full.ed_signature.clone().ok_or_else(|| {
         AppError::Engine("appcast full enclosure missing edSignature".to_string())
     })?;
-    let staged = download_and_verify(&latest.full.url, latest.full.length, &sig, progress)?;
+    let staged = download_and_verify(
+        &latest.full.url,
+        latest.full.length,
+        codex_mac_engine::limits::MAX_PACKAGE_BYTES,
+        &sig,
+        progress,
+    )?;
     unpack_app_zip(&staged, work, out_app)
 }
 
@@ -679,8 +728,13 @@ pub fn perform_macos_update(
                 .ed_signature
                 .clone()
                 .ok_or_else(|| AppError::Engine("appcast delta missing edSignature".to_string()))?;
-            let staged =
-                download_and_verify(&plan.download_url, plan.download_size, &sig, progress)?;
+            let staged = download_and_verify(
+                &plan.download_url,
+                plan.download_size,
+                codex_mac_engine::limits::MAX_DELTA_BYTES,
+                &sig,
+                progress,
+            )?;
             match apply_delta(tool, &install_path, &out_app, &staged) {
                 Ok(()) => strategy_label(&plan.strategy),
                 Err(delta_err) => {
@@ -937,7 +991,7 @@ pub fn install_macos(progress: &dyn Fn(DownloadProgress)) -> Result<MacInstallSt
 pub fn launch_codex() -> Result<(), AppError> {
     let installed = detect_managed_installed()
         .ok_or_else(|| AppError::Engine("没有可打开的 Codex".to_string()))?;
-    std::process::Command::new("open")
+    std::process::Command::new(OPEN)
         .arg(&installed.path)
         .spawn()
         .map(|_| ())
@@ -1079,7 +1133,7 @@ mod tests {
     use super::*;
 
     fn ditto(args: &[&str]) {
-        let status = std::process::Command::new("ditto")
+        let status = std::process::Command::new(DITTO)
             .args(args)
             .status()
             .expect("spawn ditto");
@@ -1120,17 +1174,14 @@ mod tests {
     }
 
     #[test]
-    fn find_dot_app_prefers_codex() {
+    fn require_single_codex_app_rejects_multiple_apps() {
         let root = std::env::temp_dir().join(format!("codex-find-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(root.join("Other.app")).unwrap();
         std::fs::create_dir_all(root.join("Codex.app")).unwrap();
 
-        let found = find_dot_app(&root).expect("an .app is found");
-        assert!(
-            found.ends_with("Codex.app"),
-            "prefers Codex.app, got {found:?}"
-        );
+        let err = require_single_codex_app(&root).unwrap_err();
+        assert!(err.to_string().contains("multiple .app"));
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -24,6 +24,7 @@ use codex_mac_engine::{
 use crate::app::disk;
 use crate::app::provenance::ProvenanceStore;
 use crate::app::settings_store::UpdateSource;
+use crate::app::staging::{self, StagingDir};
 use crate::app::url_guard::validate_custom_source;
 use crate::errors::AppError;
 
@@ -274,12 +275,6 @@ pub fn plan_macos_update(simulated_build: Option<u64>) -> Result<MacUpdateReport
     })
 }
 
-fn staging_dir() -> std::path::PathBuf {
-    std::env::temp_dir()
-        .join("codex-app-manager")
-        .join("staging")
-}
-
 fn strategy_label(strategy: &UpdateStrategy) -> String {
     match strategy {
         UpdateStrategy::Delta { from_build } => format!("delta-from-{from_build}"),
@@ -316,7 +311,7 @@ fn preflight_mac_disk_with_available<F>(plan: &UpdatePlan, available: F) -> Resu
 where
     F: Fn(&Path) -> Result<Option<u64>, AppError>,
 {
-    let staging = staging_dir();
+    let staging = staging::staging_root();
     let need = mac_space_budget(plan);
     if let Some(free) = available(&staging)? {
         if free < need {
@@ -375,6 +370,7 @@ fn quit_codex_gracefully() -> Result<(), AppError> {
 }
 
 fn download_and_verify(
+    staging: &Path,
     url: &str,
     size: u64,
     max_size: u64,
@@ -388,7 +384,7 @@ fn download_and_verify(
         )));
     }
     let file_name = url.rsplit('/').next().unwrap_or("payload.bin");
-    let dest = staging_dir().join(file_name);
+    let dest = staging.join(file_name);
     let source = host_of(url);
 
     let already = std::fs::metadata(&dest)
@@ -471,13 +467,25 @@ pub fn stage_macos_update(simulated_build: Option<u64>) -> Result<MacStageReport
         .ed_signature
         .clone()
         .ok_or_else(|| AppError::Engine("appcast enclosure missing edSignature".to_string()))?;
-    let dest = download_and_verify(
+    let staging = staging::create_unique_staging("update")?;
+    let result = download_and_verify(
+        staging.path(),
         &plan.download_url,
         plan.download_size,
         max_bytes_for_strategy(&plan.strategy),
         &signature,
         &no_progress,
-    )?;
+    );
+    let dest = match result {
+        Ok(dest) => {
+            let _ = staging.keep();
+            dest
+        }
+        Err(err) => {
+            staging.discard();
+            return Err(err);
+        }
+    };
 
     Ok(MacStageReport {
         up_to_date: false,
@@ -610,6 +618,7 @@ fn reconstruct_full(
         AppError::Engine("appcast full enclosure missing edSignature".to_string())
     })?;
     let staged = download_and_verify(
+        work,
         &latest.full.url,
         latest.full.length,
         codex_mac_engine::limits::MAX_PACKAGE_BYTES,
@@ -710,154 +719,172 @@ pub fn perform_macos_update(
     preflight_mac_disk(&plan)?;
 
     // 1) Set up same-volume staging for the reconstructed bundle + backup.
-    let work = staging_dir();
+    let staging = staging::create_unique_staging("update")?;
+    let work = staging.path().to_path_buf();
     let out_app = work.join("Codex.app");
     let backup = work.join("backup-Codex.app");
     let _ = std::fs::remove_dir_all(&out_app);
     let _ = std::fs::remove_dir_all(&backup);
-
-    // 2) Reconstruct the new bundle into out_app. Prefer a delta when the tool is
-    //    present; fall back to the appcast's full package when the tool is missing
-    //    OR the delta fails to apply (modified basis, tool/patch version mismatch,
-    //    …). The full enclosure is always present in the same appcast entry and
-    //    needs no tool, so a recoverable delta failure no longer fails the update.
-    let want_delta = matches!(plan.strategy, UpdateStrategy::Delta { .. });
-    let effective_strategy = if want_delta {
-        if let Some(tool) = binary_delta.as_deref() {
-            let sig = plan
-                .ed_signature
-                .clone()
-                .ok_or_else(|| AppError::Engine("appcast delta missing edSignature".to_string()))?;
-            let staged = download_and_verify(
-                &plan.download_url,
-                plan.download_size,
-                codex_mac_engine::limits::MAX_DELTA_BYTES,
-                &sig,
-                progress,
-            )?;
-            match apply_delta(tool, &install_path, &out_app, &staged) {
-                Ok(()) => strategy_label(&plan.strategy),
-                Err(delta_err) => {
-                    reconstruct_full(&appcast, &work, &out_app, progress)?;
-                    format!("full (delta 应用失败回退: {delta_err})")
+    let mut keep_staging = false;
+    let perform_result = (|| -> Result<MacPerformReport, AppError> {
+        // 2) Reconstruct the new bundle into out_app. Prefer a delta when the tool is
+        //    present; fall back to the appcast's full package when the tool is missing
+        //    OR the delta fails to apply (modified basis, tool/patch version mismatch,
+        //    …). The full enclosure is always present in the same appcast entry and
+        //    needs no tool, so a recoverable delta failure no longer fails the update.
+        let want_delta = matches!(plan.strategy, UpdateStrategy::Delta { .. });
+        let effective_strategy = if want_delta {
+            if let Some(tool) = binary_delta.as_deref() {
+                let sig = plan.ed_signature.clone().ok_or_else(|| {
+                    AppError::Engine("appcast delta missing edSignature".to_string())
+                })?;
+                let staged = download_and_verify(
+                    &work,
+                    &plan.download_url,
+                    plan.download_size,
+                    codex_mac_engine::limits::MAX_DELTA_BYTES,
+                    &sig,
+                    progress,
+                )?;
+                match apply_delta(tool, &install_path, &out_app, &staged) {
+                    Ok(()) => strategy_label(&plan.strategy),
+                    Err(delta_err) => {
+                        reconstruct_full(&appcast, &work, &out_app, progress)?;
+                        format!("full (delta 应用失败回退: {delta_err})")
+                    }
                 }
+            } else {
+                reconstruct_full(&appcast, &work, &out_app, progress)?;
+                "full (delta 工具缺失，回退全量)".to_string()
             }
         } else {
             reconstruct_full(&appcast, &work, &out_app, progress)?;
-            "full (delta 工具缺失，回退全量)".to_string()
-        }
-    } else {
-        reconstruct_full(&appcast, &work, &out_app, progress)?;
-        "full".to_string()
-    };
-
-    // 3) gate the reconstructed bundle before it touches the install root.
-    gate_reconstructed(&out_app)
-        .map_err(|e| AppError::Engine(format!("codesign 闸失败（拒绝替换）: {e}")))?;
-
-    // 4a) pre-flight the atomic-swap precondition BEFORE quitting Codex, so a
-    //     cross-volume staging dir fails fast WITHOUT closing the user's app.
-    let install_parent = install_path.parent().unwrap_or(install_path.as_path());
-    if !codex_mac_engine::swap::same_volume(&out_app, install_parent) {
-        return Err(AppError::Engine(
-            "暂存目录与安装根不在同一卷，无法原子替换：请确保 TMPDIR 与安装根同卷".to_string(),
-        ));
-    }
-
-    // 4b) graceful quit (never force-kill), then 5) atomic same-volume swap. If
-    //     the swap fails after the quit, swap_in_place has restored the old
-    //     bundle in place — bring the user's app back before surfacing the error.
-    let was_running = codex_running();
-    quit_codex_gracefully()?;
-    if let Err(err) = swap_in_place(&install_path, &out_app, &backup) {
-        if was_running {
-            let _ = relaunch(&install_path);
-        }
-        return Err(AppError::Engine(err.to_string()));
-    }
-
-    // 6) filesystem health check on the installed root.
-    let healthy = sys::installed_codex_build_at_path(&installed.path)
-        .map(|(_, build)| build == plan.latest_build)
-        .unwrap_or(false)
-        && gate_reconstructed(&install_path).is_ok();
-
-    if healthy {
-        // The new bundle is authentic + correct-version; record provenance. If
-        // the store can't be written (disk full / unwritable data dir), the
-        // update still succeeded — but surface it, since status would otherwise
-        // keep classifying this now-manager install as "external".
-        let mut store = ProvenanceStore::load();
-        store.record(
-            installed.path.clone(),
-            plan.latest_build,
-            "manager-installed",
-        );
-        let save_warning = match store.save() {
-            Ok(()) => None,
-            Err(e) => Some(format!("托管记录保存失败（{e}），安装暂仍会被识别为外部")),
+            "full".to_string()
         };
 
-        if was_running {
-            // Relaunch BEFORE discarding the backup: if `open` fails we keep the
-            // backup as a recovery path instead of claiming a clean success. We
-            // do NOT downgrade a healthy, gated install just because auto-launch
-            // failed — the user can launch it manually.
-            if let Err(err) = relaunch(&install_path) {
-                return Ok(MacPerformReport {
-                    up_to_date: false,
-                    from_build: installed.build,
-                    to_build: plan.latest_build,
-                    strategy: effective_strategy.clone(),
-                    installed_path: installed.path,
-                    verified: true,
-                    relaunched: false,
-                    relaunch_failed: true,
-                    rolled_back: false,
-                    warning: Some(match &save_warning {
-                        Some(note) => format!("旧版本备份暂留于 {}；{note}", backup.display()),
-                        None => format!("旧版本备份暂留于 {}", backup.display()),
-                    }),
-                    message: format!(
-                        "已替换为 build {}，但自动重启失败（{err}）：请手动启动 Codex",
-                        plan.latest_build
-                    ),
-                });
-            }
+        // 3) gate the reconstructed bundle before it touches the install root.
+        gate_reconstructed(&out_app)
+            .map_err(|e| AppError::Engine(format!("codesign 闸失败（拒绝替换）: {e}")))?;
+
+        // 4a) pre-flight the atomic-swap precondition BEFORE quitting Codex, so a
+        //     cross-volume staging dir fails fast WITHOUT closing the user's app.
+        let install_parent = install_path.parent().unwrap_or(install_path.as_path());
+        if !codex_mac_engine::swap::same_volume(&out_app, install_parent) {
+            return Err(AppError::Engine(
+                "暂存目录与安装根不在同一卷，无法原子替换：请确保 TMPDIR 与安装根同卷".to_string(),
+            ));
         }
 
-        // Not running, or relaunched cleanly → the backup is no longer needed.
-        let _ = std::fs::remove_dir_all(&backup);
-        Ok(MacPerformReport {
-            up_to_date: false,
-            from_build: installed.build,
-            to_build: plan.latest_build,
-            strategy: effective_strategy.clone(),
-            installed_path: installed.path,
-            verified: true,
-            relaunched: was_running,
-            relaunch_failed: false,
-            rolled_back: false,
-            warning: save_warning,
-            message: format!("已更新 build {} → {}", installed.build, plan.latest_build),
-        })
-    } else {
-        rollback(&install_path, &backup)
-            .map_err(|e| AppError::Engine(format!("回滚失败（需人工介入）: {e}")))?;
-        let relaunched = was_running && relaunch(&install_path).is_ok();
-        Ok(MacPerformReport {
-            up_to_date: false,
-            from_build: installed.build,
-            to_build: plan.latest_build,
-            strategy: effective_strategy.clone(),
-            installed_path: installed.path,
-            verified: true,
-            relaunched,
-            relaunch_failed: false,
-            rolled_back: true,
-            warning: None,
-            message: "新版本健康检查未通过，已回滚到旧版本".to_string(),
-        })
+        // 4b) graceful quit (never force-kill), then 5) atomic same-volume swap. If
+        //     the swap fails after the quit, swap_in_place has restored the old
+        //     bundle in place — bring the user's app back before surfacing the error.
+        let was_running = codex_running();
+        quit_codex_gracefully()?;
+        if let Err(err) = swap_in_place(&install_path, &out_app, &backup) {
+            if was_running {
+                let _ = relaunch(&install_path);
+            }
+            return Err(AppError::Engine(err.to_string()));
+        }
+
+        // 6) filesystem health check on the installed root.
+        let healthy = sys::installed_codex_build_at_path(&installed.path)
+            .map(|(_, build)| build == plan.latest_build)
+            .unwrap_or(false)
+            && gate_reconstructed(&install_path).is_ok();
+
+        if healthy {
+            // The new bundle is authentic + correct-version; record provenance. If
+            // the store can't be written (disk full / unwritable data dir), the
+            // update still succeeded — but surface it, since status would otherwise
+            // keep classifying this now-manager install as "external".
+            let mut store = ProvenanceStore::load();
+            store.record(
+                installed.path.clone(),
+                plan.latest_build,
+                "manager-installed",
+            );
+            let save_warning = match store.save() {
+                Ok(()) => None,
+                Err(e) => Some(format!("托管记录保存失败（{e}），安装暂仍会被识别为外部")),
+            };
+
+            if was_running {
+                // Relaunch BEFORE discarding the backup: if `open` fails we keep the
+                // backup as a recovery path instead of claiming a clean success. We
+                // do NOT downgrade a healthy, gated install just because auto-launch
+                // failed — the user can launch it manually.
+                if let Err(err) = relaunch(&install_path) {
+                    keep_staging = true;
+                    return Ok(MacPerformReport {
+                        up_to_date: false,
+                        from_build: installed.build,
+                        to_build: plan.latest_build,
+                        strategy: effective_strategy.clone(),
+                        installed_path: installed.path.clone(),
+                        verified: true,
+                        relaunched: false,
+                        relaunch_failed: true,
+                        rolled_back: false,
+                        warning: Some(match &save_warning {
+                            Some(note) => format!("旧版本备份暂留于 {}；{note}", backup.display()),
+                            None => format!("旧版本备份暂留于 {}", backup.display()),
+                        }),
+                        message: format!(
+                            "已替换为 build {}，但自动重启失败（{err}）：请手动启动 Codex",
+                            plan.latest_build
+                        ),
+                    });
+                }
+            }
+
+            // Not running, or relaunched cleanly → the backup is no longer needed.
+            let _ = std::fs::remove_dir_all(&backup);
+            Ok(MacPerformReport {
+                up_to_date: false,
+                from_build: installed.build,
+                to_build: plan.latest_build,
+                strategy: effective_strategy.clone(),
+                installed_path: installed.path.clone(),
+                verified: true,
+                relaunched: was_running,
+                relaunch_failed: false,
+                rolled_back: false,
+                warning: save_warning,
+                message: format!("已更新 build {} → {}", installed.build, plan.latest_build),
+            })
+        } else {
+            rollback(&install_path, &backup)
+                .map_err(|e| AppError::Engine(format!("回滚失败（需人工介入）: {e}")))?;
+            let relaunched = was_running && relaunch(&install_path).is_ok();
+            Ok(MacPerformReport {
+                up_to_date: false,
+                from_build: installed.build,
+                to_build: plan.latest_build,
+                strategy: effective_strategy.clone(),
+                installed_path: installed.path.clone(),
+                verified: true,
+                relaunched,
+                relaunch_failed: false,
+                rolled_back: true,
+                warning: None,
+                message: "新版本健康检查未通过，已回滚到旧版本".to_string(),
+            })
+        }
+    })();
+    match perform_result {
+        Ok(report) => {
+            if keep_staging {
+                let _ = staging.keep();
+            } else {
+                staging.discard();
+            }
+            Ok(report)
+        }
+        Err(err) => {
+            staging.discard();
+            Err(err)
+        }
     }
 }
 
@@ -951,22 +978,44 @@ pub fn install_macos(progress: &dyn Fn(DownloadProgress)) -> Result<MacInstallSt
         .ok_or_else(|| AppError::Engine("appcast had no items".to_string()))?;
     preflight_mac_disk(&plan)?;
 
-    let work = staging_dir();
-    let out_app = work.join("Codex.app");
+    let staging = staging::create_unique_staging("update")?;
+    let install_result =
+        install_macos_in_staging(&appcast, &install_dir, &install_path, &staging, progress);
+    match install_result {
+        Ok(status) => {
+            staging.discard();
+            Ok(status)
+        }
+        Err(err) => {
+            staging.discard();
+            Err(err)
+        }
+    }
+}
+
+fn install_macos_in_staging(
+    appcast: &Appcast,
+    install_dir: &Path,
+    install_path: &Path,
+    staging: &StagingDir,
+    progress: &dyn Fn(DownloadProgress),
+) -> Result<MacInstallStatus, AppError> {
+    let work = staging.path();
+    let out_app = staging.join("Codex.app");
     let _ = std::fs::remove_dir_all(&out_app);
 
     // Full package only — no basis bundle to delta against.
-    reconstruct_full(&appcast, &work, &out_app, progress)?;
+    reconstruct_full(appcast, work, &out_app, progress)?;
     gate_reconstructed(&out_app)
         .map_err(|e| AppError::Engine(format!("codesign 闸失败（拒绝安装）: {e}")))?;
 
-    if !codex_mac_engine::swap::same_volume(&out_app, &install_dir) {
+    if !codex_mac_engine::swap::same_volume(&out_app, install_dir) {
         return Err(AppError::Engine(format!(
             "暂存目录与 {} 不在同一卷,无法安装",
             install_dir.display()
         )));
     }
-    std::fs::rename(&out_app, &install_path)
+    std::fs::rename(&out_app, install_path)
         .map_err(|e| AppError::Engine(format!("写入 {} 失败: {e}", install_dir.display())))?;
 
     if let Some((path, build)) = sys::installed_codex_build() {

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -6,5 +6,6 @@ pub mod oplock;
 pub mod paths;
 pub mod provenance;
 pub mod settings_store;
+pub mod staging;
 pub mod url_guard;
 pub mod win_update;

--- a/src-tauri/src/app/oplock.rs
+++ b/src-tauri/src/app/oplock.rs
@@ -47,6 +47,7 @@ pub enum OperationError {
     Lock(String),
 }
 
+#[derive(Clone)]
 pub struct OperationManager {
     inner: Arc<Mutex<Inner>>,
     stale_after_secs: u64,
@@ -159,8 +160,24 @@ impl OperationManager {
         let Ok(mut inner) = self.inner.lock() else {
             return false;
         };
-        let _ = self.reclaim_stale_detached(&mut inner);
-        inner.active.is_some()
+        if self.reclaim_stale_detached(&mut inner).is_err() {
+            return true;
+        }
+        if inner.active.is_some() {
+            return true;
+        }
+        let Ok(lock_file) = Self::lock_file_mut(&mut inner) else {
+            return false;
+        };
+        match lock_file.try_lock_exclusive() {
+            Ok(true) => {
+                let _ = lock_file.unlock();
+                false
+            }
+            Ok(false) => true,
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => true,
+            Err(_) => false,
+        }
     }
 
     fn begin_inner(
@@ -364,6 +381,7 @@ mod tests {
         let _guard = first.begin(OperationKind::Update).unwrap();
         let second = OperationManager::new(path.clone());
 
+        assert!(second.is_busy());
         assert!(matches!(
             second.begin(OperationKind::Install),
             Err(OperationError::BusyOtherProcess)

--- a/src-tauri/src/app/staging.rs
+++ b/src-tauri/src/app/staging.rs
@@ -1,0 +1,172 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use uuid::Uuid;
+
+use crate::app::oplock::OperationManager;
+use crate::errors::AppError;
+
+const STALE_AFTER: Duration = Duration::from_secs(30 * 60);
+
+pub struct StagingDir {
+    root: PathBuf,
+}
+
+impl StagingDir {
+    pub fn path(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn join(&self, rel: &str) -> PathBuf {
+        self.root.join(rel)
+    }
+
+    pub fn discard(self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+
+    pub fn keep(self) -> PathBuf {
+        self.root
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CleanupSummary {
+    pub scanned: usize,
+    pub removed: usize,
+    pub failed: usize,
+    pub skipped_busy: bool,
+}
+
+pub fn staging_root() -> PathBuf {
+    std::env::temp_dir()
+        .join("codex-app-manager")
+        .join("staging")
+}
+
+pub fn create_unique_staging(prefix: &str) -> Result<StagingDir, AppError> {
+    let root = staging_root().join(format!("{prefix}-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&root)
+        .map_err(|e| AppError::Internal(format!("创建暂存目录失败: {e}")))?;
+    set_owner_only(&root)?;
+    Ok(StagingDir { root })
+}
+
+pub fn cleanup_stale_staging(ops: &OperationManager) -> CleanupSummary {
+    let mut summary = CleanupSummary::default();
+    if ops.is_busy() {
+        summary.skipped_busy = true;
+        return summary;
+    }
+
+    let root = staging_root();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return summary;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_update_dir = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("update-"));
+        if !is_update_dir || !path.is_dir() {
+            continue;
+        }
+        summary.scanned += 1;
+        if !is_stale(&path, now) {
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => summary.removed += 1,
+            Err(_) => summary.failed += 1,
+        }
+    }
+    summary
+}
+
+fn is_stale(path: &Path, now: SystemTime) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return false;
+    };
+    now.duration_since(modified)
+        .map(|age| age >= STALE_AFTER)
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn set_owner_only(path: &Path) -> Result<(), AppError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let permissions = std::fs::Permissions::from_mode(0o700);
+    std::fs::set_permissions(path, permissions)
+        .map_err(|e| AppError::Internal(format!("设置暂存目录权限失败: {e}")))
+}
+
+#[cfg(not(unix))]
+fn set_owner_only(_path: &Path) -> Result<(), AppError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cleanup_stale_staging, create_unique_staging};
+    use crate::app::oplock::{OperationKind, OperationManager};
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+    fn lock_path(name: &str) -> std::path::PathBuf {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test-data")
+            .join(format!("staging-{name}-{}-{id}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("operation.lock")
+    }
+
+    #[test]
+    fn create_unique_staging_uses_distinct_update_dirs() {
+        let first = create_unique_staging("update").unwrap();
+        let second = create_unique_staging("update").unwrap();
+        assert_ne!(first.path(), second.path());
+        assert!(first.path().is_dir());
+        assert!(second.path().is_dir());
+        assert!(first
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap()
+            .starts_with("update-"));
+        first.discard();
+        second.discard();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_unique_staging_is_owner_only_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let staging = create_unique_staging("update").unwrap();
+        let mode = fs::metadata(staging.path()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+        staging.discard();
+    }
+
+    #[test]
+    fn cleanup_skips_everything_while_operation_is_busy() {
+        let staging = create_unique_staging("update").unwrap();
+        let manager = OperationManager::new(lock_path("busy"));
+        let _guard = manager.begin(OperationKind::Update).unwrap();
+        let summary = cleanup_stale_staging(&manager);
+        assert!(summary.skipped_busy);
+        assert!(staging.path().exists());
+        staging.discard();
+    }
+}

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -24,6 +24,7 @@ use codex_win_engine::{
 };
 
 use crate::app::provenance::ProvenanceStore;
+use crate::app::staging;
 use crate::domain::manifest::MirrorEndpoints;
 use crate::domain::settings::AppSettings;
 use crate::errors::AppError;
@@ -234,14 +235,8 @@ fn read_windows_release(endpoints: &MirrorEndpoints) -> Result<(WindowsRelease, 
     Ok((release, sha256))
 }
 
-fn staging_dir() -> PathBuf {
-    std::env::temp_dir()
-        .join("codex-app-manager")
-        .join("windows-staging")
-}
-
-fn staged_msix_path(release: &WindowsRelease) -> PathBuf {
-    staging_dir().join(format!("{}.msix", release.package_moniker))
+fn staged_msix_path(staging: &std::path::Path, release: &WindowsRelease) -> PathBuf {
+    staging.join(format!("{}.msix", release.package_moniker))
 }
 
 fn route_label(plan: &WindowsUpdatePlan) -> String {
@@ -411,117 +406,130 @@ pub fn stage_windows_update_with_install_mode(
         });
     }
 
-    let dest = staged_msix_path(&report.release);
-    let expected_size = report.release.content_length.unwrap_or(0);
-    if expected_size > MAX_PACKAGE_BYTES {
-        return Err(AppError::Engine(format!(
-            "MSIX content length {expected_size} exceeds {} byte limit",
-            MAX_PACKAGE_BYTES
-        )));
-    }
-    let expected_sha = report.plan.sha256.clone();
-    let source = host_of(&report.package_url);
-
-    let cached_ok = dest.exists()
-        && sha256_file(&dest)
-            .map(|actual| actual.eq_ignore_ascii_case(&expected_sha))
-            .unwrap_or(false);
-    if !cached_ok {
-        if dest.exists() {
-            let _ = std::fs::remove_file(&dest);
-        }
-        download_to_with_progress_bounded(
-            &report.package_url,
-            &dest,
-            MAX_PACKAGE_BYTES,
-            &|downloaded| {
-                progress(DownloadProgress {
-                    downloaded,
-                    total: expected_size,
-                    source: source.clone(),
-                });
-            },
-        )
-        .map_err(engine_err)?;
-    }
-
-    let actual_size = std::fs::metadata(&dest)
-        .map_err(|e| AppError::Engine(format!("read staged MSIX metadata: {e}")))?
-        .len();
-    if expected_size > 0 && actual_size != expected_size {
-        return Err(AppError::Engine(format!(
-            "MSIX size mismatch: {actual_size} != {expected_size}"
-        )));
-    }
-    if actual_size > MAX_PACKAGE_BYTES {
-        return Err(AppError::Engine(format!(
-            "MSIX size {actual_size} exceeds {} byte limit",
-            MAX_PACKAGE_BYTES
-        )));
-    }
-    progress(DownloadProgress {
-        downloaded: actual_size,
-        total: if expected_size > 0 {
-            expected_size
-        } else {
-            actual_size
-        },
-        source,
-    });
-
-    let actual_sha = sha256_file(&dest).map_err(engine_err)?;
-    if !actual_sha.eq_ignore_ascii_case(&expected_sha) {
-        return Err(AppError::Engine(format!(
-            "MSIX sha256 mismatch: {actual_sha} != {expected_sha}"
-        )));
-    }
-
-    let authenticode = verify_openai_authenticode(&dest).map_err(engine_err)?;
-    if !authenticode.is_valid_openai() {
-        return Err(AppError::Engine(format!(
-            "MSIX Authenticode verification failed: status={}, subject={}",
-            authenticode.status, authenticode.subject
-        )));
-    }
-
-    let identity = read_msix_identity(&dest).map_err(engine_err)?;
-    validate_codex_identity(
-        &identity,
-        &report.release.version,
-        report.release.architecture.as_deref(),
-    )
-    .map_err(engine_err)?;
-    if let Some(expected_identity) = report.release.package_identity.as_deref() {
-        if identity.name != expected_identity {
+    let staging = staging::create_unique_staging("update")?;
+    let stage_result = (|| -> Result<WinStageReport, AppError> {
+        let dest = staged_msix_path(staging.path(), &report.release);
+        let expected_size = report.release.content_length.unwrap_or(0);
+        if expected_size > MAX_PACKAGE_BYTES {
             return Err(AppError::Engine(format!(
-                "MSIX identity {} does not match manifest package identity {}",
-                identity.name, expected_identity
+                "MSIX content length {expected_size} exceeds {} byte limit",
+                MAX_PACKAGE_BYTES
             )));
         }
+        let expected_sha = report.plan.sha256.clone();
+        let source = host_of(&report.package_url);
+
+        let cached_ok = dest.exists()
+            && sha256_file(&dest)
+                .map(|actual| actual.eq_ignore_ascii_case(&expected_sha))
+                .unwrap_or(false);
+        if !cached_ok {
+            if dest.exists() {
+                let _ = std::fs::remove_file(&dest);
+            }
+            download_to_with_progress_bounded(
+                &report.package_url,
+                &dest,
+                MAX_PACKAGE_BYTES,
+                &|downloaded| {
+                    progress(DownloadProgress {
+                        downloaded,
+                        total: expected_size,
+                        source: source.clone(),
+                    });
+                },
+            )
+            .map_err(engine_err)?;
+        }
+
+        let actual_size = std::fs::metadata(&dest)
+            .map_err(|e| AppError::Engine(format!("read staged MSIX metadata: {e}")))?
+            .len();
+        if expected_size > 0 && actual_size != expected_size {
+            return Err(AppError::Engine(format!(
+                "MSIX size mismatch: {actual_size} != {expected_size}"
+            )));
+        }
+        if actual_size > MAX_PACKAGE_BYTES {
+            return Err(AppError::Engine(format!(
+                "MSIX size {actual_size} exceeds {} byte limit",
+                MAX_PACKAGE_BYTES
+            )));
+        }
+        progress(DownloadProgress {
+            downloaded: actual_size,
+            total: if expected_size > 0 {
+                expected_size
+            } else {
+                actual_size
+            },
+            source,
+        });
+
+        let actual_sha = sha256_file(&dest).map_err(engine_err)?;
+        if !actual_sha.eq_ignore_ascii_case(&expected_sha) {
+            return Err(AppError::Engine(format!(
+                "MSIX sha256 mismatch: {actual_sha} != {expected_sha}"
+            )));
+        }
+
+        let authenticode = verify_openai_authenticode(&dest).map_err(engine_err)?;
+        if !authenticode.is_valid_openai() {
+            return Err(AppError::Engine(format!(
+                "MSIX Authenticode verification failed: status={}, subject={}",
+                authenticode.status, authenticode.subject
+            )));
+        }
+
+        let identity = read_msix_identity(&dest).map_err(engine_err)?;
+        validate_codex_identity(
+            &identity,
+            &report.release.version,
+            report.release.architecture.as_deref(),
+        )
+        .map_err(engine_err)?;
+        if let Some(expected_identity) = report.release.package_identity.as_deref() {
+            if identity.name != expected_identity {
+                return Err(AppError::Engine(format!(
+                    "MSIX identity {} does not match manifest package identity {}",
+                    identity.name, expected_identity
+                )));
+            }
+        }
+
+        let mut notes = report.plan.warnings.clone();
+        notes.push(
+            "MSIX is staged and verified; install execution will sideload first and fall back transparently to the portable path if sideloading fails."
+                .to_string(),
+        );
+
+        Ok(WinStageReport {
+            up_to_date: false,
+            route,
+            latest_version: report.plan.latest_version,
+            package_moniker: report.plan.package_moniker,
+            download_size: actual_size,
+            staged_path: Some(dest.to_string_lossy().into_owned()),
+            sha256: actual_sha,
+            hash_verified: true,
+            authenticode: Some(authenticode),
+            identity: Some(identity),
+            identity_verified: true,
+            install_ready: true,
+            portable_fallback_ready: report.plan.portable_fallback_ready,
+            notes,
+        })
+    })();
+    match stage_result {
+        Ok(report) => {
+            let _ = staging.keep();
+            Ok(report)
+        }
+        Err(err) => {
+            staging.discard();
+            Err(err)
+        }
     }
-
-    let mut notes = report.plan.warnings.clone();
-    notes.push(
-        "MSIX is staged and verified; install execution will sideload first and fall back transparently to the portable path if sideloading fails."
-            .to_string(),
-    );
-
-    Ok(WinStageReport {
-        up_to_date: false,
-        route,
-        latest_version: report.plan.latest_version,
-        package_moniker: report.plan.package_moniker,
-        download_size: actual_size,
-        staged_path: Some(dest.to_string_lossy().into_owned()),
-        sha256: actual_sha,
-        hash_verified: true,
-        authenticode: Some(authenticode),
-        identity: Some(identity),
-        identity_verified: true,
-        install_ready: true,
-        portable_fallback_ready: report.plan.portable_fallback_ready,
-        notes,
-    })
 }
 
 pub fn auto_stage_windows_update(

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -12,14 +12,15 @@ use serde::{Deserialize, Serialize};
 
 use codex_win_engine::{
     cancel_active_download, close_codex_gracefully_for_root, detect_installed_codex,
-    detect_portable_install, download_to_with_progress, fetch_text, find_msix_sha256,
-    install_msix_sideload, install_portable_from_msix, parse_manifest, pause_active_download,
-    plan_update, precheck_msix_dependencies, probe_capabilities, purge_codex_user_data,
-    read_msix_identity, remove_msix_package, sha256_file, uninstall_portable,
-    validate_codex_identity, verify_msix_health, verify_openai_authenticode, version_key,
-    AuthenticodeReport, CapabilityState, InstalledWindowsCodex, MsixHealthReport, MsixIdentity,
-    MsixRemoveReport, MsixSideloadReport, PortableInstallReport, PortableUninstallReport,
-    WinCapabilityReport, WinInstallRoute, WindowsRelease, WindowsUpdatePlan,
+    detect_portable_install, download_to_with_progress_bounded, fetch_text, find_msix_sha256,
+    install_msix_sideload, install_portable_from_msix, limits::MAX_PACKAGE_BYTES, parse_manifest,
+    pause_active_download, plan_update, precheck_msix_dependencies, probe_capabilities,
+    purge_codex_user_data, read_msix_identity, remove_msix_package, sha256_file,
+    uninstall_portable, validate_codex_identity, verify_msix_health, verify_openai_authenticode,
+    version_key, AuthenticodeReport, CapabilityState, InstalledWindowsCodex, MsixHealthReport,
+    MsixIdentity, MsixRemoveReport, MsixSideloadReport, PortableInstallReport,
+    PortableUninstallReport, WinCapabilityReport, WinInstallRoute, WindowsRelease,
+    WindowsUpdatePlan,
 };
 
 use crate::app::provenance::ProvenanceStore;
@@ -175,11 +176,61 @@ fn portable_fallback_ready(_endpoints: &MirrorEndpoints) -> bool {
     true
 }
 
+fn msix_stem(file_name: &str) -> Option<&str> {
+    let base = file_name.rsplit('/').find(|segment| !segment.is_empty())?;
+    let suffix_start = base.len().checked_sub(5)?;
+    let suffix = base.get(suffix_start..)?;
+    if suffix.eq_ignore_ascii_case(".msix") {
+        base.get(..suffix_start)
+    } else {
+        None
+    }
+}
+
+fn package_file_name_from_url(package_url: &str) -> Result<String, AppError> {
+    let parsed = url::Url::parse(package_url)
+        .map_err(|e| AppError::Engine(format!("invalid Windows package URL: {e}")))?;
+    parsed
+        .path()
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .map(|segment| segment.to_string())
+        .ok_or_else(|| AppError::Engine("Windows package URL has no file name".to_string()))
+}
+
+fn bind_manifest_checksums(
+    release: &WindowsRelease,
+    checksums_text: &str,
+    package_url: &str,
+) -> Result<String, AppError> {
+    let package_file = package_file_name_from_url(package_url)?;
+    let Some(url_moniker) = msix_stem(&package_file) else {
+        return Err(AppError::Engine(format!(
+            "Windows package URL does not end in .msix: {package_url}"
+        )));
+    };
+    if !url_moniker.eq_ignore_ascii_case(&release.package_moniker) {
+        return Err(AppError::Engine(format!(
+            "Windows manifest package moniker {} does not match URL artifact {}",
+            release.package_moniker, package_file
+        )));
+    }
+    if let Some(identity) = release.package_identity.as_deref() {
+        if identity != codex_win_engine::OPENAI_PACKAGE_IDENTITY {
+            return Err(AppError::Engine(format!(
+                "Windows manifest package identity {identity} does not match {}",
+                codex_win_engine::OPENAI_PACKAGE_IDENTITY
+            )));
+        }
+    }
+    find_msix_sha256(checksums_text, &release.package_moniker).map_err(engine_err)
+}
+
 fn read_windows_release(endpoints: &MirrorEndpoints) -> Result<(WindowsRelease, String), AppError> {
     let manifest_text = fetch_text(&endpoints.manifest_url).map_err(engine_err)?;
     let checksums_text = fetch_text(&endpoints.checksums_url).map_err(engine_err)?;
     let release = parse_manifest(&manifest_text).map_err(engine_err)?;
-    let sha256 = find_msix_sha256(&checksums_text, &release.package_moniker).map_err(engine_err)?;
+    let sha256 = bind_manifest_checksums(&release, &checksums_text, &endpoints.windows_msix_url)?;
     Ok((release, sha256))
 }
 
@@ -238,7 +289,8 @@ fn close_existing_codex_before_portable_fallback(
     settings: &AppSettings,
     previous_installed: Option<&InstalledWindowsCodex>,
 ) -> Result<(), AppError> {
-    if let Some(installed) = detect_installed_codex(PathBuf::from(&settings.install_root).as_path()) {
+    if let Some(installed) = detect_installed_codex(PathBuf::from(&settings.install_root).as_path())
+    {
         if installed.source == "msix" {
             close_codex_gracefully_for_root(30, PathBuf::from(&installed.path).as_path())
                 .map_err(engine_err)?;
@@ -361,6 +413,12 @@ pub fn stage_windows_update_with_install_mode(
 
     let dest = staged_msix_path(&report.release);
     let expected_size = report.release.content_length.unwrap_or(0);
+    if expected_size > MAX_PACKAGE_BYTES {
+        return Err(AppError::Engine(format!(
+            "MSIX content length {expected_size} exceeds {} byte limit",
+            MAX_PACKAGE_BYTES
+        )));
+    }
     let expected_sha = report.plan.sha256.clone();
     let source = host_of(&report.package_url);
 
@@ -372,13 +430,18 @@ pub fn stage_windows_update_with_install_mode(
         if dest.exists() {
             let _ = std::fs::remove_file(&dest);
         }
-        download_to_with_progress(&report.package_url, &dest, &|downloaded| {
-            progress(DownloadProgress {
-                downloaded,
-                total: expected_size,
-                source: source.clone(),
-            });
-        })
+        download_to_with_progress_bounded(
+            &report.package_url,
+            &dest,
+            MAX_PACKAGE_BYTES,
+            &|downloaded| {
+                progress(DownloadProgress {
+                    downloaded,
+                    total: expected_size,
+                    source: source.clone(),
+                });
+            },
+        )
         .map_err(engine_err)?;
     }
 
@@ -388,6 +451,12 @@ pub fn stage_windows_update_with_install_mode(
     if expected_size > 0 && actual_size != expected_size {
         return Err(AppError::Engine(format!(
             "MSIX size mismatch: {actual_size} != {expected_size}"
+        )));
+    }
+    if actual_size > MAX_PACKAGE_BYTES {
+        return Err(AppError::Engine(format!(
+            "MSIX size {actual_size} exceeds {} byte limit",
+            MAX_PACKAGE_BYTES
         )));
     }
     progress(DownloadProgress {
@@ -422,6 +491,14 @@ pub fn stage_windows_update_with_install_mode(
         report.release.architecture.as_deref(),
     )
     .map_err(engine_err)?;
+    if let Some(expected_identity) = report.release.package_identity.as_deref() {
+        if identity.name != expected_identity {
+            return Err(AppError::Engine(format!(
+                "MSIX identity {} does not match manifest package identity {}",
+                identity.name, expected_identity
+            )));
+        }
+    }
 
     let mut notes = report.plan.warnings.clone();
     notes.push(
@@ -562,7 +639,14 @@ pub fn perform_windows_update(
     settings: &AppSettings,
     confirm: bool,
 ) -> Result<WinPerformReport, AppError> {
-    perform_windows_update_with_install_mode(endpoints, settings, confirm, "msix", None, &no_progress)
+    perform_windows_update_with_install_mode(
+        endpoints,
+        settings,
+        confirm,
+        "msix",
+        None,
+        &no_progress,
+    )
 }
 
 pub fn perform_windows_update_with_install_mode(
@@ -826,7 +910,9 @@ pub fn win_install_status(settings: &AppSettings) -> WinInstallStatus {
         // Build-aware (matching the macOS path): a self-updated or path-reused
         // install no longer matches its record and reads as "external" so the
         // user is prompted to re-adopt rather than silently treated as managed.
-        Some(codex) if store.is_managed_build(&codex.path, version_key(&codex.version)) => "managed",
+        Some(codex) if store.is_managed_build(&codex.path, version_key(&codex.version)) => {
+            "managed"
+        }
         Some(_) => "external",
     }
     .to_string();
@@ -888,7 +974,10 @@ pub fn uninstall_windows_codex(
     // isn't an install we manage at this exact build. Path-only matching could
     // delete a path-reused external install or one left by a stale record —
     // more likely now that the install root is user-configurable.
-    if !store.is_managed_build(&installed_before.path, version_key(&installed_before.version)) {
+    if !store.is_managed_build(
+        &installed_before.path,
+        version_key(&installed_before.version),
+    ) {
         return Ok(WinUninstallReport {
             success: false,
             action: "external-not-managed".to_string(),
@@ -959,7 +1048,8 @@ pub fn uninstall_windows_codex(
 
 #[cfg(test)]
 mod tests {
-    use super::WinPerformAction;
+    use super::{bind_manifest_checksums, WinPerformAction};
+    use codex_win_engine::WindowsRelease;
 
     #[test]
     fn serializes_win_perform_actions_as_frontend_contract() {
@@ -984,5 +1074,63 @@ mod tests {
         for (action, expected) in cases {
             assert_eq!(serde_json::to_string(&action).unwrap(), expected);
         }
+    }
+
+    fn release() -> WindowsRelease {
+        WindowsRelease {
+            version: "26.602.3474.0".to_string(),
+            package_moniker: "OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0".to_string(),
+            architecture: Some("x64".to_string()),
+            content_length: Some(566_504_666),
+            etag: None,
+            store_product_id: Some("9PLM9XGG6VKS".to_string()),
+            package_identity: Some("OpenAI.Codex".to_string()),
+        }
+    }
+
+    #[test]
+    fn binds_manifest_checksums_to_url_moniker() {
+        let checksums = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.Msix
+";
+        let sha = bind_manifest_checksums(
+            &release(),
+            checksums,
+            "https://example.com/OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.Msix",
+        )
+        .unwrap();
+        assert_eq!(
+            sha,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn rejects_manifest_url_moniker_mismatch() {
+        let checksums = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.Msix
+";
+        let err = bind_manifest_checksums(
+            &release(),
+            checksums,
+            "https://example.com/OpenAI.Codex_26.602.3474.0_arm64__2p2nqsd0c76g0.Msix",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("does not match URL artifact"));
+    }
+
+    #[test]
+    fn rejects_manifest_identity_mismatch() {
+        let mut release = release();
+        release.package_identity = Some("OpenAI.Other".to_string());
+        let checksums = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.Msix
+";
+        assert!(bind_manifest_checksums(
+            &release,
+            checksums,
+            "https://example.com/OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0.Msix",
+        )
+        .is_err());
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -852,7 +852,7 @@ fn validate_external_http_url(url: &str) -> Result<(), AppError> {
 
 #[cfg(target_os = "macos")]
 fn open_external_url(url: &str) -> Result<(), String> {
-    std::process::Command::new("open")
+    std::process::Command::new("/usr/bin/open")
         .arg(url)
         .spawn()
         .map(|_| ())

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,7 +12,9 @@ use crate::app::mac_update::{
     plan_macos_update, stage_macos_update, uninstall_macos, MacInstallStatus, MacPerformReport,
     MacStageReport, MacUninstallReport, MacUpdateReport, PerformExpectation,
 };
-use crate::app::oplock::{OperationError, OperationGuard, OperationKind, OperationToken};
+use crate::app::oplock::{
+    OperationError, OperationGuard, OperationKind, OperationManager, OperationToken,
+};
 use crate::app::paths;
 use crate::app::provenance::ProvenanceStore;
 use crate::app::settings_store::AppSettings as PersistedAppSettings;
@@ -122,6 +124,42 @@ fn begin_guard(state: &ManagerState, kind: OperationKind) -> Result<OperationGua
         .begin(kind)
         .map_err(AppError::from)
         .map_err(Into::into)
+}
+
+struct DetachedGuard {
+    operations: OperationManager,
+    token: Option<OperationToken>,
+}
+
+impl DetachedGuard {
+    fn validate(state: &ManagerState, token: OperationToken) -> Result<Self, CommandError> {
+        let operations = state.operations.clone();
+        operations
+            .validate(&token)
+            .map_err(destructive_token_error)?;
+        Ok(Self {
+            operations,
+            token: Some(token),
+        })
+    }
+}
+
+impl Drop for DetachedGuard {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.take() {
+            let _ = self.operations.end(token);
+        }
+    }
+}
+
+fn destructive_token_error(err: OperationError) -> CommandError {
+    match err {
+        OperationError::InvalidToken => {
+            AppError::StaleExpectation("操作令牌无效或已过期，请重新检查后再确认".to_string())
+                .into()
+        }
+        other => AppError::from(other).into(),
+    }
 }
 
 fn refresh_config_health(state: &ManagerState) -> ConfigHealth {
@@ -372,6 +410,7 @@ pub async fn mac_perform_update(
     app: tauri::AppHandle,
     state: State<'_, ManagerState>,
     confirm: bool,
+    token: OperationToken,
     expected_from_build: u64,
     expected_to_build: u64,
     expected_path: String,
@@ -384,7 +423,7 @@ pub async fn mac_perform_update(
             AppError::Internal("拒绝执行：破坏性更新必须带显式 confirm".to_string()).into(),
         );
     }
-    let _op = begin_guard(&state, OperationKind::Update)?;
+    let _op = DetachedGuard::validate(&state, token)?;
     // Best-effort: a full-package update needs no delta tool, so don't reject the
     // whole operation when it's absent — only the delta branch requires it.
     let binary_delta = resolve_binary_delta(&app);
@@ -624,6 +663,23 @@ pub fn begin_operation(
 }
 
 #[tauri::command]
+pub fn arm_destructive(
+    state: State<'_, ManagerState>,
+    kind: OperationKind,
+) -> Result<OperationToken, CommandError> {
+    if !matches!(kind, OperationKind::Update | OperationKind::Uninstall) {
+        return Err(
+            AppError::Internal("仅 update/uninstall 操作可使用破坏性令牌".to_string()).into(),
+        );
+    }
+    state
+        .operations
+        .begin_detached(kind)
+        .map_err(AppError::from)
+        .map_err(Into::into)
+}
+
+#[tauri::command]
 pub fn end_operation(
     state: State<'_, ManagerState>,
     token: OperationToken,
@@ -728,6 +784,7 @@ pub fn win_reset_install_root(
 pub async fn mac_uninstall(
     state: State<'_, ManagerState>,
     confirm: bool,
+    token: OperationToken,
     keep_codex_home: bool,
 ) -> Result<MacUninstallReport, CommandError> {
     if !cfg!(target_os = "macos") {
@@ -736,7 +793,7 @@ pub async fn mac_uninstall(
     if !confirm {
         return Err(AppError::Internal("拒绝执行：卸载必须带显式 confirm".to_string()).into());
     }
-    let _op = begin_guard(&state, OperationKind::Uninstall)?;
+    let _op = DetachedGuard::validate(&state, token)?;
     tauri::async_runtime::spawn_blocking(move || uninstall_macos(keep_codex_home))
         .await
         .map_err(|e| AppError::Internal(format!("join: {e}")))?
@@ -960,6 +1017,7 @@ pub async fn win_perform_update(
     app: tauri::AppHandle,
     state: State<'_, ManagerState>,
     confirm: bool,
+    token: OperationToken,
     install_root: Option<String>,
     expected: Option<WinPerformExpectation>,
 ) -> Result<WinPerformReport, CommandError> {
@@ -971,7 +1029,7 @@ pub async fn win_perform_update(
             AppError::Internal("拒绝执行：Windows 更新必须带显式 confirm".to_string()).into(),
         );
     }
-    let _op = begin_guard(&state, OperationKind::Update)?;
+    let _op = DetachedGuard::validate(&state, token)?;
     let endpoints = windows_endpoints_for_settings(&state)?;
     let mut settings = windows_domain_settings_for_persisted(&state);
     // Validate (but don't yet persist) an explicitly chosen install root: it
@@ -1019,6 +1077,7 @@ pub async fn win_perform_update(
 pub async fn win_uninstall(
     state: State<'_, ManagerState>,
     confirm: bool,
+    token: OperationToken,
     purge_user_data: bool,
 ) -> Result<WinUninstallReport, CommandError> {
     if !matches!(state.target.os, OperatingSystem::Windows) {
@@ -1029,7 +1088,7 @@ pub async fn win_uninstall(
             AppError::Internal("拒绝执行：Windows 卸载必须带显式 confirm".to_string()).into(),
         );
     }
-    let _op = begin_guard(&state, OperationKind::Uninstall)?;
+    let _op = DetachedGuard::validate(&state, token)?;
     let settings = windows_domain_settings_for_persisted(&state);
     tauri::async_runtime::spawn_blocking(move || {
         uninstall_windows_codex(&settings, confirm, purge_user_data)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             commands::restore_config_backup,
             commands::reset_config,
             commands::begin_operation,
+            commands::arm_destructive,
             commands::end_operation,
             commands::confirm_quit,
             commands::win_default_install_root,
@@ -119,6 +120,16 @@ pub fn run() {
         .setup(|app| {
             #[cfg(target_os = "macos")]
             install_macos_menu(app)?;
+            let operations = app.state::<state::ManagerState>().operations.clone();
+            tauri::async_runtime::spawn_blocking(move || {
+                let summary = crate::app::staging::cleanup_stale_staging(&operations);
+                if summary.failed > 0 {
+                    eprintln!(
+                        "staging cleanup removed {} of {} stale dirs ({} failed)",
+                        summary.removed, summary.scanned, summary.failed
+                    );
+                }
+            });
             let health = app
                 .state::<state::ManagerState>()
                 .config_health

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -9,6 +9,8 @@ import type {
   MacPerformReport,
   MacUninstallReport,
   MacUpdateReport,
+  OperationKind,
+  OperationToken,
   WinInstallStatus,
   WinPerformReport,
   WinStageReport,
@@ -276,6 +278,12 @@ const WIN_FALLBACK_UNINSTALL: WinUninstallReport = {
 };
 
 export const managerApi = {
+  armDestructive(kind: OperationKind): Promise<OperationToken> {
+    if (!hasTauriRuntime()) {
+      return Promise.resolve(`browser-dev-token-${kind}`);
+    }
+    return invoke<OperationToken>("arm_destructive", { kind });
+  },
   macPlanUpdate(simulatedBuild?: number): Promise<MacUpdateReport> {
     if (!hasTauriRuntime()) {
       return Promise.resolve({ ...FALLBACK_PLAN, simulatedBuild: simulatedBuild ?? null });
@@ -289,7 +297,7 @@ export const managerApi = {
   // by a UI second confirmation before this is ever called. The expected target
   // (from/to build + install path the user confirmed) is sent so the backend can
   // refuse if reality drifted (appcast refresh / Codex self-update) since confirm.
-  macPerformUpdate(expected: {
+  async macPerformUpdate(expected: {
     fromBuild: number;
     toBuild: number;
     path: string;
@@ -309,8 +317,10 @@ export const managerApi = {
         message: "（浏览器开发态：真实替换仅在桌面 app 内执行）",
       });
     }
+    const token = await managerApi.armDestructive("update");
     return invoke<MacPerformReport>("mac_perform_update", {
       confirm: true,
+      token,
       expectedFromBuild: expected.fromBuild,
       expectedToBuild: expected.toBuild,
       expectedPath: expected.path,
@@ -470,7 +480,7 @@ export const managerApi = {
 
   // Destructive: remove the Codex app. keepCodexHome defaults to true so the
   // user's ~/.codex (sign-in, sessions, config) survives unless they opt out.
-  macUninstall(keepCodexHome: boolean): Promise<MacUninstallReport> {
+  async macUninstall(keepCodexHome: boolean): Promise<MacUninstallReport> {
     if (!hasTauriRuntime()) {
       return Promise.resolve({
         removed: true,
@@ -478,7 +488,8 @@ export const managerApi = {
         message: keepCodexHome ? "（浏览器开发态）已卸载,保留数据" : "（浏览器开发态）已卸载并清除数据",
       });
     }
-    return invoke<MacUninstallReport>("mac_uninstall", { confirm: true, keepCodexHome });
+    const token = await managerApi.armDestructive("uninstall");
+    return invoke<MacUninstallReport>("mac_uninstall", { confirm: true, token, keepCodexHome });
   },
   winPlanUpdate(): Promise<WinUpdateReport> {
     if (!hasTauriRuntime()) {
@@ -498,7 +509,7 @@ export const managerApi = {
     }
     return invoke<boolean>("win_cancel_download");
   },
-  winPerformUpdate(
+  async winPerformUpdate(
     confirm: boolean,
     expected?: {
       currentVersion: string | null;
@@ -513,19 +524,28 @@ export const managerApi = {
         ? Promise.resolve(WIN_FALLBACK_PERFORM)
         : Promise.reject(new Error("explicit confirmation is required"));
     }
+    if (!confirm) {
+      return Promise.reject(new Error("explicit confirmation is required"));
+    }
+    const token = await managerApi.armDestructive("update");
     return invoke<WinPerformReport>("win_perform_update", {
       confirm,
+      token,
       installRoot: installRoot ?? null,
       expected: expected ?? null,
     });
   },
-  winUninstall(confirm: boolean, purgeUserData: boolean): Promise<WinUninstallReport> {
+  async winUninstall(confirm: boolean, purgeUserData: boolean): Promise<WinUninstallReport> {
     if (!hasTauriRuntime()) {
       return confirm
         ? Promise.resolve({ ...WIN_FALLBACK_UNINSTALL, purgedUserData: purgeUserData })
         : Promise.reject(new Error("explicit confirmation is required"));
     }
-    return invoke<WinUninstallReport>("win_uninstall", { confirm, purgeUserData });
+    if (!confirm) {
+      return Promise.reject(new Error("explicit confirmation is required"));
+    }
+    const token = await managerApi.armDestructive("uninstall");
+    return invoke<WinUninstallReport>("win_uninstall", { confirm, token, purgeUserData });
   },
   winStatus(): Promise<WinInstallStatus> {
     if (!hasTauriRuntime()) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,7 @@
 export type OperatingSystem = "windows" | "macos" | "linux" | "unknown";
 export type Architecture = "x64" | "arm64" | "unknown";
+export type OperationKind = "install" | "update" | "uninstall" | "set-install-root" | "adopt";
+export type OperationToken = string;
 
 /**
  * Serialized error returned by failing Tauri commands. Mirrors the backend


### PR DESCRIPTION
PR-2:引擎下载与产物校验硬化(#65 #71)。复用 PR-1 的 oplock。

## #65 下载 / staging 硬化
- 唯一 staging(`update-{uuid}`)+ unix owner-only `0700` + 启动 stale cleanup(受 oplock `is_busy` 保护、只清过期未持锁);win portable rollback/staging UUID 化。
- mac 下载原子化(`.part` → rename)+ 120s 停滞检测;win 已 `.part`。
- 文本响应 8 MiB 上限;包 2 GiB / delta 512 MiB 上限 + content-length sanity。

## #71 产物校验 + 命令 + token
- mac:恰好一个 `Codex.app`(0/多/错名 → fail,删「第一个 .app」fallback)。
- win:checksum 精确唯一匹配 moniker(删「第一个 .msix」fallback);manifest↔checksums↔URL↔identity 强绑定。
- 外部命令绝对路径(mac `/usr/bin`·`/usr/sbin`;win `%SystemRoot%\System32\curl.exe`)。
- destructive(perform/uninstall)改 `confirm` + 一次性 operation token 双门槛:`arm_destructive`(begin_detached)下发 token → 命令 `DetachedGuard::validate` + RAII end;复用 PR-1 oplock;前端同步接入。

## 验收(Claude)
- mac clippy `-D warnings` 0;mac test ×4 全 38 passed 零 flaky;前端 `npm run build` OK。
- win-engine 的 Windows-target clippy 干净;`staging.rs` unix-only 代码正确 `#[cfg(unix)]` gate。
- #71 对抗测试齐全(missing/duplicate moniker、x64/arm64 不串、多 `.app` fail、manifest 绑定);token 底层 oplock 对抗测试完整(validate / 一次性 end / 超时 / 跨进程);staging cleanup `is_busy` 测试。
- 不重复 PR-1 的 curl `--proto`(只追加 `--max-filesize`/绝对路径)。

## 已知边界
- arm/perform token 的**端到端集成**对抗测试未单独写(perform 是真实安装命令难单测);核心由 oplock 底层测试 + 接线 review 覆盖。
- src-tauri 的 Windows-target clippy 本地未跑(tauri 交叉编译难),由本 PR 的 CI Rust(windows)验。

Refs #65, #71