### PR TITLE
chore(release): bump version to 0.1.21

### DIFF
--- a/docs/releases/v0.1.21.md
+++ b/docs/releases/v0.1.21.md
@@ -1,0 +1,40 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版修好了应用内更新的暂停与续传:暂停后能从断点接着下,并理顺了取消与「安装中」的状态提示。
+> This release fixes in-app update pause and resume — a paused download now continues from where it stopped, with clearer cancel and "installing" states.
+
+## 🐛 修复 · Fixes
+
+- **暂停更新真的能续传**:之前点「暂停」会被弹回主页,号称「再次更新会继续下载」却每次都从零开始;现在暂停会停在进度页并给出〔继续〕按钮,从中断的字节处接着下载,只有「取消」才丢弃已下载的部分。
+  Pausing an update actually resumes now — it used to bounce you back to the home screen and quietly restart from zero despite promising to continue; pause now stays on the progress screen with a 〔Resume〕 button that picks up from the exact byte it stopped at, and only Cancel discards the partial.
+- **取消与安装阶段的提示更清楚**:「取消」在「正在准备」阶段也能点(用来放弃整个更新),并和「暂停」做了颜色区分;下载完成、进入不可中断的安装阶段后,界面会显示「正在安装,请勿关闭」,而不是留一排点不动的灰按钮。
+  Cancel and the install stage read clearly now — Cancel works during "preparing" to back out, is colour-distinct from Pause, and once the download finishes the screen says "Installing, don't close" instead of leaving a row of dead, greyed-out buttons.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` is not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256`, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.1.20"
+version = "0.1.21"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release **v0.1.21** — version bump + release notes for the in-app update pause/resume/cancel fix (already on main via #91).

## What ships
- **暂停能真正续传**:下载产物移到稳定缓存目录,引擎层 `.part` 断点续传真正生效;暂停停留在进度页并提供〔继续〕从断点恢复,只有取消才丢弃已下载部分。
- **取消随阶段自解释**:准备阶段也可取消(经 abort 检查点放弃整个操作),取消按钮 danger 化;下载完成后切「正在安装,请勿关闭」文案。
- mac/win 双平台对称;新增 `mac_discard_download`/`win_discard_download`;11 语言文案补齐。

## Release note
`docs/releases/v0.1.21.md`(release.yml 按 tag 取作 GitHub Release 正文)。

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ / `cargo test --workspace` ✅ (50)
- `npm run check` ✅ / `npm run test` ✅ (41) / `npm run build` ✅
- 经 `codex review --uncommitted` 迭代至无意见(并发 abort latch 的竞态/盲区/残留/嵌套均闭合)。

> bump PR 会额外触发非必需的 `nsis` 检查(~8min),等它也绿再合并。