### PR TITLE
fix(robustness): calmer global errors, contract guards, safer interpolation, event-driven sheet exit

### DIFF
--- a/src/app/Sheet.tsx
+++ b/src/app/Sheet.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 
 import { useFocusTrap } from "./useFocusTrap";
 
-// Keep in sync with the longest `.sheet-frame.is-closing` exit transition in
-// styles.css — once it elapses the sheet is actually unmounted.
-const CLOSE_MS = 240;
+// Upper bound on the exit. Unmount is driven by the frame's animationend
+// (the `.is-closing` exit is a CSS animation); this only needs to be ≥ the
+// longest exit in styles.css, as the safety net for environments where the
+// animation never fires (jsdom, display:none ancestors).
+const CLOSE_FALLBACK_MS = 400;
 
 function prefersReducedMotion(): boolean {
   return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
@@ -30,12 +32,15 @@ export function Sheet({
   children: ReactNode;
 }) {
   const sheetRef = useRef<HTMLDivElement>(null);
+  const frameRef = useRef<HTMLDivElement>(null);
   // Keep the sheet in the DOM through its exit. `mounted` only *lags* `open` on
   // close: presence is `open || mounted`, so opening shows the node immediately
   // (the focus trap can grab focus the same render) while closing keeps the same
   // node around. The closing flag is derived live as `!open`, so the frame `open`
   // flips false the *existing* node gains `.is-closing` and the exit transition
-  // animates from its current state — then a timer drops `mounted` to unmount.
+  // animates from its current state — unmount happens on the frame's own
+  // animationend (with a timeout safety net), so the CSS duration can change
+  // without touching this file.
   // (Driving `.is-closing` off an effect-set state instead would unmount the node
   // before the class lands, so the exit would never play.)
   const [mounted, setMounted] = useState(open);
@@ -50,8 +55,17 @@ export function Sheet({
       setMounted(false);
       return;
     }
-    const id = window.setTimeout(() => setMounted(false), CLOSE_MS);
-    return () => window.clearTimeout(id);
+    const frame = frameRef.current;
+    const finish = () => setMounted(false);
+    const onAnimationEnd = (event: AnimationEvent) => {
+      if (event.target === frame) finish();
+    };
+    frame?.addEventListener("animationend", onAnimationEnd);
+    const id = window.setTimeout(finish, CLOSE_FALLBACK_MS);
+    return () => {
+      frame?.removeEventListener("animationend", onAnimationEnd);
+      window.clearTimeout(id);
+    };
   }, [open, mounted]);
 
   // Ignore dismissals once the exit is playing (`open` already false). The trap
@@ -73,6 +87,7 @@ export function Sheet({
   return (
     <div className={`${scrimClass}${closing ? " is-closing" : ""}`} onClick={dismiss}>
       <div
+        ref={frameRef}
         className={`sheet-frame${closing ? " is-closing" : ""}`}
         onClick={(event) => event.stopPropagation()}
       >

--- a/src/app/globalErrors.test.ts
+++ b/src/app/globalErrors.test.ts
@@ -40,4 +40,49 @@ describe("installGlobalErrorHandlers", () => {
 
     window.removeEventListener("cam:fatal", fatal);
   });
+
+  it("ignores benign ResizeObserver noise entirely", () => {
+    const fatal = vi.fn();
+    window.addEventListener("cam:fatal", fatal);
+    installGlobalErrorHandlers();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", {
+        message: "ResizeObserver loop completed with undelivered notifications.",
+      }),
+    );
+
+    expect(reportFrontendError).not.toHaveBeenCalled();
+    expect(fatal).not.toHaveBeenCalled();
+    window.removeEventListener("cam:fatal", fatal);
+  });
+
+  it("still escalates non-Error throwables to fatal", () => {
+    const fatal = vi.fn();
+    window.addEventListener("cam:fatal", fatal);
+    installGlobalErrorHandlers();
+
+    // `throw "boom"` — event.error is set but is not an Error instance.
+    window.dispatchEvent(new ErrorEvent("error", { message: "boom", error: "boom" }));
+
+    expect(reportFrontendError).toHaveBeenCalledTimes(1);
+    expect(fatal).toHaveBeenCalledTimes(1);
+    window.removeEventListener("cam:fatal", fatal);
+  });
+
+  it("reports error-less window.error events without escalating to fatal", () => {
+    const fatal = vi.fn();
+    window.addEventListener("cam:fatal", fatal);
+    installGlobalErrorHandlers();
+
+    // e.g. a failed resource load: the event carries a message but no Error.
+    window.dispatchEvent(new ErrorEvent("error", { message: "Script load failed" }));
+
+    expect(reportFrontendError).toHaveBeenCalledTimes(1);
+    expect(reportFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "window.error", message: "Script load failed" }),
+    );
+    expect(fatal).not.toHaveBeenCalled();
+    window.removeEventListener("cam:fatal", fatal);
+  });
 });

