### PR TITLE
chore(release): bump version to 0.1.20

### DIFF
--- a/docs/releases/v0.1.20.md
+++ b/docs/releases/v0.1.20.md
@@ -1,0 +1,40 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版修复 Windows 免商店更新在镜像短链下被过早拒绝的问题。
+> This release fixes Windows non-Store updates being rejected too early when the mirror serves a stable short URL.
+
+## 🐛 修复 · Fixes
+
+- **Windows 更新短链可用**:`/latest/win` 这类稳定镜像地址不再因为路径本身不以 `.msix` 结尾而失败;管理器会继续读取 manifest/checksums,下载后再做 SHA256、OpenAI 签名和包身份校验。
+  Windows short update URLs now work — stable mirror URLs such as `/latest/win` are no longer rejected just because the path itself does not end in `.msix`; the manager still binds manifest/checksums and verifies SHA256, OpenAI signature, and package identity after download.
+- **保留直链错包保护**:如果自定义更新源直接给出 `.msix` 文件名,管理器仍会检查文件名里的 package moniker 是否和 manifest 匹配,避免 x64/arm64 或其他包混用。
+  Direct artifact protection stays in place — when a custom source exposes a direct `.msix` filename, the manager still checks that its package moniker matches the manifest to avoid mixing x64/arm64 or unrelated packages.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` is not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.19"
+version = "0.1.20"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Codex App Manager to 0.1.20 across package, Tauri, and Cargo metadata
- add docs/releases/v0.1.20.md for the Windows short MSIX URL fix

## Verification
- jq empty package.json package-lock.json src-tauri/tauri.conf.json
- npm run build
- npm test
- cargo test --manifest-path src-tauri/Cargo.toml --workspace
- cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
- codex review --base main