### PR TITLE
fix(a11y): switch names, real radio semantics, keyboard nav

### DIFF
--- a/src/app/components.tsx
+++ b/src/app/components.tsx
@@ -5,6 +5,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -290,6 +291,42 @@ export function ResultBanner({
   );
 }
 
+/** Shared arrow-key contract for the button-based radio groups (Segmented,
+ *  the settings source / install-mode lists, the language grid): arrows move
+ *  AND select, wrapping at the ends; roving tabindex keeps Tab a single stop.
+ *  Horizontal arrows follow the group's writing direction so RTL (Arabic)
+ *  isn't mirrored. Returns the key to select (focus moves with it via the
+ *  roving tabIndex render), or null for keys the group doesn't own. Ignores
+ *  events from non-radio targets so inputs inside the group keep their caret
+ *  keys. */
+export function radioNavTarget(
+  keys: string[],
+  value: string,
+  event: KeyboardEvent<HTMLElement>,
+  container: HTMLElement | null,
+): string | null {
+  const { key } = event;
+  if (key !== "ArrowLeft" && key !== "ArrowRight" && key !== "ArrowUp" && key !== "ArrowDown") {
+    return null;
+  }
+  const target = event.target as HTMLElement | null;
+  if (target && target.getAttribute("role") !== "radio") return null;
+  event.preventDefault();
+  // Only the horizontal pair mirrors with the writing direction; Up/Down are
+  // direction-agnostic.
+  const rtl = container ? getComputedStyle(container).direction === "rtl" : false;
+  const horizontal = key === "ArrowLeft" || key === "ArrowRight";
+  const forward = horizontal ? (key === "ArrowRight") !== rtl : key === "ArrowDown";
+  const idx = keys.indexOf(value);
+  const next = keys[(idx + (forward ? 1 : keys.length - 1)) % keys.length];
+  // Focus the radio that is about to become checked. It carries tabIndex=-1
+  // until the re-render lands, so look it up positionally.
+  container
+    ?.querySelectorAll<HTMLElement>('[role="radio"]')
+    [keys.indexOf(next)]?.focus();
+  return next;
+}
+
 export interface SegmentedItem {
   key: string;
   label: ReactNode;
@@ -321,7 +358,7 @@ export function Segmented({
     const bar = barRef.current;
     const pill = pillRef.current;
     if (!bar || !pill) return;
-    const active = bar.querySelector<HTMLElement>('[aria-selected="true"]');
+    const active = bar.querySelector<HTMLElement>('[aria-checked="true"]');
     // offsetWidth is 0 while collapsed (e.g. inside a closed schedule panel) or
     // under jsdom — skip so we don't pin the pill to a zero-width ghost.
     if (!active || active.offsetWidth === 0) return;
@@ -359,13 +396,26 @@ export function Segmented({
     return () => ro.disconnect();
   }, [place]);
 
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const next = radioNavTarget(
+      items.map((item) => item.key),
+      value,
+      event,
+      barRef.current,
+    );
+    if (next === null) return;
+    onChange(next);
+  };
+
   return (
-    <div className="seg" ref={barRef} aria-label={ariaLabel}>
+    <div className="seg" ref={barRef} role="radiogroup" aria-label={ariaLabel} onKeyDown={onKeyDown}>
       <span className="seg-pill" aria-hidden="true" ref={pillRef} />
       {items.map((item) => (
         <button
           key={item.key}
-          aria-selected={value === item.key}
+          role="radio"
+          aria-checked={value === item.key}
+          tabIndex={value === item.key ? 0 : -1}
           onClick={() => onChange(item.key)}
         >
           {item.label}
@@ -379,16 +429,21 @@ export function Toggle({
   checked,
   onChange,
   disabled = false,
+  ariaLabelledBy,
 }: {
   checked: boolean;
   onChange?: (v: boolean) => void;
   disabled?: boolean;
+  /** id of the visible row title — the switch itself renders no text, so
+   *  without this a screen reader announces a nameless "switch, on". */
+  ariaLabelledBy?: string;
 }) {
   return (
     <button
       className="toggle"
       role="switch"
       aria-checked={checked}
+      aria-labelledby={ariaLabelledBy}
       disabled={disabled}
       onClick={() => onChange?.(!checked)}
     />

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1347,10 +1347,10 @@ button.row.danger:hover {
   border-radius: var(--r-sm);
   transition: color 0.18s var(--ease);
 }
-.seg button:hover:not([aria-selected="true"]) {
+.seg button:hover:not([aria-checked="true"]) {
   color: var(--text);
 }
-.seg button[aria-selected="true"] {
+.seg button[aria-checked="true"] {
   color: var(--text);
 }
 @media (prefers-reduced-motion: reduce) {
@@ -2065,11 +2065,11 @@ button.row.danger:hover {
   transition: background 0.18s var(--ease), color 0.18s var(--ease),
     box-shadow 0.18s var(--ease), border-color 0.18s var(--ease);
 }
-.langgrid button:hover:not([aria-selected="true"]) {
+.langgrid button:hover:not([aria-checked="true"]) {
   background: var(--surface);
   color: var(--text);
 }
-.langgrid button[aria-selected="true"] {
+.langgrid button[aria-checked="true"] {
   background: linear-gradient(180deg, var(--surface-3-top), var(--surface-3));
   color: var(--text);
   border-color: var(--line-2);

--- a/src/app/useFocusTrap.ts
+++ b/src/app/useFocusTrap.ts
@@ -1,7 +1,10 @@
 import { useEffect, type RefObject } from "react";
 
+// tabindex="-1" is excluded everywhere so a roving-tabindex radio group (the
+// language grid) counts as ONE Tab stop — otherwise the trap's first/last
+// cycling would disagree with what the browser actually tabs to.
 const FOCUSABLE =
-  'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])';
+  'button:not(:disabled):not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not(:disabled):not([tabindex="-1"]), select:not(:disabled):not([tabindex="-1"]), textarea:not(:disabled):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
 
 export function getFocusable(root: HTMLElement): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((el) => {
@@ -68,7 +71,9 @@ export function useFocusTrap(
         node.tabIndex = -1;
         return node;
       }
-      return node.querySelector<HTMLElement>('[aria-selected="true"]') ?? focusables[0];
+      return (
+        node.querySelector<HTMLElement>('[role="radio"][aria-checked="true"]') ?? focusables[0]
+      );
     };
     pick()?.focus();
 

--- a/src/app/views/Settings.tsx
+++ b/src/app/views/Settings.tsx
@@ -4,9 +4,9 @@ import { errorMessage, managerApi } from "../../services/managerApi";
 import type { AppSettings, ProxyMode, UpdateSourceKind, WindowsInstallMode } from "../../shared/types";
 import { DEFAULT_SETTINGS } from "../../shared/types";
 import { Icon } from "../icons";
-import { useI18n, LANGS, type TFn, type TKey } from "../i18n";
+import { useI18n, LANGS, type Lang, type TFn, type TKey } from "../i18n";
 import { useTheme, type ThemeMode } from "../theme";
-import { NavBar, Segmented, Toggle } from "../components";
+import { NavBar, Segmented, Toggle, radioNavTarget } from "../components";
 import { isWindows } from "../platform";
 import { Sheet } from "../Sheet";
 import { useSettingsSaver } from "./useSettingsSaver";
@@ -115,6 +115,9 @@ export function Settings({
   const [langSheet, setLangSheet] = useState(false);
   const [customIntervalOpen, setCustomIntervalOpen] = useState(false);
   const langTitleId = useId();
+  // Prefix for the switch-row title ids — each Toggle names itself off its
+  // visible row title via aria-labelledby.
+  const switchId = useId();
 
   useEffect(() => {
     void managerApi.getSettings().then(reset).catch(() => undefined);
@@ -211,12 +214,29 @@ export function Settings({
         {/* 更新源 */}
         <div className="group">
           <div className="group-h">{t("settings.source.header")}</div>
-          <div className="list">
+          <div
+            className="list"
+            role="radiogroup"
+            aria-label={t("settings.source.header")}
+            onKeyDown={(event) => {
+              const next = radioNavTarget(
+                availableSources.map((src) => src.kind),
+                s.source,
+                event,
+                event.currentTarget,
+              );
+              if (next === null) return;
+              setCommandError(null);
+              update({ ...s, source: next as UpdateSourceKind });
+            }}
+          >
             {availableSources.map((src) => (
               <button
                 key={src.kind}
                 className="row"
+                role="radio"
                 aria-checked={s.source === src.kind}
+                tabIndex={s.source === src.kind ? 0 : -1}
                 onClick={() => {
                   setCommandError(null);
                   update({ ...s, source: src.kind });
@@ -240,6 +260,7 @@ export function Settings({
               <div className="row" style={{ display: "block" }}>
                 <input
                   className="input mono"
+                  aria-label={t("settings.source.custom")}
                   value={s.customUrl}
                   placeholder={t("settings.source.customPlaceholder")}
                   onChange={(e) => setDraft({ ...s, customUrl: e.target.value })}
@@ -256,12 +277,29 @@ export function Settings({
         {win ? (
           <div className="group">
             <div className="group-h">{t("settings.windows.header")}</div>
-            <div className="list">
+            <div
+              className="list"
+              role="radiogroup"
+              aria-label={t("settings.windows.header")}
+              onKeyDown={(event) => {
+                const next = radioNavTarget(
+                  WINDOWS_INSTALL_MODES.map((mode) => mode.kind),
+                  s.windowsInstallMode,
+                  event,
+                  event.currentTarget,
+                );
+                if (next === null) return;
+                setCommandError(null);
+                update({ ...s, windowsInstallMode: next as WindowsInstallMode });
+              }}
+            >
               {WINDOWS_INSTALL_MODES.map((mode) => (
                 <button
                   key={mode.kind}
                   className="row"
+                  role="radio"
                   aria-checked={s.windowsInstallMode === mode.kind}
+                  tabIndex={s.windowsInstallMode === mode.kind ? 0 : -1}
                   onClick={() => {
                     setCommandError(null);
                     update({ ...s, windowsInstallMode: mode.kind });
@@ -356,9 +394,10 @@ export function Settings({
           <div className="list">
             <div className="row">
               <span className="rtext">
-                <span className="rtitle">{t("settings.general.checkOnStartup")}</span>
+                <span className="rtitle" id={`${switchId}-startup`}>{t("settings.general.checkOnStartup")}</span>
               </span>
               <Toggle
+                ariaLabelledBy={`${switchId}-startup`}
                 checked={s.checkOnStartup}
                 onChange={(v) => {
                   setCommandError(null);
@@ -368,9 +407,10 @@ export function Settings({
             </div>
             <div className="row">
               <span className="rtext">
-                <span className="rtitle">{t("settings.general.periodicCheck")}</span>
+                <span className="rtitle" id={`${switchId}-periodic`}>{t("settings.general.periodicCheck")}</span>
               </span>
               <Toggle
+                ariaLabelledBy={`${switchId}-periodic`}
                 checked={s.periodicCheck}
                 onChange={(v) => {
                   setCommandError(null);
@@ -454,9 +494,10 @@ export function Settings({
             </div>
             <div className="row">
               <span className="rtext">
-                <span className="rtitle">{t("settings.general.askBefore")}</span>
+                <span className="rtitle" id={`${switchId}-ask`}>{t("settings.general.askBefore")}</span>
               </span>
               <Toggle
+                ariaLabelledBy={`${switchId}-ask`}
                 checked={s.askBefore}
                 onChange={(v) => {
                   setCommandError(null);
@@ -466,9 +507,10 @@ export function Settings({
             </div>
             <div className="row">
               <span className="rtext">
-                <span className="rtitle">{t("settings.general.disableCodexSelfUpdates")}</span>
+                <span className="rtitle" id={`${switchId}-noselfupdate`}>{t("settings.general.disableCodexSelfUpdates")}</span>
               </span>
               <Toggle
+                ariaLabelledBy={`${switchId}-noselfupdate`}
                 checked={s.disableCodexSelfUpdates}
                 onChange={(v) => {
                   setCommandError(null);
@@ -478,16 +520,21 @@ export function Settings({
             </div>
             <div className="row">
               <span className="rtext">
-                <span className="rtitle">{t("settings.general.autostart")}</span>
+                <span className="rtitle" id={`${switchId}-autostart`}>{t("settings.general.autostart")}</span>
                 <span className="rsub">{t("settings.general.autostartNote")}</span>
               </span>
-              <Toggle checked={autostart} onChange={toggleAutostart} />
+              <Toggle
+                ariaLabelledBy={`${switchId}-autostart`}
+                checked={autostart}
+                onChange={toggleAutostart}
+              />
             </div>
             <div className="row">
               <span className="rtext">
-                <span className="rtitle">{t("settings.general.confirmClose")}</span>
+                <span className="rtitle" id={`${switchId}-confirmclose`}>{t("settings.general.confirmClose")}</span>
               </span>
               <Toggle
+                ariaLabelledBy={`${switchId}-confirmclose`}
                 checked={s.confirmClose}
                 onChange={(v) => {
                   setCommandError(null);
@@ -600,12 +647,31 @@ export function Settings({
         initialFocus="first"
       >
         <h3 id={langTitleId}>{t("settings.appearance.language")}</h3>
-        <div className="langgrid" style={{ marginTop: 14 }}>
+        <div
+          className="langgrid"
+          style={{ marginTop: 14 }}
+          role="radiogroup"
+          aria-labelledby={langTitleId}
+          onKeyDown={(event) => {
+            // Arrow-selecting previews the language in place; activating
+            // (Enter/Space → click) is what commits AND closes the sheet.
+            const next = radioNavTarget(
+              LANGS.map((l) => l.code),
+              lang,
+              event,
+              event.currentTarget,
+            );
+            if (next === null) return;
+            setLang(next as Lang);
+          }}
+        >
           {LANGS.map((l) => (
             <button
               key={l.code}
               lang={l.code}
-              aria-selected={lang === l.code}
+              role="radio"
+              aria-checked={lang === l.code}
+              tabIndex={lang === l.code ? 0 : -1}
               onClick={() => {
                 setLangSheet(false);
                 setLang(l.code);

--- a/src/app/views/Uninstall.tsx
+++ b/src/app/views/Uninstall.tsx
@@ -36,6 +36,7 @@ export function Uninstall({ onBack }: { onBack: () => void }) {
   const confirm1BodyId = useId();
   const confirm2TitleId = useId();
   const confirm2BodyId = useId();
+  const keepDataTitleId = useId();
 
   useEffect(() => {
     const load = win ? managerApi.winStatus() : managerApi.macStatus();
@@ -118,10 +119,15 @@ export function Uninstall({ onBack }: { onBack: () => void }) {
             <div className="list">
               <div className="row">
                 <span className="rtext">
-                  <span className="rtitle">{t("uninstall.keepData")}</span>
+                  <span className="rtitle" id={keepDataTitleId}>{t("uninstall.keepData")}</span>
                   <span className="rsub">{t("uninstall.keepDataNote", { path: codexHome })}</span>
                 </span>
-                <Toggle checked={keepData} onChange={setKeepData} disabled={busy} />
+                <Toggle
+                  ariaLabelledBy={keepDataTitleId}
+                  checked={keepData}
+                  onChange={setKeepData}
+                  disabled={busy}
+                />
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- `Toggle` names itself off the visible row title via `aria-labelledby` (6 settings switches + uninstall keep-data) — screen readers previously announced a nameless "switch, on".
- The settings source list, Windows install-mode list, language grid and `Segmented` control now expose `role="radiogroup"` / `role="radio"` + `aria-checked`. The previous bare `aria-checked` / `aria-selected` on plain buttons is invalid ARIA that assistive tech ignores.
- Full radio keyboard contract via a shared `radioNavTarget` helper: arrows move and select with wrap-around, horizontal arrows mirror with RTL (vertical arrows stay direction-agnostic), roving tabindex keeps Tab a single stop per group.
- Focus trap excludes `tabindex="-1"` so a roving group counts as one Tab stop, and initial sheet focus targets `[role="radio"][aria-checked="true"]` (language sheet opens on the current language).
- Custom source URL input gains an `aria-label`.

## Verification
- `tsc --noEmit` clean, 46/46 vitest passing.
- Browser preview: verified radiogroup/radio roles, roving tabindex `[0,-1,-1,-1]`, ArrowDown moves selection + focus in the source list, ArrowRight slides the Segmented pill, Toggle accname resolves to "启动时自动检查更新".
- `codex review --uncommitted` iterated to no findings (fixed its two review comments: missing keyboard contract on the new radio groups; RTL ArrowUp direction bug).