### PR TITLE
chore(release): bump version to 0.1.18

### DIFF
--- a/docs/releases/v0.1.18.md
+++ b/docs/releases/v0.1.18.md
@@ -1,0 +1,45 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版是一次全面的安全、可靠性与无障碍加固:杜绝多开损坏、崩溃不再白屏、新增日志与一键诊断,卸载提示也更清晰。
+> A broad security, reliability, and accessibility hardening pass — no more multi-instance corruption, no white-screen crashes, new file logging with one-click diagnostics, and clearer uninstall prompts.
+
+## ✨ 亮点 · Highlights
+
+- **单实例锁,杜绝多开损坏**:重复启动(Windows 双击两次尤甚)不再产生第二个实例并发改文件,而是聚焦已有窗口;破坏性操作另有跨进程锁兜底。
+  Single-instance lock — a second launch (easy to do on Windows) now focuses the existing window instead of racing on files; destructive operations are further guarded by a cross-process lock.
+- **日志与一键诊断**:新增滚动文件日志,「关于」页可「打开日志目录 / 复制诊断信息」,提 issue 时一键带上版本、平台与最近错误。
+  File logging + one-click diagnostics — the About page now has "Open logs / Copy diagnostics", so a bug report carries your version, platform, and recent errors.
+- **崩溃不再白屏**:任一界面渲染异常都会显示可恢复的兜底页(重新加载 + 复制诊断),而不是空白窗口。
+  No more white-screen crashes — any render error shows a recoverable fallback (reload + copy diagnostics) instead of a blank window.
+- **无障碍**:所有对话框支持键盘操作(Esc 关闭、Tab 焦点循环、关闭后焦点归还)与屏幕阅读器。
+  Accessibility — every dialog now supports keyboard use (Esc, focus trap, focus return) and screen readers.
+
+## 🐛 修复与加固 · Fixes & Hardening
+
+- **卸载更清晰**:删除数据前明确显示具体路径(`~/.codex` / `%USERPROFILE%\.codex`)与影响范围,并提供「复制路径 / 打开目录」。
+  Clearer uninstall — shows the exact data path (`~/.codex` / `%USERPROFILE%\.codex`) and what it affects before deletion, with copy-path / open-folder.
+- **更稳的更新链路**:macOS 更新前磁盘空间预检(与 Windows 对齐);下载原子化(中断不再留下半成品被复用);自定义更新源 SSRF/协议校验;配置原子写 + 损坏自动从备份恢复;设置快速切换不再被旧响应覆盖。
+  Sturdier updates — macOS disk-space preflight (matching Windows), atomic downloads (no half-finished files reused), custom-source SSRF/scheme validation, atomic config writes with backup recovery, and settings no longer clobbered by out-of-order saves.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.17"
+version = "0.1.18"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## 发版 0.1.18

bump 版本号(5 文件 6 处)+ release note。本版聚合此前已合并的 6 个 PR(#72 #76 #77 #78 #79 #80),对应 12 个加固类 issue(#59–#71)。

### 用户可感知变化(详见 `docs/releases/v0.1.18.md`)

**✨ 亮点**
- 单实例锁,杜绝多开损坏(重复启动聚焦已有窗口;破坏性操作另有跨进程锁兜底)
- 日志与一键诊断(滚动文件日志 +「关于」页「打开日志目录 / 复制诊断信息」)
- 崩溃不再白屏(渲染异常显示可恢复兜底页)
- 无障碍(对话框键盘操作 Esc/焦点循环/焦点归还 + 屏幕阅读器)

**🐛 修复与加固**
- 卸载前明确显示数据路径与影响范围
- 更稳的更新链路(磁盘预检 / 原子下载 / SSRF 校验 / 配置原子写+备份恢复 / 设置乱序响应防覆盖)

### 核对
- [x] 6 处版本位均 `0.1.17→0.1.18`,Cargo.lock 仅动 `codex-app-manager` 块
- [x] release note 双语,安装表/镜像直链为模板固化内容未改写
- [x] 无 spec 等中间产物入库
