### PR TITLE
feat(ui): in-house stroke icons with hover micro-animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "gsap": "^3.15.0",
-        "lucide-react": "1.22.0",
         "react": "19.2.7",
         "react-dom": "19.2.7"
       },
@@ -1795,15 +1794,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.22.0.tgz",
-      "integrity": "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "gsap": "^3.15.0",
-    "lucide-react": "1.22.0",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },

--- a/src/app/icons.tsx
+++ b/src/app/icons.tsx
@@ -1,4 +1,5 @@
-// Stroke icon set (currentColor, 24×24). One consistent weight, friendly caps.
+// Stroke icon set (currentColor, 24×24). The SVG groups carry stable class
+// names so parent controls can trigger lightweight CSS animations.
 
 import type { ReactNode } from "react";
 
@@ -11,6 +12,7 @@ export type IconName =
   | "alert"
   | "arrowUp"
   | "download"
+  | "play"
   | "pause"
   | "loader"
   | "refresh"
@@ -30,65 +32,66 @@ export type IconName =
   | "close";
 
 const PATHS: Record<IconName, ReactNode> = {
-  check: <polyline points="4 12.5 9.5 18 20 6.5" />,
+  check: <polyline className="cam-check-mark" points="4 12.5 9.5 18 20 6.5" />,
   alert: (
-    <>
-      <path d="M12 4 2.6 20h18.8L12 4Z" />
-      <line x1="12" y1="10" x2="12" y2="14" />
-      <circle cx="12" cy="17.4" r="0.5" />
-    </>
+    <g className="cam-alert">
+      <path className="cam-alert-body" d="M12 4 2.6 20h18.8L12 4Z" />
+      <line className="cam-alert-line" x1="12" y1="10" x2="12" y2="14" />
+      <circle className="cam-alert-dot" cx="12" cy="17.4" r="0.5" />
+    </g>
   ),
   arrowUp: (
-    <>
+    <g className="cam-arrow-up">
       <line x1="12" y1="19" x2="12" y2="5.5" />
       <polyline points="6 11 12 5 18 11" />
-    </>
+    </g>
   ),
   download: (
     <>
-      <path d="M12 3.5v11" />
-      <polyline points="7.5 10 12 14.5 16.5 10" />
-      <path d="M5 19.5h14" />
+      <path className="cam-download-stem" d="M12 3.5v11" />
+      <polyline className="cam-download-head" points="7.5 10 12 14.5 16.5 10" />
+      <path className="cam-download-tray" d="M5 19.5h14" />
     </>
   ),
+  play: <path className="cam-play-triangle" d="M8 5.5v13l10-6.5-10-6.5Z" />,
   pause: (
     <>
-      <line x1="9.5" y1="6" x2="9.5" y2="18" />
-      <line x1="14.5" y1="6" x2="14.5" y2="18" />
+      <line className="cam-pause-left" x1="9.5" y1="6" x2="9.5" y2="18" />
+      <line className="cam-pause-right" x1="14.5" y1="6" x2="14.5" y2="18" />
     </>
   ),
   loader: <path d="M12 3.5a8.5 8.5 0 1 0 8.5 8.5" />,
   refresh: (
-    <>
+    <g className="cam-refresh">
       <path d="M20 11.5a8 8 0 1 0-1.9 6.4" />
       <polyline points="20 4.5 20 11.5 13 11.5" />
-    </>
+    </g>
   ),
   gear: (
     <>
-      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-      <circle cx="12" cy="12" r="3" />
+      <path className="cam-gear-body" d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle className="cam-gear-center" cx="12" cy="12" r="3" />
     </>
   ),
   shield: (
-    <>
-      <path d="M12 3 5 5.7v5.3c0 4.3 3 7.6 7 9.5 4-1.9 7-5.2 7-9.5V5.7L12 3Z" />
-      <polyline points="9 12 11 14 15 9.6" />
-    </>
+    <g className="cam-shield">
+      <path className="cam-shield-body" d="M12 3 5 5.7v5.3c0 4.3 3 7.6 7 9.5 4-1.9 7-5.2 7-9.5V5.7L12 3Z" />
+      <polyline className="cam-shield-check" points="9 12 11 14 15 9.6" />
+    </g>
   ),
   info: (
     <>
-      <circle cx="12" cy="12" r="8.5" />
-      <line x1="12" y1="11" x2="12" y2="16.5" />
-      <circle cx="12" cy="7.6" r="0.5" />
+      <circle className="cam-info-circle" cx="12" cy="12" r="8.5" />
+      <line className="cam-info-line" x1="12" y1="11" x2="12" y2="16.5" />
+      <circle className="cam-info-dot" cx="12" cy="7.6" r="0.5" />
     </>
   ),
-  chevron: <polyline points="9 6 15 12 9 18" />,
-  back: <polyline points="15 6 9 12 15 18" />,
+  chevron: <polyline className="cam-chevron" points="9 6 15 12 9 18" />,
+  back: <polyline className="cam-back" points="15 6 9 12 15 18" />,
   trash: (
     <>
-      <path d="M5 7h14" />
-      <path d="M9.5 7V5.2A1.2 1.2 0 0 1 10.7 4h2.6a1.2 1.2 0 0 1 1.2 1.2V7" />
+      <path className="cam-trash-lid" d="M5 7h14" />
+      <path className="cam-trash-handle" d="M9.5 7V5.2A1.2 1.2 0 0 1 10.7 4h2.6a1.2 1.2 0 0 1 1.2 1.2V7" />
       <path d="M6.5 7l.8 12.1A1.3 1.3 0 0 0 8.6 20.4h6.8a1.3 1.3 0 0 0 1.3-1.3L17.5 7" />
     </>
   ),
@@ -96,43 +99,43 @@ const PATHS: Record<IconName, ReactNode> = {
     <>
       <line x1="4" y1="8" x2="20" y2="8" />
       <line x1="4" y1="16" x2="20" y2="16" />
-      <circle cx="9" cy="8" r="2.3" />
-      <circle cx="15" cy="16" r="2.3" />
+      <circle className="cam-slider-a" cx="9" cy="8" r="2.3" />
+      <circle className="cam-slider-b" cx="15" cy="16" r="2.3" />
     </>
   ),
   message: (
-    <path d="M5 5h14a1.5 1.5 0 0 1 1.5 1.5v8A1.5 1.5 0 0 1 19 16H9l-4 3.5V6.5A1.5 1.5 0 0 1 5 5Z" />
+    <path className="cam-message" d="M5 5h14a1.5 1.5 0 0 1 1.5 1.5v8A1.5 1.5 0 0 1 19 16H9l-4 3.5V6.5A1.5 1.5 0 0 1 5 5Z" />
   ),
   folder: (
     <>
-      <path d="M4 6.5h6l2 2h8v9A1.5 1.5 0 0 1 18.5 19h-13A1.5 1.5 0 0 1 4 17.5Z" />
-      <path d="M4 9h16" />
+      <path className="cam-folder-body" d="M4 6.5h6l2 2h8v9A1.5 1.5 0 0 1 18.5 19h-13A1.5 1.5 0 0 1 4 17.5Z" />
+      <path className="cam-folder-lid" d="M4 9h16" />
     </>
   ),
   copy: (
     <>
-      <rect x="8" y="8" width="11" height="11" rx="1.5" />
-      <path d="M5 15.5V6.5A1.5 1.5 0 0 1 6.5 5h9" />
+      <path className="cam-copy-back" d="M5 15.5V6.5A1.5 1.5 0 0 1 6.5 5h9" />
+      <rect className="cam-copy-front" x="8" y="8" width="11" height="11" rx="1.5" />
     </>
   ),
   globe: (
-    <>
+    <g className="cam-globe">
       <circle cx="12" cy="12" r="8.5" />
       <path d="M3.5 12h17M12 3.5c2.5 2.4 2.5 14.6 0 17M12 3.5c-2.5 2.4-2.5 14.6 0 17" />
-    </>
+    </g>
   ),
   external: (
     <>
-      <path d="M14 5h5v5" />
-      <path d="M19 5l-8 8" />
+      <path className="cam-external-arrow" d="M14 5h5v5" />
+      <path className="cam-external-arrow" d="M19 5l-8 8" />
       <path d="M18 14v4.5A1.5 1.5 0 0 1 16.5 20h-11A1.5 1.5 0 0 1 4 18.5v-11A1.5 1.5 0 0 1 5.5 6H10" />
     </>
   ),
-  minimize: <line x1="6" y1="12" x2="18" y2="12" />,
+  minimize: <line className="cam-minimize" x1="6" y1="12" x2="18" y2="12" />,
   close: (
     <>
-      <line x1="6" y1="6" x2="18" y2="18" />
-      <line x1="18" y1="6" x2="6" y2="18" />
+      <line className="cam-close-a" x1="6" y1="6" x2="18" y2="18" />
+      <line className="cam-close-b" x1="18" y1="6" x2="6" y2="18" />
     </>
   ),
 };
