### PR TITLE
chore(release): bump version to 0.1.19

### DIFF
--- a/docs/releases/v0.1.19.md
+++ b/docs/releases/v0.1.19.md
@@ -1,0 +1,49 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版把自动检查更新拆成可理解、可控制的两件事:启动时检查一次,以及按你选的频率定时检查。
+> This release makes automatic update checks explicit and controllable: one check on startup, plus periodic checks at the cadence you choose.
+
+## ✨ 亮点 · Highlights
+
+- **启动检查单独开关**:「启动时自动检查更新」现在可以独立关闭;只想手动点重新检查的用户,不用再担心打开管理器就访问更新源。
+  Startup checks get their own switch — users who prefer manual rechecks can stop the manager from hitting the update feed as soon as it opens.
+- **定时检查单独开关**:「定时自动检查更新」打开后才显示频率设置,关闭时界面会收起,设置页仍然保持在「通用」里。
+  Periodic checks get their own switch — the cadence controls appear only when periodic checks are enabled, and the setting still lives under General.
+- **默认每 15 分钟检查**:新默认值从原来的后台 6 小时调整为 15 分钟,同时提供 15 分钟、1 小时、6 小时和自定义时/分/秒输入。
+  The default cadence is now 15 minutes instead of the old 6-hour background interval, with 15-minute, 1-hour, 6-hour, and custom hour/minute/second choices.
+
+## 🐛 修复 · Fixes
+
+- **旧设置平滑迁移**:旧版「自动检查更新」关闭的用户升级后会同时关闭启动检查和定时检查;开启的用户会得到新的 15 分钟默认频率。
+  Smooth settings migration — if the old automatic-check switch was off, both new switches stay off; if it was on, the new 15-minute default is applied.
+- **避免过密轮询**:自定义频率低于 60 秒时会按 60 秒保存和执行,避免误输入导致频繁请求更新源。
+  Safer polling floor — custom cadences below 60 seconds are saved and run as 60 seconds to avoid accidental update-feed hammering.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` is not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.18"
+version = "0.1.19"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump app version to 0.1.19 across package, Tauri, and Cargo metadata
- add bilingual v0.1.19 release notes

## Verification
- npm run check
- npm test
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check