### PR TITLE
feat: add motion to segmented control, sheet exit, and back-navigation

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { I18nProvider } from "./i18n";
 import { ThemeProvider } from "./theme";
+import { withViewTransition } from "./viewTransition";
 import { QuitConfirm } from "./components";
 import { Home } from "./views/Home";
 import { Settings } from "./views/Settings";
@@ -17,6 +18,12 @@ function Shell() {
   // Home stays mounted (just hidden) so returning to it doesn't re-mount and
   // re-run the network check — it shows its last state instantly. Sub-views
   // overlay it.
+  //
+  // That same persistence is why returning to Home has no entrance to play
+  // (Home neither re-mounts nor re-keys its GSAP scene), so it would hard-cut.
+  // Cross-fade the window instead via the shared ::view-transition(root) rule —
+  // no re-mount, no re-check. Forward / inter-sub-view nav keeps each view's own
+  // staggered `.view` entrance, so only the return Home is wrapped.
   return (
     <>
       <div style={{ display: view === "home" ? "contents" : "none" }}>
@@ -24,7 +31,7 @@ function Shell() {
       </div>
       {view === "settings" ? (
         <Settings
-          onBack={() => setView("home")}
+          onBack={() => withViewTransition(() => setView("home"))}
           onOpenAbout={() => setView("about")}
           onOpenUninstall={() => setView("uninstall")}
           onOpenConfig={() => setView("config")}

--- a/src/app/Sheet.tsx
+++ b/src/app/Sheet.tsx
@@ -1,6 +1,14 @@
-import { useRef, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { useFocusTrap } from "./useFocusTrap";
+
+// Keep in sync with the longest `.sheet.is-closing` exit transition in
+// styles.css — once it elapses the sheet is actually unmounted.
+const CLOSE_MS = 240;
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+}
 
 export function Sheet({
   open,
@@ -22,22 +30,51 @@ export function Sheet({
   children: ReactNode;
 }) {
   const sheetRef = useRef<HTMLDivElement>(null);
-  const dismiss = () => {
-    if (dismissable) {
-      onDismiss?.();
-    }
-  };
-  useFocusTrap(sheetRef, { onEsc: dismiss, initialFocus });
+  // Keep the sheet in the DOM through its exit. `mounted` only *lags* `open` on
+  // close: presence is `open || mounted`, so opening shows the node immediately
+  // (the focus trap can grab focus the same render) while closing keeps the same
+  // node around. The closing flag is derived live as `!open`, so the frame `open`
+  // flips false the *existing* node gains `.is-closing` and the exit transition
+  // animates from its current state — then a timer drops `mounted` to unmount.
+  // (Driving `.is-closing` off an effect-set state instead would unmount the node
+  // before the class lands, so the exit would never play.)
+  const [mounted, setMounted] = useState(open);
 
-  if (!open) {
+  useEffect(() => {
+    if (open) {
+      setMounted(true);
+      return;
+    }
+    if (!mounted) return; // already gone
+    if (prefersReducedMotion()) {
+      setMounted(false);
+      return;
+    }
+    const id = window.setTimeout(() => setMounted(false), CLOSE_MS);
+    return () => window.clearTimeout(id);
+  }, [open, mounted]);
+
+  // Ignore dismissals once the exit is playing (`open` already false). The trap
+  // is `active` only while open: opening arms it (focus into the sheet), closing
+  // disarms it and hands focus back to the opener immediately, so the exit just
+  // plays out as a visual with no focus held in the unmounting sheet.
+  const openRef = useRef(open);
+  openRef.current = open;
+  const dismiss = useCallback(() => {
+    if (dismissable && openRef.current) onDismiss?.();
+  }, [dismissable, onDismiss]);
+  useFocusTrap(sheetRef, { onEsc: dismiss, initialFocus, active: open });
+
+  if (!open && !mounted) {
     return null;
   }
 
+  const closing = !open;
   return (
-    <div className={scrimClass} onClick={dismiss}>
+    <div className={`${scrimClass}${closing ? " is-closing" : ""}`} onClick={dismiss}>
       <div
         ref={sheetRef}
-        className="sheet"
+        className={`sheet${closing ? " is-closing" : ""}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={labelledBy}

--- a/src/app/components.tsx
+++ b/src/app/components.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useId, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 
@@ -208,7 +216,17 @@ export function ErrorHero({ message }: { message: string | null }) {
           >
             {t("home.error.details")}
           </button>
-          {showDetails ? <pre className="errdetails">{message}</pre> : null}
+          {/* Grow the raw diagnostic in via grid-rows (same accordion technique
+              as .schedule-panel) instead of letting it pop in/out. */}
+          <div
+            className={`errdetails-panel${showDetails ? " open" : ""}`}
+            aria-hidden={!showDetails}
+            inert={showDetails ? undefined : true}
+          >
+            <div className="errdetails-panel-inner">
+              <pre className="errdetails">{message}</pre>
+            </div>
+          </div>
         </>
       ) : null}
     </>
@@ -268,6 +286,91 @@ export function ResultBanner({
           <Icon name="close" />
         </button>
       </div>
+    </div>
+  );
+}
+
+export interface SegmentedItem {
+  key: string;
+  label: ReactNode;
+}
+
+/** Segmented control whose selection is a single pill that *slides* between
+ *  options instead of blinking in place. The pill carries the chrome (gradient +
+ *  border + elevation) the selected button used to paint; JS writes the active
+ *  button's offsetLeft / offsetWidth onto it and CSS owns the travel. Shared by
+ *  the theme, check-frequency and proxy choosers. */
+export function Segmented({
+  items,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  items: SegmentedItem[];
+  value: string;
+  onChange: (key: string) => void;
+  ariaLabel?: string;
+}) {
+  const barRef = useRef<HTMLDivElement>(null);
+  const pillRef = useRef<HTMLSpanElement>(null);
+  // The pill snaps (no slide) into place on first paint; only a *selection*
+  // change should animate. Tracks whether we've positioned it at least once.
+  const placed = useRef(false);
+
+  const place = useCallback((animate: boolean) => {
+    const bar = barRef.current;
+    const pill = pillRef.current;
+    if (!bar || !pill) return;
+    const active = bar.querySelector<HTMLElement>('[aria-selected="true"]');
+    // offsetWidth is 0 while collapsed (e.g. inside a closed schedule panel) or
+    // under jsdom — skip so we don't pin the pill to a zero-width ghost.
+    if (!active || active.offsetWidth === 0) return;
+    const write = () => {
+      pill.style.transform = `translateX(${active.offsetLeft}px)`;
+      pill.style.width = `${active.offsetWidth}px`;
+    };
+    if (animate) {
+      write();
+    } else {
+      // Suspend the transition, write, force a reflow, restore — so the pill
+      // lands at the new position before any tween can run.
+      const prev = pill.style.transition;
+      pill.style.transition = "none";
+      write();
+      void pill.offsetWidth;
+      pill.style.transition = prev;
+    }
+  }, []);
+
+  // Slide on selection change; snap the very first time.
+  useLayoutEffect(() => {
+    place(placed.current);
+    placed.current = true;
+  }, [value, place]);
+
+  // Re-snap (no slide) when the bar's box changes — a language switch rewrites
+  // every label's width, and the frequency segment is revealed from a collapsed
+  // panel. ResizeObserver catches both without animating a non-selection move.
+  useEffect(() => {
+    const bar = barRef.current;
+    if (!bar || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => place(false));
+    ro.observe(bar);
+    return () => ro.disconnect();
+  }, [place]);
+
+  return (
+    <div className="seg" ref={barRef} aria-label={ariaLabel}>
+      <span className="seg-pill" aria-hidden="true" ref={pillRef} />
+      {items.map((item) => (
+        <button
+          key={item.key}
+          aria-selected={value === item.key}
+          onClick={() => onChange(item.key)}
+        >
+          {item.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -683,6 +683,28 @@ input {
   border-radius: var(--r-md);
   padding: 10px 12px;
 }
+/* Grow the diagnostic body in via grid-rows (same accordion technique as
+   .schedule-panel) so 查看详情 expands smoothly instead of popping in/out.
+   Padding/margin live on the clipped content, never on the 0fr track. */
+.errdetails-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 0.28s var(--ease-out), opacity 0.2s var(--ease);
+}
+.errdetails-panel.open {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+.errdetails-panel-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+@media (prefers-reduced-motion: reduce) {
+  .errdetails-panel {
+    transition: none;
+  }
+}
 
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
 .actions {
@@ -1184,8 +1206,11 @@ button.row.danger:hover {
   transform: scale(1);
 }
 
-/* segmented control (theme) */
+/* segmented control (theme / frequency / proxy) — the selection is a single
+   pill that *slides* between options (see <Segmented>), not a per-button
+   background that blinks on/off. */
 .seg {
+  position: relative; /* offset parent for the absolutely-positioned pill */
   display: flex;
   gap: 4px;
   background: var(--surface-2);
@@ -1194,7 +1219,31 @@ button.row.danger:hover {
   padding: 3px;
   box-shadow: inset 0 1px 2px var(--shadow-1);
 }
+/* The travelling pill carries the chrome the selected button used to paint. Its
+   transform + width are written inline by <Segmented> from the active button's
+   offsetLeft/offsetWidth; top/bottom:3px match the bar's padding so its height
+   tracks the buttons automatically. The transform settles with a restrained
+   overshoot (the app's selection-moment spring, shared with the toggle/radio);
+   width eases straight so it never bounces wider than the target. */
+.seg-pill {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: 0;
+  width: 0;
+  border-radius: var(--r-sm);
+  background: linear-gradient(180deg, var(--surface-3-top), var(--surface-3));
+  border: 1px solid var(--line-2);
+  box-shadow: var(--elev-1);
+  transform: translateX(0);
+  transition: transform 0.3s var(--ease-spring), width 0.26s var(--ease);
+  will-change: transform, width;
+  pointer-events: none;
+  z-index: 0;
+}
 .seg button {
+  position: relative;
+  z-index: 1; /* labels read above the pill */
   flex: 1;
   border: 1px solid transparent;
   background: transparent;
@@ -1203,17 +1252,18 @@ button.row.danger:hover {
   font-weight: 600;
   padding: 7px 8px;
   border-radius: var(--r-sm);
-  transition: background 0.18s var(--ease), color 0.18s var(--ease),
-    box-shadow 0.18s var(--ease), border-color 0.18s var(--ease);
+  transition: color 0.18s var(--ease);
 }
 .seg button:hover:not([aria-selected="true"]) {
   color: var(--text);
 }
 .seg button[aria-selected="true"] {
-  background: linear-gradient(180deg, var(--surface-3-top), var(--surface-3));
   color: var(--text);
-  border-color: var(--line-2);
-  box-shadow: var(--elev-1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .seg-pill {
+    transition: none;
+  }
 }
 
 .schedule-panel {
@@ -1552,6 +1602,41 @@ button.row.danger:hover {
   from {
     transform: translateY(24px);
     opacity: 0;
+  }
+}
+/* Exit — the reverse of the entrances: the scrim fades and the sheet sinks back
+   down. Driven by an animation (not a transition) so it fires reliably the
+   instant `.is-closing` lands — the resting `.sheet`/`.scrim` carry no
+   transition to interpolate from, so a same-frame transition wouldn't tween. The
+   Sheet component holds the node mounted for the duration (CLOSE_MS) before
+   unmounting, so dismiss no longer hard-cuts. */
+@keyframes scrim-out {
+  to {
+    opacity: 0;
+  }
+}
+@keyframes sheet-sink {
+  to {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+}
+.scrim.is-closing,
+.quit-scrim.is-closing {
+  animation: scrim-out 0.2s var(--ease) forwards;
+}
+.sheet.is-closing {
+  animation: sheet-sink 0.24s var(--ease-out) forwards;
+}
+/* Reduced-motion: no enter/exit movement (the component also unmounts at once). */
+@media (prefers-reduced-motion: reduce) {
+  .scrim,
+  .quit-scrim,
+  .sheet,
+  .scrim.is-closing,
+  .quit-scrim.is-closing,
+  .sheet.is-closing {
+    animation: none;
   }
 }
 .sheet .ring {

--- a/src/app/useFocusTrap.ts
+++ b/src/app/useFocusTrap.ts
@@ -42,11 +42,16 @@ export function useFocusTrap(
   opts: {
     onEsc?: () => void;
     initialFocus?: "first" | "primary" | "dismiss" | "container";
+    /** When false the trap is inert: it grabs no focus and, on the transition
+     *  to false, restores focus to the opener. Lets a dialog keep playing an
+     *  exit animation (still mounted) without holding focus. Defaults to true. */
+    active?: boolean;
   },
 ) {
+  const active = opts.active ?? true;
   useEffect(() => {
     const node = ref.current;
-    if (!node) {
+    if (!node || !active) {
       return;
     }
     const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -89,5 +94,5 @@ export function useFocusTrap(
         opener.focus();
       }
     };
-  }, [ref, opts.onEsc, opts.initialFocus]);
+  }, [ref, opts.onEsc, opts.initialFocus, active]);
 }

--- a/src/app/views/Settings.tsx
+++ b/src/app/views/Settings.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_SETTINGS } from "../../shared/types";
 import { Icon } from "../icons";
 import { useI18n, LANGS, type TFn, type TKey } from "../i18n";
 import { useTheme, type ThemeMode } from "../theme";
-import { NavBar, Toggle } from "../components";
+import { NavBar, Segmented, Toggle } from "../components";
 import { isWindows } from "../platform";
 import { Sheet } from "../Sheet";
 import { useSettingsSaver } from "./useSettingsSaver";
@@ -352,30 +352,26 @@ export function Settings({
                     <span className="rtitle">{t("settings.general.checkFrequency")}</span>
                     <span className="tag">{t("settings.general.intervalEvery", { interval: intervalLabel })}</span>
                   </div>
-                  <div className="seg">
-                    {FREQUENCY_PRESETS.map((option) => (
-                      <button
-                        key={option.seconds}
-                        aria-selected={s.periodicCheckIntervalSeconds === option.seconds}
-                        onClick={() => {
-                          setCommandError(null);
-                          setCustomIntervalOpen(false);
-                          update({ ...s, periodicCheckIntervalSeconds: option.seconds });
-                        }}
-                      >
-                        {t(option.label)}
-                      </button>
-                    ))}
-                    <button
-                      aria-selected={customInterval}
-                      onClick={() => {
-                        setCommandError(null);
+                  <Segmented
+                    ariaLabel={t("settings.general.checkFrequency")}
+                    value={customInterval ? "custom" : String(s.periodicCheckIntervalSeconds)}
+                    items={[
+                      ...FREQUENCY_PRESETS.map((option) => ({
+                        key: String(option.seconds),
+                        label: t(option.label),
+                      })),
+                      { key: "custom", label: t("settings.general.customInterval") },
+                    ]}
+                    onChange={(key) => {
+                      setCommandError(null);
+                      if (key === "custom") {
                         setCustomIntervalOpen(true);
-                      }}
-                    >
-                      {t("settings.general.customInterval")}
-                    </button>
-                  </div>
+                        return;
+                      }
+                      setCustomIntervalOpen(false);
+                      update({ ...s, periodicCheckIntervalSeconds: Number(key) });
+                    }}
+                  />
                   {customInterval ? (
                     <div className="interval-grid">
                       <label>
@@ -461,17 +457,12 @@ export function Settings({
               <div className="rtitle" style={{ marginBottom: 8 }}>
                 {t("settings.appearance.theme")}
               </div>
-              <div className="seg">
-                {themes.map((th) => (
-                  <button
-                    key={th.v}
-                    aria-selected={mode === th.v}
-                    onClick={() => setMode(th.v)}
-                  >
-                    {t(th.k)}
-                  </button>
-                ))}
-              </div>
+              <Segmented
+                ariaLabel={t("settings.appearance.theme")}
+                value={mode}
+                items={themes.map((th) => ({ key: th.v, label: t(th.k) }))}
+                onChange={(key) => setMode(key as ThemeMode)}
+              />
             </div>
             <button className="row" onClick={() => setLangSheet(true)}>
               <span className="rtext">
@@ -491,25 +482,20 @@ export function Settings({
               <div className="rtitle" style={{ marginBottom: 8 }}>
                 {t("settings.network.proxy")}
               </div>
-              <div className="seg">
-                {PROXY_MODES.map((mode) => (
-                  <button
-                    key={mode.kind}
-                    aria-selected={s.proxyMode === mode.kind}
-                    onClick={() => {
-                      setCommandError(null);
-                      const next = { ...s, proxyMode: mode.kind };
-                      if (mode.kind === "custom" && !s.customProxyUrl.trim()) {
-                        setDraft(next);
-                        return;
-                      }
-                      update(next);
-                    }}
-                  >
-                    {t(mode.label)}
-                  </button>
-                ))}
-              </div>
+              <Segmented
+                ariaLabel={t("settings.network.proxy")}
+                value={s.proxyMode}
+                items={PROXY_MODES.map((mode) => ({ key: mode.kind, label: t(mode.label) }))}
+                onChange={(key) => {
+                  setCommandError(null);
+                  const next = { ...s, proxyMode: key as ProxyMode };
+                  if (key === "custom" && !s.customProxyUrl.trim()) {
+                    setDraft(next);
+                    return;
+                  }
+                  update(next);
+                }}
+              />
               {s.proxyMode === "custom" ? (
                 <div style={{ marginTop: 10 }}>
                   <input


### PR DESCRIPTION
## What

Surgical motion polish across the app. Each change adapts a transitions.dev technique to the project's **own** OKLCH design tokens — no foreign variables, no motion library, resting visuals unchanged.

- **Segmented control selection slides** between options (theme / check-frequency / proxy) via a shared `<Segmented>` component, instead of blinking the background in place. The pill reuses the existing `--surface-3` / `--line-2` / `--elev-1` chrome and `--ease-spring`, so it looks identical at rest but now travels.
- **Sheets play an exit animation** (slide-down + fade) instead of hard-cutting on dismiss. The node stays mounted as `.is-closing` for `CLOSE_MS`, with the closing flag derived live as `!open` so the animation runs from the current frame rather than re-mounting into the end state. `useFocusTrap` gains an `active` flag so focus returns to the opener the instant the sheet closes, while the exit plays out as a pure visual.
- **Returning to Home cross-fades** through the existing `::view-transition(root)` rule. Home stays mounted (no re-mount, no re-check) — it simply had no entrance to play, so it hard-cut before. Forward / inter-sub-view nav keeps each view's staggered `.view` entrance.
- **Error-details disclosure expands** via grid-rows like the existing `.schedule-panel`, instead of popping in/out.

Every snippet keeps its `prefers-reduced-motion` guard.

## Verification

- `npm run check` (tsc) ✓ · `npm run test` (42 passed) ✓ · `npm run build` ✓
- Browser preview: pill snaps correctly on first paint and slides on selection in both themes; coexists with the theme view-transition; sheet exit confirmed via `getAnimations()` (`sheet-sink` / `scrim-out`, running, 240ms, opacity 1→0, fill forwards); return-to-Home fires exactly one view transition while forward nav fires none.
- `codex review --base main`: no comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)