### PR TITLE
chore(release): bump version to 0.2.3

### DIFF
--- a/docs/releases/v0.2.3.md
+++ b/docs/releases/v0.2.3.md
@@ -1,0 +1,56 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 这一版让更新提醒更安静、更清楚,同时修正 Windows 与 macOS 上几处管理器体验细节。
+> This release makes update prompts quieter and clearer, while polishing several Windows and macOS manager details.
+
+## ✨ 亮点 · Highlights
+
+- **可跳过当前更新**: 有新版本时可以只跳过这一个版本;主屏幕保持干净,需要恢复提醒时到设置页操作。
+  Skip just the current update: when a new version appears, you can silence only that version; Home stays clean, and reminders can be restored from Settings.
+
+- **更新信息更清楚**: 首页把新版本、发布时间、更新大小放在一起展示,并将当前版本、发布时间、安装位置并列显示。
+  Clearer update details: Home groups the new version, release date, and update size together, then shows current version, release date, and install location as peer rows.
+
+- **更新操作更顺手**: 有新版本时「重新检查」和「立即更新」并排出现,保留主路径但减少视觉压力。
+  Easier update actions: when an update is available, "Check again" and "Update now" sit side by side, keeping the main path obvious without over-weighting the page.
+
+## 🐛 修复 · Fixes
+
+- **Windows 首页元数据**: 不再把安装时间当作发布时间展示;缺少真实发布时间时会避免显示误导性日期。
+  Windows Home metadata: install time is no longer shown as a release date; when a true release date is not known, the app avoids showing a misleading date.
+
+- **Windows 窗口阴影**: 调整窗口壳层阴影边距,减少底部阴影被截断和边缘过渡生硬的问题。
+  Windows window shadow: shell shadow spacing was adjusted to reduce clipped bottom shadows and harsh edge transitions.
+
+- **Codex 自更新开关**: 关闭 Codex 自身更新时同步环境变量,并避免 macOS 因一次性 helper 触发后台运行提示。
+  Codex self-update toggle: the setting now syncs the environment variable, and macOS avoids showing a background-run prompt for the one-shot helper.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.2.2"
+version = "0.2.3"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Codex App Manager from 0.2.2 to 0.2.3 across npm, Tauri, and Cargo metadata
- add docs/releases/v0.2.3.md for the tag-driven release workflow

## Validation
- npm run check
- npm test
- npm run build
- cargo clippy --all-targets -- -D warnings (src-tauri, codex-mac-engine, codex-win-engine)
- cargo test (src-tauri, codex-mac-engine, codex-win-engine)
- npm run tauri:build
- git diff --check
- codex review --uncommitted: no issues found
