### PR TITLE
[codex] Handle Windows Codex internal versions

### DIFF
--- a/crates/codex-win-engine/src/app_version.rs
+++ b/crates/codex-win-engine/src/app_version.rs
@@ -1,0 +1,202 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+const MAX_ASAR_HEADER_BYTES: u32 = 16 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+struct PackageJson {
+    version: String,
+}
+
+pub fn read_codex_app_version_from_install_root(root: &Path) -> Option<String> {
+    for candidate in app_asar_candidates(root) {
+        if let Some(version) = read_codex_app_version_from_asar(&candidate) {
+            return Some(version);
+        }
+    }
+    None
+}
+
+fn app_asar_candidates(root: &Path) -> Vec<PathBuf> {
+    let mut out = vec![
+        root.join("resources").join("app.asar"),
+        root.join("VFS")
+            .join("ProgramFilesX64")
+            .join("Codex")
+            .join("resources")
+            .join("app.asar"),
+        root.join("VFS")
+            .join("ProgramFilesArm64")
+            .join("Codex")
+            .join("resources")
+            .join("app.asar"),
+    ];
+
+    if out.iter().any(|candidate| candidate.is_file()) {
+        return out;
+    }
+
+    if let Some(found) = find_app_asar(root, 0, 6) {
+        if !out.iter().any(|candidate| candidate == &found) {
+            out.push(found);
+        }
+    }
+    out
+}
+
+fn find_app_asar(root: &Path, depth: usize, max_depth: usize) -> Option<PathBuf> {
+    if depth > max_depth {
+        return None;
+    }
+    let entries = std::fs::read_dir(root).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.file_name().and_then(|name| name.to_str()) == Some("app.asar") {
+            return Some(path);
+        }
+        if path.is_dir() {
+            if let Some(found) = find_app_asar(&path, depth + 1, max_depth) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+pub fn read_codex_app_version_from_asar(path: &Path) -> Option<String> {
+    let (mut file, header, data_offset) = read_asar_header(path).ok()?;
+    let entry = find_asar_entry(&header, &["package.json"])?;
+    let offset = asar_entry_offset(entry)?;
+    let size = asar_entry_size(entry)?;
+    let absolute_offset = data_offset.checked_add(offset)?;
+    file.seek(SeekFrom::Start(absolute_offset)).ok()?;
+    let mut bytes = vec![0; size.try_into().ok()?];
+    file.read_exact(&mut bytes).ok()?;
+    let package: PackageJson = serde_json::from_slice(&bytes).ok()?;
+    let version = package.version.trim();
+    (!version.is_empty()).then(|| version.to_string())
+}
+
+fn read_asar_header(path: &Path) -> Result<(File, Value, u64), ()> {
+    let mut file = File::open(path).map_err(|_| ())?;
+    let mut prefix = [0_u8; 8];
+    file.read_exact(&mut prefix).map_err(|_| ())?;
+    let first = u32::from_le_bytes(prefix[0..4].try_into().map_err(|_| ())?);
+    let second = u32::from_le_bytes(prefix[4..8].try_into().map_err(|_| ())?);
+
+    let (header_start, header_size) = if first == 4 {
+        (8_u64, second)
+    } else {
+        (4_u64, first)
+    };
+    if header_size == 0 || header_size > MAX_ASAR_HEADER_BYTES {
+        return Err(());
+    }
+
+    file.seek(SeekFrom::Start(header_start)).map_err(|_| ())?;
+    let mut header_bytes = vec![0; header_size.try_into().map_err(|_| ())?];
+    file.read_exact(&mut header_bytes).map_err(|_| ())?;
+    let header = parse_header_json(&header_bytes).ok_or(())?;
+    Ok((file, header, header_start + u64::from(header_size)))
+}
+
+fn parse_header_json(bytes: &[u8]) -> Option<Value> {
+    for (idx, byte) in bytes.iter().enumerate() {
+        if *byte != b'{' {
+            continue;
+        }
+        let mut de = serde_json::Deserializer::from_slice(&bytes[idx..]);
+        if let Ok(value) = Value::deserialize(&mut de) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn find_asar_entry<'a>(header: &'a Value, components: &[&str]) -> Option<&'a Value> {
+    let mut files = header.get("files")?;
+    for (idx, component) in components.iter().enumerate() {
+        let node = files.get(*component)?;
+        if idx == components.len() - 1 {
+            return Some(node);
+        }
+        files = node.get("files")?;
+    }
+    None
+}
+
+fn asar_entry_offset(entry: &Value) -> Option<u64> {
+    entry
+        .get("offset")?
+        .as_str()
+        .and_then(|offset| offset.parse().ok())
+}
+
+fn asar_entry_size(entry: &Value) -> Option<u64> {
+    entry.get("size")?.as_u64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_root_package_json_version_from_asar() {
+        let dir = std::env::temp_dir().join(format!("codex-asar-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let asar = dir.join("app.asar");
+        write_test_asar(&asar, br#"{"version":"26.623.42026","name":"Codex"}"#);
+
+        assert_eq!(
+            read_codex_app_version_from_asar(&asar).as_deref(),
+            Some("26.623.42026")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn finds_version_in_common_install_layout() {
+        let dir =
+            std::env::temp_dir().join(format!("codex-install-version-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let resources = dir.join("resources");
+        std::fs::create_dir_all(&resources).unwrap();
+        write_test_asar(
+            &resources.join("app.asar"),
+            br#"{"version":"26.623.42026"}"#,
+        );
+
+        assert_eq!(
+            read_codex_app_version_from_install_root(&dir).as_deref(),
+            Some("26.623.42026")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn write_test_asar(path: &Path, package_json: &[u8]) {
+        let header_json = format!(
+            r#"{{"files":{{"package.json":{{"size":{},"offset":"0"}}}}}}"#,
+            package_json.len()
+        );
+        let mut header = Vec::new();
+        header.extend_from_slice(&0_u32.to_le_bytes());
+        header.extend_from_slice(header_json.as_bytes());
+        while header.len() % 4 != 0 {
+            header.push(0);
+        }
+
+        let mut out = Vec::new();
+        out.extend_from_slice(&4_u32.to_le_bytes());
+        out.extend_from_slice(&(header.len() as u32).to_le_bytes());
+        out.extend_from_slice(&header);
+        out.extend_from_slice(package_json);
+        std::fs::write(path, out).unwrap();
+    }
+}

--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -11,6 +11,7 @@
 //!   - treat OpenAI Authenticode as the Windows trust anchor;
 //!   - fall back to portable only when the MSIX route is unavailable or fails.
 
+pub mod app_version;
 pub mod authenticode;
 pub mod capability;
 pub mod checksums;
@@ -25,6 +26,9 @@ mod process;
 pub mod sys;
 pub mod version;
 
+pub use app_version::{
+    read_codex_app_version_from_asar, read_codex_app_version_from_install_root,
+};
 pub use authenticode::{
     verify_openai_authenticode, AuthenticodeReport, OPENAI_MARKETPLACE_PUBLISHER_SUBJECT,
 };

--- a/crates/codex-win-engine/src/manifest.rs
+++ b/crates/codex-win-engine/src/manifest.rs
@@ -7,7 +7,10 @@ use crate::EngineError;
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WindowsRelease {
+    /// Human-facing Codex app version read from the app payload, e.g. 26.623.42026.
     pub version: String,
+    /// Four-part Windows MSIX package version, e.g. 26.623.5546.0.
+    pub package_version: String,
     pub released_at: Option<String>,
     pub package_moniker: String,
     pub architecture: Option<String>,
@@ -23,6 +26,8 @@ pub struct WindowsRelease {
 #[serde(rename_all = "camelCase")]
 struct MirrorManifest {
     schema_version: u64,
+    codex_version: Option<String>,
+    published_at: Option<String>,
     sources: Sources,
 }
 
@@ -35,6 +40,7 @@ struct Sources {
 #[serde(rename_all = "camelCase")]
 struct WindowsSource {
     version: Option<String>,
+    app_version: Option<String>,
     package_moniker: Option<String>,
     architecture: Option<String>,
     content_length: Option<u64>,
@@ -50,6 +56,7 @@ struct WindowsSource {
 #[serde(rename_all = "camelCase")]
 struct WindowsArchitectureSource {
     version: Option<String>,
+    app_version: Option<String>,
     package_moniker: Option<String>,
     architecture: Option<String>,
     content_length: Option<u64>,
@@ -89,16 +96,24 @@ pub fn parse_manifest_for_arch(
         return Err(err);
     }
 
+    let root_codex_version = manifest.codex_version.clone();
+    let root_published_at = manifest.published_at.clone();
     let windows = manifest.sources.windows;
-    let selected_architecture = preferred_architecture
-        .and_then(|arch| select_architecture(&windows.architectures, arch))
-        .or_else(|| select_architecture(&windows.architectures, "x64"));
+    let requested_architecture = preferred_architecture.and_then(normalize_architecture);
+    let selected_architecture =
+        select_architecture(&windows.architectures, requested_architecture.as_deref())?;
 
-    let version = selected_architecture
+    let package_version = selected_architecture
         .as_ref()
         .and_then(|(_, source)| source.version.clone())
         .or_else(|| windows.version.clone())
         .ok_or_else(|| EngineError::Manifest("missing Windows version".to_string()))?;
+    let version = selected_architecture
+        .as_ref()
+        .and_then(|(_, source)| source.app_version.clone())
+        .or_else(|| windows.app_version.clone())
+        .or(root_codex_version)
+        .unwrap_or_else(|| package_version.clone());
     let package_moniker = match selected_architecture.as_ref() {
         Some((_, source)) => source.package_moniker.clone(),
         None => windows.package_moniker.clone(),
@@ -117,12 +132,17 @@ pub fn parse_manifest_for_arch(
         None => windows.etag,
     };
     let released_at = match selected_architecture.as_ref() {
-        Some((_, source)) => source.last_modified.clone().or(windows.last_modified),
-        None => windows.last_modified,
+        Some((_, source)) => source
+            .last_modified
+            .clone()
+            .or(windows.last_modified)
+            .or(root_published_at),
+        None => windows.last_modified.or(root_published_at),
     };
 
     let release = WindowsRelease {
         version,
+        package_version,
         released_at,
         package_moniker,
         architecture,
@@ -138,8 +158,9 @@ pub fn parse_manifest_for_arch(
     };
     let arch = release.architecture.as_deref().unwrap_or("unknown");
     log::debug!(
-        "parse Windows manifest succeeded version={} package_moniker={} arch={arch}",
+        "parse Windows manifest succeeded version={} package_version={} package_moniker={} arch={arch}",
         release.version,
+        release.package_version,
         release.package_moniker
     );
     Ok(release)
@@ -147,16 +168,30 @@ pub fn parse_manifest_for_arch(
 
 fn select_architecture<'a>(
     architectures: &'a BTreeMap<String, WindowsArchitectureSource>,
-    requested_architecture: &str,
-) -> Option<(String, &'a WindowsArchitectureSource)> {
-    let requested = normalize_architecture(requested_architecture)?;
-    architectures
+    requested_architecture: Option<&str>,
+) -> Result<Option<(String, &'a WindowsArchitectureSource)>, EngineError> {
+    let Some(requested) = requested_architecture.or(Some("x64")) else {
+        return Ok(None);
+    };
+    if architectures.is_empty() {
+        return Ok(None);
+    }
+
+    let matching = architectures
         .iter()
-        .find(|(arch, source)| {
-            normalize_architecture(arch).as_deref() == Some(requested.as_str())
-                && source.downloadable.unwrap_or(true)
-        })
-        .map(|(_, source)| (requested, source))
+        .find(|(arch, _)| normalize_architecture(arch).as_deref() == Some(requested));
+    match matching {
+        Some((_, source)) if source.downloadable.unwrap_or(true) => {
+            Ok(Some((requested.to_string(), source)))
+        }
+        Some((_, _)) => Err(EngineError::Manifest(format!(
+            "Windows {requested} package is not available in the current mirror manifest"
+        ))),
+        None if requested == "arm64" => Err(EngineError::Manifest(
+            "Windows arm64 package is not available in the current mirror manifest".to_string(),
+        )),
+        None => Ok(None),
+    }
 }
 
 fn normalize_architecture(architecture: &str) -> Option<String> {
@@ -244,6 +279,7 @@ mod tests {
 
         let release = parse_manifest(json).unwrap();
         assert_eq!(release.version, "26.602.3474.0");
+        assert_eq!(release.package_version, "26.602.3474.0");
         assert_eq!(release.package_identity.as_deref(), Some("OpenAI.Codex"));
         assert_eq!(release.content_length, Some(566_504_666));
         assert_eq!(
@@ -251,6 +287,51 @@ mod tests {
             Some("Fri, 26 Jun 2026 05:10:43 GMT")
         );
         assert_eq!(release.download_architecture, None);
+    }
+
+    #[test]
+    fn parses_schema_v3_codex_app_version_separately_from_package_version() {
+        let json = r#"{
+          "schemaVersion": 3,
+          "codexVersion": "26.623.42026",
+          "publishedAt": "Sat, 27 Jun 2026 07:19:49 GMT",
+          "sources": {
+            "windows": {
+              "productId": "9PLM9XGG6VKS",
+              "version": "26.623.5546.0",
+              "appVersion": "26.623.42026",
+              "packageMoniker": "OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0",
+              "contentLength": 671037642,
+              "lastModified": "Sat, 27 Jun 2026 05:28:48 GMT",
+              "architectures": {
+                "x64": {
+                  "architecture": "x64",
+                  "status": "downloadable",
+                  "downloadable": true,
+                  "version": "26.623.5546.0",
+                  "appVersion": "26.623.42026",
+                  "packageMoniker": "OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0",
+                  "contentLength": 671037642,
+                  "lastModified": "Sat, 27 Jun 2026 05:28:48 GMT",
+                  "etag": "\"x64\""
+                }
+              },
+              "updateManifest": {
+                "storeProductId": "9PLM9XGG6VKS",
+                "packageIdentity": "OpenAI.Codex"
+              }
+            }
+          }
+        }"#;
+
+        let release = parse_manifest_for_arch(json, Some("x64")).unwrap();
+
+        assert_eq!(release.version, "26.623.42026");
+        assert_eq!(release.package_version, "26.623.5546.0");
+        assert_eq!(
+            release.package_moniker,
+            "OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0"
+        );
     }
 
     #[test]
@@ -296,6 +377,8 @@ mod tests {
 
         let release = parse_manifest_for_arch(json, Some("arm64")).unwrap();
 
+        assert_eq!(release.version, "26.616.9593.0");
+        assert_eq!(release.package_version, "26.616.9593.0");
         assert_eq!(release.architecture.as_deref(), Some("arm64"));
         assert_eq!(
             release.package_moniker,
@@ -311,7 +394,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_x64_when_requested_architecture_is_not_downloadable() {
+    fn rejects_requested_architecture_when_not_downloadable() {
         let json = r#"{
           "schemaVersion": 2,
           "sources": {
@@ -337,14 +420,11 @@ mod tests {
           }
         }"#;
 
-        let release = parse_manifest_for_arch(json, Some("arm64")).unwrap();
+        let err = parse_manifest_for_arch(json, Some("arm64")).unwrap_err();
 
-        assert_eq!(release.architecture.as_deref(), Some("x64"));
-        assert_eq!(
-            release.package_moniker,
-            "OpenAI.Codex_26.616.9593.0_x64__2p2nqsd0c76g0"
-        );
-        assert_eq!(release.download_architecture.as_deref(), Some("x64"));
+        assert!(err
+            .to_string()
+            .contains("Windows arm64 package is not available"));
     }
 
     #[test]

--- a/crates/codex-win-engine/src/plan.rs
+++ b/crates/codex-win-engine/src/plan.rs
@@ -38,7 +38,10 @@ pub fn plan_update(
     let current_version = installed.as_ref().map(|i| i.version.clone());
     let up_to_date = current_version
         .as_ref()
-        .map(|current| compare_versions(current, &release.version).is_ge())
+        .map(|current| {
+            compare_versions(current, &release.version).is_ge()
+                || current.eq_ignore_ascii_case(&release.package_version)
+        })
         .unwrap_or(false);
 
     let route = match capabilities.recommendation {
@@ -73,6 +76,7 @@ mod tests {
     fn release() -> WindowsRelease {
         WindowsRelease {
             version: "26.602.3474.0".to_string(),
+            package_version: "26.602.3474.0".to_string(),
             released_at: None,
             package_moniker: "OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0".to_string(),
             architecture: Some("x64".to_string()),
@@ -136,5 +140,83 @@ mod tests {
         );
         assert_eq!(plan.route, WinInstallRoute::PortableFallback);
         assert!(!plan.portable_fallback_ready);
+    }
+
+    #[test]
+    fn compares_codex_app_versions_not_msix_package_versions() {
+        let mut release = release();
+        release.version = "26.623.42026".to_string();
+        release.package_version = "26.623.5546.0".to_string();
+        release.package_moniker = "OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0".to_string();
+        let capabilities = WinCapabilityReport::from_checks(
+            CapabilityCheck::available("present"),
+            CapabilityCheck::available("running"),
+            CapabilityCheck::available("AllowAllTrustedApps=1"),
+            CapabilityCheck::available("installed"),
+            CapabilityCheck::available("PackageManager activates"),
+            CapabilityCheck::unknown("not probed"),
+            vec![],
+        );
+        let installed = Some(InstalledWindowsCodex {
+            path: "C:/Program Files/WindowsApps/OpenAI.Codex".to_string(),
+            version: "26.623.42026".to_string(),
+            arch: Some("x64".to_string()),
+            source: "msix".to_string(),
+            package_family_name: Some("OpenAI.Codex_2p2nqsd0c76g0".to_string()),
+            installed_at: None,
+        });
+
+        let plan = plan_update(
+            &release,
+            "a".repeat(64).as_str(),
+            "https://example/win-x64",
+            &installed,
+            &capabilities,
+            true,
+        );
+
+        assert!(plan.up_to_date);
+        assert_eq!(plan.latest_version, "26.623.42026");
+        assert_eq!(
+            plan.package_moniker,
+            "OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0"
+        );
+    }
+
+    #[test]
+    fn treats_matching_msix_package_version_as_current_when_app_version_is_unreadable() {
+        let mut release = release();
+        release.version = "26.623.42026".to_string();
+        release.package_version = "26.623.5546.0".to_string();
+        let capabilities = WinCapabilityReport::from_checks(
+            CapabilityCheck::available("present"),
+            CapabilityCheck::available("running"),
+            CapabilityCheck::available("AllowAllTrustedApps=1"),
+            CapabilityCheck::available("installed"),
+            CapabilityCheck::available("PackageManager activates"),
+            CapabilityCheck::unknown("not probed"),
+            vec![],
+        );
+        let installed = Some(InstalledWindowsCodex {
+            path: "C:/Program Files/WindowsApps/OpenAI.Codex".to_string(),
+            version: "26.623.5546.0".to_string(),
+            arch: Some("x64".to_string()),
+            source: "msix".to_string(),
+            package_family_name: Some("OpenAI.Codex_2p2nqsd0c76g0".to_string()),
+            installed_at: None,
+        });
+
+        let plan = plan_update(
+            &release,
+            "a".repeat(64).as_str(),
+            "https://example/win-x64",
+            &installed,
+            &capabilities,
+            true,
+        );
+
+        assert!(plan.up_to_date);
+        assert_eq!(plan.current_version.as_deref(), Some("26.623.5546.0"));
+        assert_eq!(plan.latest_version, "26.623.42026");
     }
 }

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::app_version::read_codex_app_version_from_install_root;
 use crate::msix::{parse_appx_manifest_xml, MsixIdentity};
 use crate::process::hidden_command;
 use crate::EngineError;
@@ -604,11 +605,14 @@ fn install_portable_from_msix_inner(
 
     let _ = fs::remove_dir_all(&work_dir);
 
+    let version = read_codex_app_version_from_install_root(install_root)
+        .unwrap_or_else(|| prepared.identity.version.clone());
+
     Ok(PortableInstallReport {
         success: true,
         install_root: install_root.to_string_lossy().into_owned(),
         executable_path: exe.exists().then(|| exe.to_string_lossy().into_owned()),
-        version: prepared.identity.version,
+        version,
         backup_path,
         shortcut_created,
         uninstall_entry_created,

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::app_version::read_codex_app_version_from_install_root;
 use crate::capability::WinCapabilityReport;
 #[cfg(windows)]
 use crate::capability::{CapabilityCheck, CapabilityState};
@@ -17,6 +18,8 @@ use crate::EngineError;
 #[serde(rename_all = "camelCase")]
 pub struct InstalledWindowsCodex {
     pub path: String,
+    /// Human-facing Codex app version read from app.asar/package.json when available.
+    /// Falls back to the Windows package version if the app payload is unreadable.
     pub version: String,
     pub arch: Option<String>,
     /// "msix" | "portable"
@@ -43,6 +46,13 @@ fn path_mtime_secs(path: &str) -> Option<u64> {
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs())
+}
+
+fn prefer_codex_app_version(mut codex: InstalledWindowsCodex) -> InstalledWindowsCodex {
+    if let Some(version) = read_codex_app_version_from_install_root(Path::new(&codex.path)) {
+        codex.version = version;
+    }
+    codex
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -321,8 +331,11 @@ try {{
     );
     let json = run_powershell_json(&script)
         .map_err(|e| EngineError::Install(format!("run Add-AppxPackage: {e}")))?;
-    let report: MsixSideloadReport = serde_json::from_str(&json)
+    let mut report: MsixSideloadReport = serde_json::from_str(&json)
         .map_err(|e| EngineError::Install(format!("parse Add-AppxPackage result: {e}")))?;
+    if let Some(installed) = report.installed.take() {
+        report.installed = Some(prefer_codex_app_version(installed));
+    }
     if report.success {
         let path_display = path.display();
         log::info!("MSIX sideload completed path={path_display}");
@@ -829,7 +842,7 @@ if ($null -ne $p) {{
     }
     let mut codex: InstalledWindowsCodex = serde_json::from_str(&json).ok()?;
     codex.installed_at = path_mtime_secs(&codex.path);
-    Some(codex)
+    Some(prefer_codex_app_version(codex))
 }
 
 #[cfg(not(windows))]
@@ -857,6 +870,7 @@ pub fn detect_portable_install(portable_root: &Path) -> Option<InstalledWindowsC
         package_family_name: None,
         installed_at: path_mtime_secs(&exe.to_string_lossy()),
     };
+    let installed = prefer_codex_app_version(installed);
     let path = &installed.path;
     log::debug!("detected portable install path={path}");
     Some(installed)

--- a/src-tauri/examples/win_real_smoke.rs
+++ b/src-tauri/examples/win_real_smoke.rs
@@ -83,6 +83,7 @@ fn staged_msix_path(release: &WindowsRelease) -> PathBuf {
 fn old_release() -> WindowsRelease {
     WindowsRelease {
         version: OLD_MSIX_VERSION.to_string(),
+        package_version: OLD_MSIX_VERSION.to_string(),
         released_at: None,
         package_moniker: OLD_MSIX_MONIKER.to_string(),
         architecture: Some("x64".to_string()),

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -575,7 +575,7 @@ pub fn stage_windows_update_with_install_mode_and_network(
         let identity = read_msix_identity(&dest).map_err(engine_err)?;
         validate_codex_identity(
             &identity,
-            &report.release.version,
+            &report.release.package_version,
             report.release.architecture.as_deref(),
         )
         .map_err(engine_err)?;
@@ -1378,6 +1378,7 @@ mod tests {
     fn release() -> WindowsRelease {
         WindowsRelease {
             version: "26.602.3474.0".to_string(),
+            package_version: "26.602.3474.0".to_string(),
             released_at: None,
             package_moniker: "OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0".to_string(),
             architecture: Some("x64".to_string()),

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -239,8 +239,8 @@ const FALLBACK_PLAN: MacUpdateReport = {
 };
 
 const WIN_FALLBACK_INSTALLED = {
-  path: "C:\\Program Files\\WindowsApps\\OpenAI.Codex_26.623.4041.0_x64__2p2nqsd0c76g0",
-  version: "26.623.4041.0",
+  path: "C:\\Program Files\\WindowsApps\\OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0",
+  version: "26.623.42026",
   arch: "x64",
   source: "msix",
   packageFamilyName: "OpenAI.Codex_2p2nqsd0c76g0",
@@ -252,11 +252,12 @@ const WIN_FALLBACK_PLAN: WinUpdateReport = {
   checksumsUrl: "https://codexapp.agentsmirror.com/latest/checksums",
   packageUrl: "https://codexapp.agentsmirror.com/latest/win",
   release: {
-    version: "26.623.4041.0",
-    releasedAt: "Fri, 26 Jun 2026 10:10:00 GMT",
-    packageMoniker: "OpenAI.Codex_26.623.4041.0_x64__2p2nqsd0c76g0",
+    version: "26.623.42026",
+    packageVersion: "26.623.5546.0",
+    releasedAt: "Sat, 27 Jun 2026 05:28:48 GMT",
+    packageMoniker: "OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0",
     architecture: "x64",
-    contentLength: 566504666,
+    contentLength: 671037642,
     etag: '"4XJflSyTxVc59Sr2FfA4HAqFCD0="',
     storeProductId: "9PLM9XGG6VKS",
     packageIdentity: "OpenAI.Codex",
@@ -274,11 +275,11 @@ const WIN_FALLBACK_PLAN: WinUpdateReport = {
   },
   plan: {
     upToDate: true,
-    currentVersion: "26.623.4041.0",
-    latestVersion: "26.623.4041.0",
-    packageMoniker: "OpenAI.Codex_26.623.4041.0_x64__2p2nqsd0c76g0",
+    currentVersion: "26.623.42026",
+    latestVersion: "26.623.42026",
+    packageMoniker: "OpenAI.Codex_26.623.5546.0_x64__2p2nqsd0c76g0",
     packageUrl: "https://codexapp.agentsmirror.com/latest/win",
-    downloadSize: 566504666,
+    downloadSize: 671037642,
     sha256: "6dc2e05ac2b760bbc77ce3f8a992efdb327363512c9c4744b9a146c41bc4d55a",
     route: "msix-sideload",
     portableFallbackReady: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -188,6 +188,7 @@ export interface MacUninstallReport {
 
 export interface InstalledWindowsCodex {
   path: string;
+  /** Human-facing Codex app version; falls back to the MSIX package version when unreadable. */
   version: string;
   arch: string | null;
   source: "msix" | "portable" | string;
@@ -197,7 +198,10 @@ export interface InstalledWindowsCodex {
 }
 
 export interface WindowsRelease {
+  /** Human-facing Codex app version, e.g. 26.623.42026. */
   version: string;
+  /** Four-part Windows MSIX package version, e.g. 26.623.5546.0. */
+  packageVersion: string;
   /** Release/publish timestamp for this Windows package, when the manifest provides it. */
   releasedAt?: string | null;
   packageMoniker: string;


### PR DESCRIPTION
## Summary

- Parse mirror schema v3 Windows metadata as two versions: Codex app version for UI/update semantics and MSIX package version for package identity.
- Read installed Windows Codex internal version from `resources/app.asar/package.json` for MSIX and portable installs, with package-version fallback when unreadable.
- Keep MSIX verification bound to the package version and package moniker, and reject unavailable requested architectures instead of silently falling back to x64.

## Root Cause

The mirror now groups releases by the Codex internal app version while Windows MSIX assets still use a separate four-part package version. Manager was treating `sources.windows.architectures.*.version` as the user-facing latest Codex version, so Windows could show package versions such as `26.623.5546.0` instead of internal versions such as `26.623.42026`.

## Validation

- `cargo test` in `crates/codex-win-engine`
- `cargo test -p codex-app-manager` in `src-tauri`
- `npm run check`
- `npm run test`
- `git diff --check`