--- a/src/app/globalErrors.ts
+++ b/src/app/globalErrors.ts
@@ -2,6 +2,14 @@ import { managerApi } from "../services/managerApi";
 
 let installed = false;
 
+// Browser-noise messages that are neither reportable nor fatal: the
+// ResizeObserver pair is a well-known benign loop warning some engines
+// surface as a window.error.
+const BENIGN_MESSAGES = [
+  "ResizeObserver loop limit exceeded",
+  "ResizeObserver loop completed with undelivered notifications",
+];
+
 export function installGlobalErrorHandlers() {
   if (installed) {
     return;
@@ -9,14 +17,27 @@ export function installGlobalErrorHandlers() {
   installed = true;
 
   window.addEventListener("error", (event) => {
-    const error = event.error instanceof Error ? event.error : new Error(String(event.message));
+    const message =
+      event.error instanceof Error ? event.error.message : String(event.message ?? "");
+    if (BENIGN_MESSAGES.some((benign) => message.includes(benign))) {
+      return;
+    }
+    const error =
+      event.error instanceof Error ? event.error : new Error(message || "Unknown window.error");
     void managerApi.reportFrontendError({
       kind: "window.error",
       message: error.message,
       stack: error.stack ?? null,
       componentStack: null,
     });
-    window.dispatchEvent(new CustomEvent("cam:fatal", { detail: { error } }));
+    // Escalate to the full-screen fatal state whenever the window saw a real
+    // thrown value — including non-Error throwables like `throw "boom"`. Only
+    // error-LESS events (failed resource loads and other engine-synthesized
+    // noise, where event.error is null/undefined) are logged without blanking
+    // a perfectly healthy UI.
+    if (event.error != null) {
+      window.dispatchEvent(new CustomEvent("cam:fatal", { detail: { error } }));
+    }
   });
 
   window.addEventListener("unhandledrejection", (event) => {

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -2455,7 +2455,9 @@ export function I18nProvider({ children }: { children: ReactNode }) {
       let s = CATALOG[lang][key] ?? CATALOG.en[key] ?? key;
       if (vars) {
         for (const [k, v] of Object.entries(vars)) {
-          s = s.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          // split/join, not String.replace: an interpolated value containing
+          // "$&"/"$1" (e.g. a path or an error string) must land verbatim.
+          s = s.split(`{${k}}`).join(String(v));
         }
       }
       return s;

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1986,8 +1986,8 @@ button.row.danger:hover {
    down. Driven by an animation (not a transition) so it fires reliably the
    instant `.is-closing` lands — the resting `.sheet-frame`/`.scrim` carry no
    transition to interpolate from, so a same-frame transition wouldn't tween. The
-   Sheet component holds the node mounted for the duration (CLOSE_MS) before
-   unmounting, so dismiss no longer hard-cuts. */
+   Sheet component holds the node mounted until the frame's animationend (plus
+   a timeout safety net), so dismiss no longer hard-cuts. */
 @keyframes scrim-out {
   to {
     opacity: 0;

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -391,6 +391,74 @@ const FALLBACK_DIAGNOSTICS: Diagnostics = {
   generatedAtUnix: Math.floor(Date.now() / 1000),
 };
 
+// ── Contract guards ──────────────────────────────────────────────────────────
+// invoke<T>() is a bare type assertion: if the backend contract drifts (field
+// renamed, made nullable), the UI would otherwise crash deep in a render with
+// an unhelpful stack. Guard the load-bearing read paths — the report/status
+// shapes every home-screen decision keys on — and fail them as a readable
+// CommandError instead. Only structural keystones are checked, not every
+// field: enough to catch a desynced engine, cheap enough to never drift far
+// from the real types.
+
+function contractError(what: string): CommandError {
+  return {
+    code: "contract_mismatch",
+    message: `Backend returned an unexpected ${what} shape — the app and its engine may be out of sync. Reinstalling the manager usually fixes this.`,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function guardMacStatus(status: MacInstallStatus): MacInstallStatus {
+  const s = status as unknown;
+  if (
+    !isRecord(s) ||
+    typeof s.status !== "string" ||
+    (s.installed !== null && !(isRecord(s.installed) && typeof s.installed.build === "number"))
+  ) {
+    throw contractError("macOS install status");
+  }
+  return status;
+}
+
+function guardMacReport(report: MacUpdateReport): MacUpdateReport {
+  const r = report as unknown;
+  if (
+    !isRecord(r) ||
+    (r.installed !== null && !(isRecord(r.installed) && typeof r.installed.build === "number")) ||
+    (r.plan !== null && !(isRecord(r.plan) && typeof r.plan.upToDate === "boolean"))
+  ) {
+    throw contractError("macOS update report");
+  }
+  return report;
+}
+
+function guardWinStatus(status: WinInstallStatus): WinInstallStatus {
+  const s = status as unknown;
+  if (
+    !isRecord(s) ||
+    typeof s.status !== "string" ||
+    (s.installed !== null && !(isRecord(s.installed) && typeof s.installed.version === "string"))
+  ) {
+    throw contractError("Windows install status");
+  }
+  return status;
+}
+
+function guardWinReport(report: WinUpdateReport): WinUpdateReport {
+  const r = report as unknown;
+  if (
+    !isRecord(r) ||
+    !(isRecord(r.plan) && typeof r.plan.upToDate === "boolean") ||
+    (r.installed !== null && !(isRecord(r.installed) && typeof r.installed.version === "string"))
+  ) {
+    throw contractError("Windows update report");
+  }
+  return report;
+}
+
 export const managerApi = {
   armDestructive(kind: OperationKind): Promise<OperationToken> {
     if (!hasTauriRuntime()) {
@@ -404,7 +472,7 @@ export const managerApi = {
     }
     return invoke<MacUpdateReport>("mac_plan_update", {
       simulatedBuild: simulatedBuild ?? null,
-    });
+    }).then(guardMacReport);
   },
   // Destructive: reconstruct + codesign-gate + atomic swap + relaunch (or
   // rollback). `confirm` must be true; the backend rejects it otherwise. Guarded
@@ -463,7 +531,7 @@ export const managerApi = {
     if (!hasTauriRuntime()) {
       return Promise.resolve({ installed: null, status: "none" });
     }
-    return invoke<MacInstallStatus>("mac_status");
+    return invoke<MacInstallStatus>("mac_status").then(guardMacStatus);
   },
   macAdopt(): Promise<MacInstallStatus> {
     if (!hasTauriRuntime()) {
@@ -679,7 +747,7 @@ export const managerApi = {
     if (!hasTauriRuntime()) {
       return Promise.resolve(WIN_FALLBACK_PLAN);
     }
-    return invoke<WinUpdateReport>("win_plan_update");
+    return invoke<WinUpdateReport>("win_plan_update").then(guardWinReport);
   },
   winPauseDownload(): Promise<boolean> {
     if (!hasTauriRuntime()) {
@@ -742,7 +810,7 @@ export const managerApi = {
     if (!hasTauriRuntime()) {
       return Promise.resolve({ installed: WIN_FALLBACK_INSTALLED, status: "managed" });
     }
-    return invoke<WinInstallStatus>("win_status");
+    return invoke<WinInstallStatus>("win_status").then(guardWinStatus);
   },
   winAdopt(): Promise<WinInstallStatus> {
     if (!hasTauriRuntime()) {


### PR DESCRIPTION
## Summary
- **Global errors**: `ResizeObserver loop` noise is ignored entirely; error-less `window.error` events (failed resource loads, engine-synthesized noise) are reported but no longer blank a healthy UI with the fatal screen. Real throwables — including non-Error values like `throw "boom"` — still escalate to `cam:fatal`.
- **Backend contract guards**: `invoke<T>()` is a bare type assertion, so a desynced engine used to crash deep in a render. The load-bearing read paths (`mac/win` plan + status) now fail as a readable `contract_mismatch` CommandError.
- **i18n `t()`**: interpolation via split/join so values containing `$&`/`$1` (paths, raw error strings) land verbatim instead of triggering `String.replace` substitution semantics.
- **Sheet exit**: unmount on the frame's `animationend` (+ timeout safety net) instead of a `CLOSE_MS` constant that had to be hand-synced with the CSS duration.

## Verification
- `tsc --noEmit` clean, 49/49 vitest passing (3 new globalErrors cases: benign noise ignored, error-less events non-fatal, non-Error throwables still fatal).
- `codex review --uncommitted` iterated to no findings (fixed its two comments: non-Error throwables must stay fatal; the sheet exit is an animation, so listen to `animationend`, not `transitionend`).