### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/docs/releases/v0.2.2.md
+++ b/docs/releases/v0.2.2.md
@@ -1,0 +1,48 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版打磨界面动效:分段选择会滑动、弹窗有了关闭动画、从子页返回主页平滑过渡。
+> This release polishes the app's motion — the segmented selectors slide, sheets animate on close, and returning Home cross-fades.
+
+## ✨ 亮点 · Highlights
+
+- **分段控件滑动选择**:外观主题、检查频率、网络代理的分段选择器,选中高亮现在会在选项之间平滑滑动,而不是原地切换。
+  Sliding segmented controls: the theme, check-frequency, and proxy selectors now glide the highlight between options instead of snapping in place.
+- **返回主页平滑过渡**:从设置及其子页返回主页时,界面整屏交叉淡入,不再生硬切换。
+  Smooth back-navigation: returning to the home screen from Settings and its sub-pages now cross-fades instead of cutting abruptly.
+
+## 🐛 修复 · Fixes
+
+- **弹窗关闭不再瞬断**:确认、语言选择等底部弹窗在关闭时平滑下滑并淡出,而不是直接消失。
+  Sheets animate closed: confirm and language-picker sheets now slide down and fade out on dismiss instead of disappearing instantly.
+- **错误详情平滑展开**:检查失败页的「查看详情」改为顺滑展开 / 收起,不再突兀跳出。
+  Error details expand smoothly: the "view details" disclosure on the check-failed screen now grows and collapses smoothly instead of popping in and out.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.2.1"
+version = "0.2.2"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Patch release bundling the motion polish from #110.

Bilingual notes: [`docs/releases/v0.2.2.md`](docs/releases/v0.2.2.md). User-visible changes:

- **Segmented controls** (theme / check-frequency / proxy) slide the selection between options instead of snapping in place.
- **Returning to Home** cross-fades through the existing root view-transition instead of hard-cutting.
- **Sheets animate closed** (slide-down + fade) instead of vanishing on dismiss.
- **Error-details disclosure** expands/collapses smoothly instead of popping.

Version bumped across the 6 standard spots: `package.json`, `package-lock.json` (×2), `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and the `codex-app-manager` block in `src-tauri/Cargo.lock` (third-party `0.2.1` deps left untouched). The `v0.2.2` tag will be pushed after merge to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)