@@ -140,7 +143,7 @@ const PATHS: Record<IconName, ReactNode> = {
 export function Icon({ name, className }: { name: IconName; className?: string }) {
   return (
     <svg
-      className={className}
+      className={["cam-icon", `cam-icon-${name}`, className].filter(Boolean).join(" ")}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/src/app/motion.ts
+++ b/src/app/motion.ts
@@ -8,11 +8,10 @@ import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
 import { CustomEase } from "gsap/CustomEase";
 import { DrawSVGPlugin } from "gsap/DrawSVGPlugin";
-import { Flip } from "gsap/Flip";
 import { SplitText } from "gsap/SplitText";
 import type { RefObject } from "react";
 
-gsap.registerPlugin(useGSAP, CustomEase, DrawSVGPlugin, Flip, SplitText);
+gsap.registerPlugin(useGSAP, CustomEase, DrawSVGPlugin, SplitText);
 
 // Signature curves — smooth deceleration (no tacky bounce); "pop" is a
 // restrained overshoot reserved for the focal medallion.
@@ -20,7 +19,7 @@ CustomEase.create("cam-out", "0.16, 1, 0.3, 1"); // expo-out settle
 CustomEase.create("cam-in-out", "0.65, 0, 0.35, 1");
 CustomEase.create("cam-pop", "0.34, 1.3, 0.5, 1"); // gentle overshoot
 
-export { gsap, useGSAP, Flip, SplitText };
+export { gsap, useGSAP, SplitText };
 
 interface HomeMotionOpts {
   /** Reveal the headline character-by-character (skip for shimmer/loading text,

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -435,10 +435,252 @@ input {
   width: 16px;
   height: 16px;
 }
+.cam-icon {
+  overflow: visible;
+  pointer-events: none;
+}
+.cam-icon :is(g, path, polyline, line, circle, rect) {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+/* Hover / focus-visible micro-animations for the stroke icon set. One shared
+   trigger list — interactive hosts plus the manual `.cam-anim-trigger` opt-in
+   hook for non-interactive containers. The whole block sits behind
+   prefers-reduced-motion: no-preference, mirroring the GSAP matchMedia gate in
+   motion.ts, so reduced-motion users get fully static icons (including the
+   dasharray setup, which would otherwise leave check strokes dashed). */
+@media (prefers-reduced-motion: no-preference) {
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-check-mark {
+    stroke-dasharray: 20;
+    animation: cam-stroke-draw 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-alert-body {
+    animation: cam-alert-pop 0.38s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) :is(.cam-alert-line, .cam-alert-dot) {
+    animation: cam-pulse 0.55s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-arrow-up {
+    animation: cam-lift 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) :is(.cam-download-stem, .cam-download-head) {
+    animation: cam-download-drop 0.9s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-download-tray {
+    animation: cam-tray-bounce 0.9s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-play-triangle {
+    animation: cam-play-squeeze 0.38s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) :is(.cam-pause-left, .cam-pause-right) {
+    animation: cam-pause-squeeze 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-refresh {
+    animation: cam-half-spin 0.5s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-gear-body {
+    animation: cam-full-spin 0.9s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-gear-center {
+    animation: cam-center-pop 0.36s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-shield-body {
+    animation: cam-shield-guard 0.46s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-shield-check {
+    stroke-dasharray: 12;
+    animation: cam-stroke-draw 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) :is(.cam-info-line, .cam-info-dot) {
+    animation: cam-info-nudge 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) :is(.cam-chevron, .cam-back) {
+    animation: cam-side-nudge 0.32s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) :is(.cam-trash-lid, .cam-trash-handle) {
+    animation: cam-trash-open 0.34s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-slider-a {
+    animation: cam-slide-right 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-slider-b {
+    animation: cam-slide-left 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-message {
+    animation: cam-message-pop 0.42s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-folder-lid {
+    animation: cam-folder-open 0.34s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-copy-front {
+    animation: cam-copy-slide 0.36s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-globe {
+    animation: cam-globe-turn 0.64s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-external-arrow {
+    animation: cam-external-lift 0.36s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) .cam-minimize {
+    animation: cam-minimize-settle 0.3s var(--ease) both;
+  }
+  :where(.cam-anim-trigger, button:not(:disabled), a, [role="button"], .row, .install-root-copy, .ring):is(:hover, :focus-visible) :is(.cam-close-a, .cam-close-b) {
+    animation: cam-close-snap 0.28s var(--ease) both;
+  }
+}
 .spinicon {
   animation: spin 0.8s linear infinite;
   transform-box: fill-box;
   transform-origin: center;
+}
+@keyframes cam-stroke-draw {
+  from {
+    stroke-dashoffset: 20;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes cam-alert-pop {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  55% {
+    transform: translateY(-1.5px) scale(1.06);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes cam-pulse {
+  50% {
+    opacity: 0.45;
+    transform: scale(0.82);
+  }
+}
+@keyframes cam-lift {
+  45% {
+    transform: translateY(-2px);
+  }
+}
+@keyframes cam-download-drop {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  38% {
+    transform: translateY(6px);
+    opacity: 0;
+  }
+  48% {
+    transform: translateY(-6px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@keyframes cam-tray-bounce {
+  48% {
+    transform: translateY(0);
+  }
+  65% {
+    transform: translateY(1.5px) scaleX(1.08);
+  }
+}
+@keyframes cam-play-squeeze {
+  50% {
+    transform: scale(0.84);
+  }
+}
+@keyframes cam-pause-squeeze {
+  50% {
+    transform: scaleY(0.78);
+  }
+}
+@keyframes cam-half-spin {
+  to {
+    transform: rotate(180deg);
+  }
+}
+@keyframes cam-full-spin {
+  55% {
+    transform: rotate(360deg) scale(1.03);
+  }
+  100% {
+    transform: rotate(360deg) scale(1);
+  }
+}
+@keyframes cam-center-pop {
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes cam-shield-guard {
+  50% {
+    transform: translateY(-1px) scale(1.04);
+  }
+}
+@keyframes cam-info-nudge {
+  45% {
+    transform: translateY(-1px);
+  }
+}
+@keyframes cam-side-nudge {
+  50% {
+    transform: translateX(1.75px);
+  }
+}
+@keyframes cam-trash-open {
+  to {
+    transform: translate(-1px, -3px) rotate(-24deg);
+  }
+}
+@keyframes cam-slide-right {
+  55% {
+    transform: translateX(4px);
+  }
+}
+@keyframes cam-slide-left {
+  55% {
+    transform: translateX(-4px);
+  }
+}
+@keyframes cam-message-pop {
+  50% {
+    transform: translateY(-1px) scale(1.04);
+  }
+}
+@keyframes cam-folder-open {
+  55% {
+    transform: translateY(-2px) rotate(-5deg);
+  }
+}
+@keyframes cam-copy-slide {
+  50% {
+    transform: translate(2px, 2px);
+  }
+}
+@keyframes cam-globe-turn {
+  50% {
+    transform: rotate(-10deg) scale(1.03);
+  }
+}
+@keyframes cam-external-lift {
+  50% {
+    transform: translate(1.5px, -1.5px);
+  }
+}
+@keyframes cam-minimize-settle {
+  45% {
+    transform: translateY(1px) scaleX(0.82);
+  }
+}
+@keyframes cam-close-snap {
+  50% {
+    transform: rotate(8deg) scale(1.08);
+  }
 }
 
 /* sub-view nav bar */
@@ -940,6 +1182,10 @@ button.row:active {
   color: var(--text-soft);
   flex-shrink: 0;
 }
+.row .ricon svg {
+  width: 100%;
+  height: 100%;
+}
 .row .rtext {
   flex: 1;
   min-width: 0;
@@ -974,6 +1220,10 @@ button.row:active {
   height: 16px;
   flex-shrink: 0;
   transition: transform 0.18s var(--ease), color 0.18s var(--ease);
+}
+.row .chev svg {
+  width: 100%;
+  height: 100%;
 }
 button.row:hover .chev {
   color: var(--text-soft);
@@ -1046,6 +1296,10 @@ button.row.danger:hover {
   color: var(--text-soft);
   flex-shrink: 0;
   margin-top: 1px;
+}
+.install-root-copy .ricon svg {
+  width: 100%;
+  height: 100%;
 }
 .install-root-copy .rtext {
   min-width: 0;
@@ -1399,6 +1653,14 @@ button.row.danger:hover {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-xs);
   animation: risein 0.22s var(--ease-out) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .schedule-panel {
+    transition: none;
+  }
+  .interval-grid {
+    animation: none;
+  }
 }
 .interval-grid label {
   display: grid;
@@ -1997,6 +2259,7 @@ button.row.danger:hover {
   .bar-fill.indeterminate,
   .ring.spin svg,
   .spinicon,
+  .cam-icon *,
   .view > * {
     animation: none !important;
   }

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { Pause, Play, XCircle } from "lucide-react";
 
 import {
   errorCode,
@@ -655,7 +654,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
             <div className="progress-actions">
               {paused ? (
                 <button className="btn primary" onClick={resumeDownload}>
-                  <Play />
+                  <Icon name="play" />
                   {t("progress.resume")}
                 </button>
               ) : (
@@ -664,7 +663,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
                   onClick={() => void requestDownloadStop("pause")}
                   disabled={!canPause}
                 >
-                  <Pause />
+                  <Icon name="pause" />
                   {downloadStop === "pause" ? t("progress.pausePending") : t("progress.pause")}
                 </button>
               )}
@@ -676,7 +675,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
                 }}
                 disabled={!paused && !canCancel}
               >
-                <XCircle />
+                <Icon name="close" />
                 {downloadStop === "cancel" ? t("progress.cancelPending") : t("progress.cancel")}
               </button>
             </div>

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { Pause, Play, XCircle } from "lucide-react";
 
 import {
   errorCode,
@@ -618,7 +617,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
             <div className="progress-actions">
               {paused ? (
                 <button className="btn primary" onClick={resumeDownload}>
-                  <Play />
+                  <Icon name="play" />
                   {t("progress.resume")}
                 </button>
               ) : (
@@ -627,7 +626,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
                   onClick={() => void requestDownloadStop("pause")}
                   disabled={!canPause}
                 >
-                  <Pause />
+                  <Icon name="pause" />
                   {downloadStop === "pause" ? t("progress.pausePending") : t("progress.pause")}
                 </button>
               )}
@@ -639,7 +638,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
                 }}
                 disabled={!paused && !canCancel}
               >
-                <XCircle />
+                <Icon name="close" />
                 {downloadStop === "cancel" ? t("progress.cancelPending") : t("progress.cancel")}
               </button>
             </div>


### PR DESCRIPTION
## Summary
- Replace the last three lucide-react icons (Play/Pause/XCircle on the progress screen) with the in-house 24px stroke set and **drop the lucide-react dependency**.
- Add lightweight hover / focus-visible micro-animations to the stroke icons via stable `cam-*` part classes. One shared trigger list (interactive hosts + a manual `.cam-anim-trigger` opt-in hook) instead of per-rule duplicated selectors.
- Gate the entire animation block behind `prefers-reduced-motion: no-preference`, mirroring the GSAP `matchMedia` gate in `motion.ts` — reduced-motion users keep fully static icons (including the dasharray setup).
- Close two pre-existing reduced-motion gaps: `.schedule-panel` transition and `.interval-grid` entrance.
- Remove the registered-but-unused GSAP `Flip` plugin.

## Verification
- `tsc --noEmit` clean, 46/46 vitest passing, production build OK.
- Verified in browser preview: all 25 animation rules sit inside the `no-preference` media gate, no standalone dead `.cam-anim-trigger` selectors remain, icons render correctly.
- `codex review --uncommitted`: no findings.