### PR TITLE
refactor(home): extract shared progress/download/focus pieces + Windows focus re-check

### DIFF
--- a/docs/prototypes/auto-update-settings.html
+++ b/docs/prototypes/auto-update-settings.html
@@ -1,0 +1,740 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex App Manager - 自动检查更新设置原型</title>
+    <style>
+      :root {
+        --brand-violet: oklch(0.78 0.13 286);
+        --brand-blue: oklch(0.72 0.15 264);
+        --r-lg: 16px;
+        --r-md: 12px;
+        --r-sm: 9px;
+        --r-pill: 999px;
+        --space-xs: 8px;
+        --space-sm: 12px;
+        --space-md: 16px;
+        --font: ui-rounded, "SF Pro Rounded", -apple-system, BlinkMacSystemFont,
+          "Segoe UI Variable Display", "Segoe UI", system-ui, "PingFang SC",
+          "Microsoft YaHei", sans-serif;
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Code",
+          Menlo, Consolas, monospace;
+        --fs-caption: 0.6875rem;
+        --fs-label: 0.75rem;
+        --fs-sm: 0.8125rem;
+        --fs-body: 0.875rem;
+        --ease: cubic-bezier(0.22, 0.61, 0.36, 1);
+        --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+        --ease-spring: cubic-bezier(0.34, 1.32, 0.5, 1);
+        --grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23g)'/%3E%3C/svg%3E");
+      }
+
+      :root,
+      [data-theme="dark"] {
+        color-scheme: dark;
+        --bg: oklch(0.168 0.014 274);
+        --surface: oklch(0.214 0.016 274);
+        --surface-top: oklch(0.246 0.018 274);
+        --surface-2: oklch(0.252 0.018 274);
+        --surface-2-top: oklch(0.288 0.02 274);
+        --surface-3: oklch(0.305 0.02 274);
+        --surface-3-top: oklch(0.34 0.022 274);
+        --line: oklch(0.32 0.018 274);
+        --line-2: oklch(0.4 0.024 274);
+        --text: oklch(0.965 0.008 274);
+        --text-soft: oklch(0.74 0.02 274);
+        --text-faint: oklch(0.58 0.022 274);
+        --accent: oklch(0.71 0.155 274);
+        --accent-2: oklch(0.62 0.19 270);
+        --accent-deep: oklch(0.82 0.11 280);
+        --accent-ink: oklch(0.99 0.01 274);
+        --success: oklch(0.78 0.155 168);
+        --amber: oklch(0.8 0.135 78);
+        --accent-tint: color-mix(in oklch, var(--accent) 18%, transparent);
+        --success-tint: color-mix(in oklch, var(--success) 16%, transparent);
+        --amber-tint: color-mix(in oklch, var(--amber) 16%, transparent);
+        --ring-focus: color-mix(in oklch, var(--accent) 55%, transparent);
+        --hl-top: inset 0 1px 0 oklch(1 0 0 / 0.07);
+        --hl-top-strong: inset 0 1px 0 oklch(1 0 0 / 0.12);
+        --shadow-1: oklch(0.12 0.03 274 / 0.5);
+        --shadow-2: oklch(0.08 0.03 274 / 0.45);
+        --shadow-3: oklch(0.05 0.02 274 / 0.6);
+        --elev-1: var(--hl-top), 0 1px 2px var(--shadow-1);
+        --elev-2: var(--hl-top), 0 1px 2px var(--shadow-1),
+          0 14px 32px -8px var(--shadow-2);
+        --elev-3: var(--hl-top-strong), 0 2px 6px var(--shadow-1),
+          0 28px 64px -10px var(--shadow-3);
+        --grain-opacity: 0.05;
+        --ambient: radial-gradient(
+          125% 80% at 50% -8%,
+          color-mix(in oklch, var(--accent) 9%, transparent),
+          transparent 60%
+        );
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 22px;
+        background:
+          radial-gradient(circle at 50% 0, oklch(0.26 0.04 274), transparent 34%),
+          oklch(0.11 0.015 274);
+        color: var(--text);
+        font-family: var(--font);
+        font-size: var(--fs-body);
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+        font-variant-numeric: tabular-nums;
+      }
+
+      button,
+      input {
+        font: inherit;
+      }
+
+      button {
+        cursor: pointer;
+      }
+
+      button:focus,
+      input:focus {
+        outline: none;
+      }
+
+      button:focus-visible,
+      input:focus-visible {
+        outline: 2px solid var(--ring-focus);
+        outline-offset: 2px;
+      }
+
+      .frame {
+        width: 400px;
+        height: 640px;
+        padding: 14px;
+      }
+
+      .pop {
+        position: relative;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        isolation: isolate;
+        background-color: var(--bg);
+        background-image: var(--ambient);
+        border: 1px solid var(--line-2);
+        border-radius: var(--r-lg);
+        box-shadow:
+          inset 0 1px 0 oklch(1 0 0 / 0.06),
+          0 6px 16px var(--shadow-2),
+          0 1px 3px var(--shadow-1);
+      }
+
+      .pop::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image: var(--grain);
+        background-size: 160px 160px;
+        opacity: var(--grain-opacity);
+        pointer-events: none;
+        z-index: -1;
+        mix-blend-mode: overlay;
+      }
+
+      .topbar {
+        display: flex;
+        align-items: center;
+        gap: var(--space-xs);
+        padding: var(--space-sm) var(--space-sm) 0;
+      }
+
+      .iconbtn,
+      .winclose {
+        width: 30px;
+        height: 30px;
+        border-radius: var(--r-sm);
+        border: 1px solid transparent;
+        background: transparent;
+        color: var(--text-faint);
+        display: grid;
+        place-items: center;
+        transition:
+          background 0.18s var(--ease),
+          color 0.18s var(--ease),
+          border-color 0.18s var(--ease),
+          transform 0.08s var(--ease);
+      }
+
+      .iconbtn:hover,
+      .winclose:hover {
+        background: var(--surface-2);
+        border-color: var(--line);
+        color: var(--text);
+      }
+
+      .iconbtn:active,
+      .winclose:active {
+        transform: scale(0.94);
+      }
+
+      .iconbtn svg,
+      .winclose svg,
+      .row-icon {
+        width: 17px;
+        height: 17px;
+      }
+
+      .title {
+        flex: 1;
+        text-align: center;
+        font-weight: 680;
+        letter-spacing: -0.006em;
+      }
+
+      .scroll {
+        flex: 1;
+        overflow-y: auto;
+        padding: var(--space-sm) var(--space-md) var(--space-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
+      }
+
+      .scroll::-webkit-scrollbar {
+        width: 0;
+      }
+
+      .scroll > * {
+        animation: risein 0.46s var(--ease-out) both;
+      }
+
+      .scroll > *:nth-child(1) {
+        animation-delay: 0.02s;
+      }
+
+      .scroll > *:nth-child(2) {
+        animation-delay: 0.07s;
+      }
+
+      .scroll > *:nth-child(3) {
+        animation-delay: 0.12s;
+      }
+
+      @keyframes risein {
+        from {
+          opacity: 0;
+          transform: translateY(9px);
+        }
+      }
+
+      .group {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xs);
+      }
+
+      .group-h {
+        font-size: var(--fs-caption);
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--text-faint);
+        padding: 2px 6px;
+      }
+
+      .list {
+        background: linear-gradient(180deg, var(--surface-top), var(--surface));
+        border: 1px solid var(--line);
+        border-radius: var(--r-lg);
+        overflow: hidden;
+        box-shadow: var(--elev-2);
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 11px;
+        width: 100%;
+        min-height: 58px;
+        padding: 12px 14px;
+        border: 0;
+        border-top: 1px solid var(--line);
+        background: none;
+        color: var(--text);
+        text-align: start;
+      }
+
+      .row:first-child {
+        border-top: 0;
+      }
+
+      .row-icon {
+        color: var(--text-soft);
+        flex: 0 0 auto;
+      }
+
+      .rtext {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .rtitle {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        min-width: 0;
+        font-weight: 650;
+        letter-spacing: -0.005em;
+      }
+
+      .rsub {
+        color: var(--text-faint);
+        font-size: var(--fs-label);
+        line-height: 1.45;
+        margin-top: 3px;
+      }
+
+      .tag {
+        flex: 0 0 auto;
+        font-size: 10.5px;
+        font-weight: 700;
+        color: var(--accent-deep);
+        background: var(--accent-tint);
+        border: 1px solid color-mix(in oklch, var(--accent) 22%, transparent);
+        border-radius: var(--r-pill);
+        padding: 2px 8px;
+      }
+
+      .tag.quiet {
+        color: var(--text-soft);
+        background: var(--surface-3);
+        border-color: var(--line);
+      }
+
+      .toggle {
+        width: 42px;
+        height: 25px;
+        border-radius: var(--r-pill);
+        background: var(--surface-3);
+        border: 1px solid var(--line-2);
+        position: relative;
+        flex-shrink: 0;
+        box-shadow: inset 0 1px 3px var(--shadow-1);
+        transition:
+          background 0.22s var(--ease),
+          border-color 0.22s var(--ease),
+          opacity 0.18s var(--ease);
+      }
+
+      .toggle[aria-checked="true"] {
+        background: linear-gradient(180deg, var(--accent), var(--accent-2));
+        border-color: transparent;
+        box-shadow:
+          inset 0 1px 0 oklch(1 0 0 / 0.25),
+          0 2px 8px -2px color-mix(in oklch, var(--accent) 34%, transparent);
+      }
+
+      .toggle::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 19px;
+        height: 19px;
+        border-radius: 50%;
+        background: oklch(0.99 0.005 274);
+        box-shadow:
+          0 1px 3px var(--shadow-2),
+          0 1px 1px var(--shadow-1);
+        transition: transform 0.22s var(--ease-spring);
+      }
+
+      .toggle[aria-checked="true"]::after {
+        transform: translateX(17px);
+      }
+
+      .toggle[aria-disabled="true"] {
+        opacity: 0.45;
+        pointer-events: none;
+      }
+
+      .frequency {
+        display: grid;
+        grid-template-rows: 0fr;
+        border-top: 0 solid transparent;
+        opacity: 0;
+        transform: translateY(-6px);
+        transition:
+          grid-template-rows 0.28s var(--ease-out),
+          opacity 0.2s var(--ease),
+          transform 0.24s var(--ease),
+          border-color 0.18s var(--ease);
+      }
+
+      .frequency.is-open {
+        grid-template-rows: 1fr;
+        border-top-width: 1px;
+        border-top-color: var(--line);
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .frequency-inner {
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .frequency-content {
+        padding: 13px 14px 14px;
+        display: grid;
+        gap: 10px;
+      }
+
+      .section-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .section-title strong {
+        font-weight: 650;
+      }
+
+      .pill-summary {
+        color: var(--success);
+        background: var(--success-tint);
+        border: 1px solid color-mix(in oklch, var(--success) 22%, transparent);
+        border-radius: var(--r-pill);
+        padding: 3px 8px;
+        font-size: 10.5px;
+        font-weight: 750;
+        white-space: nowrap;
+      }
+
+      .seg {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 4px;
+        padding: 3px;
+        background: var(--surface-2);
+        border: 1px solid var(--line);
+        border-radius: var(--r-md);
+        box-shadow: inset 0 1px 2px var(--shadow-1);
+      }
+
+      .seg button {
+        min-width: 0;
+        border: 1px solid transparent;
+        border-radius: var(--r-sm);
+        background: transparent;
+        color: var(--text-soft);
+        padding: 7px 5px;
+        font-size: var(--fs-label);
+        font-weight: 700;
+        line-height: 1.15;
+        transition:
+          background 0.18s var(--ease),
+          color 0.18s var(--ease),
+          border-color 0.18s var(--ease),
+          box-shadow 0.18s var(--ease);
+      }
+
+      .seg button:hover:not([aria-selected="true"]) {
+        color: var(--text);
+      }
+
+      .seg button[aria-selected="true"] {
+        background: linear-gradient(180deg, var(--surface-3-top), var(--surface-3));
+        border-color: var(--line-2);
+        color: var(--text);
+        box-shadow: var(--elev-1);
+      }
+
+      .custom-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 8px;
+        overflow: hidden;
+        max-height: 0;
+        opacity: 0;
+        transform: translateY(-4px);
+        transition:
+          max-height 0.24s var(--ease),
+          opacity 0.2s var(--ease),
+          transform 0.2s var(--ease);
+      }
+
+      .custom-grid.show {
+        max-height: 92px;
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .num-field {
+        display: grid;
+        gap: 5px;
+      }
+
+      .num-field label {
+        padding-left: 2px;
+        color: var(--text-faint);
+        font-size: var(--fs-caption);
+        font-weight: 700;
+      }
+
+      .num-field input {
+        width: 100%;
+        height: 36px;
+        border: 1px solid var(--line-2);
+        border-radius: var(--r-sm);
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: inset 0 1px 2px var(--shadow-1);
+        padding: 8px 9px;
+        font-family: var(--mono);
+        font-size: 12px;
+        text-align: center;
+      }
+
+      .num-field input:focus {
+        border-color: var(--accent);
+        background: var(--surface);
+        box-shadow:
+          inset 0 1px 2px var(--shadow-1),
+          0 0 0 3px var(--accent-tint);
+      }
+
+      @media (max-width: 440px) {
+        body {
+          padding: 0;
+        }
+
+        .frame {
+          width: 100vw;
+          height: 100vh;
+          padding: 10px;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="frame" aria-label="自动检查更新设置原型">
+      <section class="pop">
+        <header class="topbar">
+          <button class="iconbtn" type="button" aria-label="返回">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="15 6 9 12 15 18"></polyline>
+            </svg>
+          </button>
+          <div class="title">设置</div>
+          <button class="winclose" type="button" aria-label="关闭">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+            </svg>
+          </button>
+        </header>
+
+        <div class="scroll">
+          <section class="group">
+            <div class="group-h">更新源</div>
+            <div class="list">
+              <button class="row" type="button" aria-checked="true">
+                <svg class="row-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="8.5"></circle>
+                  <path d="M3.5 12h17M12 3.5c2.5 2.4 2.5 14.6 0 17M12 3.5c-2.5 2.4-2.5 14.6 0 17"></path>
+                </svg>
+                <span class="rtext">
+                  <span class="rtitle">自动 <span class="tag">推荐</span></span>
+                  <span class="rsub">自动选择最快、可用的来源</span>
+                </span>
+              </button>
+            </div>
+          </section>
+
+          <section class="group">
+            <div class="group-h">通用</div>
+            <div class="list">
+              <div class="row">
+                <svg class="row-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M20 11.5a8 8 0 1 0-1.9 6.4"></path>
+                  <polyline points="20 4.5 20 11.5 13 11.5"></polyline>
+                </svg>
+                <span class="rtext">
+                  <span class="rtitle">启动时自动检查更新</span>
+                </span>
+                <button id="startupToggle" class="toggle" type="button" role="switch"
+                  aria-checked="true" aria-label="启动时自动检查更新"></button>
+              </div>
+
+              <div class="row">
+                <svg class="row-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="8.5"></circle>
+                  <path d="M12 7v5l3.2 2"></path>
+                </svg>
+                <span class="rtext">
+                  <span class="rtitle">定时自动检查更新</span>
+                </span>
+                <button id="periodicToggle" class="toggle" type="button" role="switch"
+                  aria-checked="true" aria-label="定时自动检查更新"></button>
+              </div>
+
+              <div id="frequencyPanel" class="frequency is-open" aria-hidden="false">
+                <div class="frequency-inner">
+                  <div class="frequency-content">
+                    <div class="section-title">
+                      <strong>每隔多久检查一次</strong>
+                      <span id="summaryPill" class="pill-summary">每 1 小时</span>
+                    </div>
+
+                    <div class="seg" role="tablist" aria-label="检查频率">
+                      <button type="button" data-preset="900" aria-selected="false">15 分钟</button>
+                      <button type="button" data-preset="3600" aria-selected="true">1 小时</button>
+                      <button type="button" data-preset="21600" aria-selected="false">6 小时</button>
+                      <button type="button" data-preset="custom" aria-selected="false">自定义</button>
+                    </div>
+
+                    <div id="customGrid" class="custom-grid" aria-label="自定义检查频率">
+                      <div class="num-field">
+                        <label for="hours">时</label>
+                        <input id="hours" type="number" inputmode="numeric" min="0" max="168" value="1" />
+                      </div>
+                      <div class="num-field">
+                        <label for="minutes">分</label>
+                        <input id="minutes" type="number" inputmode="numeric" min="0" max="59" value="0" />
+                      </div>
+                      <div class="num-field">
+                        <label for="seconds">秒</label>
+                        <input id="seconds" type="number" inputmode="numeric" min="0" max="59" value="0" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const MIN_SECONDS = 300;
+      const startupToggle = document.querySelector("#startupToggle");
+      const periodicToggle = document.querySelector("#periodicToggle");
+      const frequencyPanel = document.querySelector("#frequencyPanel");
+      const customGrid = document.querySelector("#customGrid");
+      const summaryPill = document.querySelector("#summaryPill");
+      const presetButtons = Array.from(document.querySelectorAll("[data-preset]"));
+      const inputs = {
+        hours: document.querySelector("#hours"),
+        minutes: document.querySelector("#minutes"),
+        seconds: document.querySelector("#seconds"),
+      };
+
+      let selectedPreset = "3600";
+
+      function isOn(button) {
+        return button.getAttribute("aria-checked") === "true";
+      }
+
+      function setToggle(button, value) {
+        button.setAttribute("aria-checked", value ? "true" : "false");
+      }
+
+      function readCustomSeconds() {
+        const hours = Math.max(0, Number(inputs.hours.value || 0));
+        const minutes = Math.max(0, Number(inputs.minutes.value || 0));
+        const seconds = Math.max(0, Number(inputs.seconds.value || 0));
+        return hours * 3600 + minutes * 60 + seconds;
+      }
+
+      function selectedSeconds() {
+        if (selectedPreset === "custom") return Math.max(MIN_SECONDS, readCustomSeconds());
+        return Number(selectedPreset);
+      }
+
+      function formatSeconds(total) {
+        const seconds = Math.max(MIN_SECONDS, Number(total) || 0);
+        const h = Math.floor(seconds / 3600);
+        const m = Math.floor((seconds % 3600) / 60);
+        const s = seconds % 60;
+        const parts = [];
+        if (h) parts.push(`${h} 小时`);
+        if (m) parts.push(`${m} 分钟`);
+        if (s) parts.push(`${s} 秒`);
+        return parts.length ? parts.join(" ") : "5 分钟";
+      }
+
+      function updateUi() {
+        const periodic = isOn(periodicToggle);
+        const seconds = selectedSeconds();
+        const label = `每 ${formatSeconds(seconds)}`;
+
+        frequencyPanel.classList.toggle("is-open", periodic);
+        frequencyPanel.setAttribute("aria-hidden", periodic ? "false" : "true");
+        customGrid.classList.toggle("show", selectedPreset === "custom");
+        summaryPill.textContent = label;
+
+        presetButtons.forEach((button) => {
+          button.setAttribute(
+            "aria-selected",
+            button.dataset.preset === selectedPreset ? "true" : "false",
+          );
+        });
+      }
+
+      startupToggle.addEventListener("click", () => {
+        setToggle(startupToggle, !isOn(startupToggle));
+        updateUi();
+      });
+
+      periodicToggle.addEventListener("click", () => {
+        setToggle(periodicToggle, !isOn(periodicToggle));
+        updateUi();
+      });
+
+      presetButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          selectedPreset = button.dataset.preset;
+          updateUi();
+        });
+      });
+
+      Object.values(inputs).forEach((input) => {
+        input.addEventListener("input", () => {
+          selectedPreset = "custom";
+          updateUi();
+        });
+      });
+
+      updateUi();
+    </script>
+  </body>
+</html>

--- a/src/app/paths.ts
+++ b/src/app/paths.ts
@@ -3,3 +3,16 @@ import type { Platform } from "./platform";
 export function codexHomeDisplay(platform: Platform): string {
   return platform === "windows" ? "%USERPROFILE%\\.codex" : "~/.codex";
 }
+
+/** Normalize a Windows path for comparison: trim, drop the trailing slash,
+ *  unify separators to `\`, and lowercase (install roots come back with mixed
+ *  `\`/`/` and casing). NOT for mac paths — those are case-sensitive. */
+export function normalizePath(value: string): string {
+  return value.trim().replace(/[\\/]+$/, "").replace(/\//g, "\\").toLowerCase();
+}
+
+/** Case-insensitive path equality (Windows). Shared by the Windows home and
+ *  settings. */
+export function samePath(a: string, b: string): boolean {
+  return normalizePath(a) === normalizePath(b);
+}

--- a/src/app/views/Home.test.tsx
+++ b/src/app/views/Home.test.tsx
@@ -247,6 +247,14 @@ describe("MacHome state machine", () => {
       onProgress?.({ payload: { downloaded: 512, total: 1024, source: "mirror.example" } });
     });
 
+    // The progress bar exposes progressbar semantics to assistive tech. The
+    // exact aria-valuenow eases (useCountUp), so assert the range + presence
+    // rather than a timing-dependent value.
+    const progressbar = await screen.findByRole("progressbar");
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0");
+    expect(progressbar).toHaveAttribute("aria-valuemax", "100");
+    expect(progressbar).toHaveAttribute("aria-valuenow");
+
     const pause = await screen.findByRole("button", { name: /^暂停$/ });
     await waitFor(() => expect(pause).toBeEnabled());
     await user.click(pause);

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { listen } from "@tauri-apps/api/event";
 
 import {
   errorCode,
@@ -10,7 +9,6 @@ import {
 } from "../../services/managerApi";
 import type {
   AppSettings,
-  DownloadProgress,
   MacInstallStatus,
   MacPerformReport,
   MacUpdateReport,
@@ -22,7 +20,6 @@ import { useI18n, dirOf, type TKey } from "../i18n";
 import { Ring, TopBar, ResultBanner, ErrorHero } from "../components";
 import { currentPlatform } from "../platform";
 import { WinHome } from "./WinHome";
-import { useCountUp } from "../useCountUp";
 import { mib, fmtDateTime } from "../format";
 import { useHomeMotion } from "../motion";
 import { Sheet } from "../Sheet";
@@ -31,9 +28,11 @@ import {
   ManualExistingInstallSheet,
   type ManualExistingCandidate,
 } from "./ManualExistingInstall";
+import { ProgressScreen, type PausedDownload } from "./ProgressScreen";
+import { useDownloadProgress } from "./useDownloadProgress";
+import { useFocusRecheck, installIdentity } from "./useFocusRecheck";
 
 type Kind = "loading" | "error" | "none" | "idle" | "update" | "external" | "uptodate";
-type DownloadStopIntent = "pause" | "cancel";
 
 /** Platform dispatcher — the backend command surface differs per OS. */
 export function Home(props: { onOpenSettings: () => void }) {
@@ -71,87 +70,37 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   // Whether a fresh install just completed — show a done state with an explicit
   // 〔打开 Codex〕 instead of auto-launching.
   const [justInstalled, setJustInstalled] = useState(false);
-  // Live download progress (real bytes, emitted by the backend during
-  // install/update); null when not downloading.
-  const [dl, setDl] = useState<DownloadProgress | null>(null);
-  const [speed, setSpeed] = useState(0);
-  const dlSample = useRef<{ t: number; bytes: number } | null>(null);
-  const [downloadStop, setDownloadStop] = useState<DownloadStopIntent | null>(null);
-  const [downloadStopBusy, setDownloadStopBusy] = useState(false);
-  const downloadStopRef = useRef<DownloadStopIntent | null>(null);
-  // Latest live progress, read at pause time to snapshot the paused figures
-  // (the `dl` state is cleared when the perform call unwinds).
-  const dlRef = useRef<DownloadProgress | null>(null);
   // A paused download: the progress screen stays up (not routed home) offering
   // 〔继续〕/〔取消〕. `dl` is the byte snapshot captured at the moment of pause.
-  const [paused, setPaused] = useState<{
-    kind: "perform" | "install";
-    dl: DownloadProgress | null;
-  } | null>(null);
+  const [paused, setPaused] = useState<PausedDownload | null>(null);
   const scopeRef = useRef<HTMLDivElement>(null);
   const confirmTitleId = useId();
   const confirmBodyId = useId();
   const manualExistingTitleId = useId();
   const manualExistingBodyId = useId();
-  // Smoothly roll the live download figures instead of snapping per event.
-  const dlPctTarget = dl && dl.total > 0 ? Math.min(100, (dl.downloaded / dl.total) * 100) : 0;
-  const dlPct = useCountUp(dlPctTarget);
-  const dlBytes = useCountUp(dl?.downloaded ?? 0);
-  const dlSpeed = useCountUp(speed);
 
-  const onDlProgress = useCallback((e: { payload: DownloadProgress }) => {
-    const p = e.payload;
-    setDl(p);
-    dlRef.current = p;
-    const now = Date.now();
-    const prev = dlSample.current;
-    if (!prev) {
-      dlSample.current = { t: now, bytes: p.downloaded };
-    } else if (now > prev.t + 400) {
-      setSpeed((p.downloaded - prev.bytes) / ((now - prev.t) / 1000));
-      dlSample.current = { t: now, bytes: p.downloaded };
-    }
-  }, []);
-
-  const startDlListen = useCallback(async () => {
-    setDl(null);
-    dlRef.current = null;
-    setSpeed(0);
-    dlSample.current = null;
-    try {
-      return await listen<DownloadProgress>("mac://download-progress", onDlProgress);
-    } catch {
-      // Non-Tauri (web preview): no event bus — nothing to clean up.
-      return () => {};
-    }
-  }, [onDlProgress]);
-
-  const requestDownloadStop = useCallback(
-    async (intent: DownloadStopIntent) => {
-      setActionError(null);
-      setDownloadStop(intent);
-      setDownloadStopBusy(true);
-      downloadStopRef.current = intent;
-      try {
-        const active =
-          intent === "pause"
-            ? await managerApi.macPauseDownload()
-            : await managerApi.macCancelDownload();
-        if (!active) {
-          downloadStopRef.current = null;
-          setDownloadStop(null);
-          setDownloadStopBusy(false);
-          setActionError(t("progress.cannotCancel"));
-        }
-      } catch (cause) {
-        downloadStopRef.current = null;
-        setDownloadStop(null);
-        setDownloadStopBusy(false);
-        setActionError(userErrorMessage(cause, t));
-      }
-    },
-    [t],
-  );
+  // Live download state machine (bytes + eased readouts + pause/cancel intent),
+  // shared with the Windows home; only the channel + stop commands differ.
+  const {
+    dl,
+    setDl,
+    dlRef,
+    dlPct,
+    dlBytes,
+    dlSpeed,
+    downloadStop,
+    downloadStopBusy,
+    downloadStopRef,
+    startDlListen,
+    requestDownloadStop,
+    resetStop,
+  } = useDownloadProgress({
+    eventName: "mac://download-progress",
+    pauseDownload: () => managerApi.macPauseDownload(),
+    cancelDownload: () => managerApi.macCancelDownload(),
+    cannotCancelMessage: t("progress.cannotCancel"),
+    onError: setActionError,
+  });
 
   const refreshStatus = useCallback(async () => {
     try {
@@ -234,60 +183,28 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     return () => window.clearInterval(id);
   }, [settings.periodicCheck, settings.periodicCheckIntervalSeconds]);
 
-  // Window focus → silently re-detect the local install (milliseconds, no
-  // network). If it no longer matches the snapshot on screen (Codex was
-  // updated / downgraded out-of-band while we weren't looking), re-run the
-  // full check so the card corrects itself instead of waiting to fail the
-  // perform-time guard.
-  useEffect(() => {
-    let last = 0;
-    let un: (() => void) | undefined;
-    void (async () => {
-      try {
-        un = await listen("tauri://focus", () => {
-          const now = Date.now();
-          if (busyRef.current || now - last < 3000) return;
-          last = now;
-          void (async () => {
-            try {
-              const st = await managerApi.macStatus();
-              setStatus(st);
-              setStatusLoaded(true);
-              setStatusFailed(false);
-              // Re-check whenever the install identity (build OR path) differs
-              // from the last checked snapshot — in EITHER direction, so a
-              // fresh external install (snapshot had none), a removal, a
-              // version change, and a same-build move to a new path all
-              // re-plan. Gate on `checked` (we have planned at least once), not
-              // on a non-null installed, or the none→installed transition is
-              // missed. The perform expectation pins build+path, so a stale
-              // plan here would only fail the backend guard or mislead the card.
-              const checked = reportRef.current;
-              const snap = checked?.installed ?? null;
-              const fresh = st.installed ?? null;
-              const identityChanged =
-                (snap?.build ?? null) !== (fresh?.build ?? null) ||
-                (snap?.path ?? null) !== (fresh?.path ?? null);
-              if (checked && identityChanged) {
-                // Drop any open confirm sheet first: it was built for the OLD
-                // target, and the install may now be external/gone. Leaving it
-                // up would let a click run perform against a snapshot the user
-                // never saw — bypassing the external→adopt boundary. The user
-                // re-confirms against the freshly-checked card.
-                setConfirmOpen(false);
-                void check();
-              }
-            } catch {
-              // Transient/unsupported — the next explicit check will surface it.
-            }
-          })();
-        });
-      } catch {
-        // Non-Tauri (web preview): no event bus — nothing to clean up.
-      }
-    })();
-    return () => un?.();
-  }, [check]);
+  // Re-check whenever the install identity (build OR path) differs from the
+  // last checked snapshot — in EITHER direction, so a fresh external install
+  // (snapshot had none), a removal, a version change, and a same-build move to
+  // a new path all re-plan. The perform expectation pins build+path, so a stale
+  // plan would only fail the backend guard or mislead the card. Dropping any
+  // open confirm sheet first: it was built for the OLD target.
+  useFocusRecheck<MacInstallStatus>({
+    fetchStatus: () => managerApi.macStatus(),
+    onStatus: (st) => {
+      setStatus(st);
+      setStatusLoaded(true);
+      setStatusFailed(false);
+    },
+    hasChecked: () => reportRef.current != null,
+    checkedIdentity: () => installIdentity(reportRef.current?.installed ?? null),
+    identityOf: (st) => installIdentity(st.installed ?? null),
+    isBusy: () => busyRef.current != null,
+    onIdentityChanged: () => {
+      setConfirmOpen(false);
+      void check();
+    },
+  });
 
   const adopt = useCallback(async () => {
     setBusy("adopt");
@@ -325,12 +242,9 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     } finally {
       un();
       setBusy(null);
-      setDl(null);
-      setDownloadStop(null);
-      setDownloadStopBusy(false);
-      downloadStopRef.current = null;
+      resetStop();
     }
-  }, [check, startDlListen, t]);
+  }, [check, startDlListen, resetStop, t]);
 
   const runPerform = useCallback(async () => {
     // ONE atomic snapshot (the report carries installed + plan detected
@@ -384,12 +298,9 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     } finally {
       un();
       setBusy(null);
-      setDl(null);
-      setDownloadStop(null);
-      setDownloadStopBusy(false);
-      downloadStopRef.current = null;
+      resetStop();
     }
-  }, [report, check, startDlListen, t]);
+  }, [report, check, startDlListen, resetStop, t]);
 
   // 〔继续〕from the paused state — re-run the same operation. The backend finds
   // the cached `.part` and resumes via `curl -C -`, so the bar picks up where it
@@ -594,94 +505,25 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
 
   // ── progress (performing / installing / paused) takes over the whole screen ─
   if (busy === "perform" || busy === "install" || paused) {
-    const installing = paused ? paused.kind === "install" : busy === "install";
-    // Paused reads from its captured snapshot; live runs from the eased `dl`.
-    const snap = paused ? paused.dl : dl;
-    const known = Boolean(snap && snap.total > 0);
-    const snapPct = snap && snap.total > 0 ? Math.min(100, (snap.downloaded / snap.total) * 100) : 0;
-    const pct = known ? Math.round(paused ? snapPct : dlPct) : null;
-    const barPct = paused ? snapPct : dlPct;
-    // Bytes are in → the uninterruptible install phase (gate/quit/atomic swap).
-    // Say so and drop the dead buttons rather than leave them greyed for no
-    // visible reason.
-    const finishing = !paused && Boolean(snap && snap.total > 0 && snap.downloaded >= snap.total);
-    // Pause only makes sense mid-transfer; cancel is the "abandon" out and works
-    // through the preparing phase too (a backend abort checkpoint honors it), but
-    // not once the install has begun.
-    const canPause =
-      !paused && Boolean(dl && dl.total > 0 && dl.downloaded < dl.total) && !downloadStopBusy;
-    const canCancel = !paused && !finishing && !downloadStopBusy;
     return (
-      <div className="pop">
-        <TopBar />
-        <div className="scroll" ref={scopeRef}>
-          <div className="hero" style={{ marginTop: 24 }} key={scene}>
-            <Ring icon={paused ? "pause" : "loader"} spin={!paused} className="glow" />
-            <div className={`headline${paused ? "" : " shimmer"}`}>
-              {paused
-                ? t("progress.paused.title")
-                : installing
-                  ? t("progress.installing")
-                  : t("progress.title")}
-            </div>
-            {!paused ? (
-              <div className="sub">
-                {finishing
-                  ? t("progress.finishing")
-                  : snap
-                    ? t("progress.downloadingFrom", { source: snap.source })
-                    : t("progress.preparing")}
-              </div>
-            ) : null}
-            {pct !== null ? (
-              <div className="pctbig">
-                {pct}
-                <span className="pctsign">%</span>
-              </div>
-            ) : null}
-            <div className="bar">
-              <div
-                className={`bar-fill${pct === null ? " indeterminate" : ""}`}
-                style={pct === null ? undefined : { width: `${barPct}%` }}
-              />
-            </div>
-            {known && snap ? (
-              <div className="dlmeta">
-                {mib(paused ? snap.downloaded : dlBytes)} / {mib(snap.total)}
-                {!paused && dlSpeed > 0 ? ` · ${mib(dlSpeed)}/s` : ""}
-              </div>
-            ) : null}
-            <div className="progress-actions">
-              {paused ? (
-                <button className="btn primary" onClick={resumeDownload}>
-                  <Icon name="play" />
-                  {t("progress.resume")}
-                </button>
-              ) : (
-                <button
-                  className="btn ghost"
-                  onClick={() => void requestDownloadStop("pause")}
-                  disabled={!canPause}
-                >
-                  <Icon name="pause" />
-                  {downloadStop === "pause" ? t("progress.pausePending") : t("progress.pause")}
-                </button>
-              )}
-              <button
-                className="btn danger"
-                onClick={() => {
-                  if (paused) cancelPausedDownload();
-                  else void requestDownloadStop("cancel");
-                }}
-                disabled={!paused && !canCancel}
-              >
-                <Icon name="close" />
-                {downloadStop === "cancel" ? t("progress.cancelPending") : t("progress.cancel")}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <ProgressScreen
+        scene={scene}
+        scopeRef={scopeRef}
+        paused={paused}
+        dl={dl}
+        dlPct={dlPct}
+        dlBytes={dlBytes}
+        dlSpeed={dlSpeed}
+        installing={paused ? paused.kind === "install" : busy === "install"}
+        downloadStop={downloadStop}
+        downloadStopBusy={downloadStopBusy}
+        onResume={resumeDownload}
+        onPause={() => void requestDownloadStop("pause")}
+        onCancel={() => {
+          if (paused) void cancelPausedDownload();
+          else void requestDownloadStop("cancel");
+        }}
+      />
     );
   }
 

--- a/src/app/views/ProgressScreen.tsx
+++ b/src/app/views/ProgressScreen.tsx
@@ -1,0 +1,149 @@
+import type { RefObject } from "react";
+
+import type { DownloadProgress } from "../../shared/types";
+import { Icon } from "../icons";
+import { useI18n } from "../i18n";
+import { Ring, TopBar } from "../components";
+import { mib } from "../format";
+
+export type DownloadStopIntent = "pause" | "cancel";
+
+export interface PausedDownload {
+  kind: "perform" | "install";
+  dl: DownloadProgress | null;
+}
+
+/** The full-screen download/install progress view, shared by the Mac and
+ *  Windows homes (byte-for-byte identical before this extraction). Owns the
+ *  progressbar accessibility semantics so assistive tech can follow a
+ *  destructive install/update: `role="progressbar"` + aria-value*, and an
+ *  aria-live phase line ("preparing" → "downloading" → "finishing"). */
+export function ProgressScreen({
+  scene,
+  scopeRef,
+  paused,
+  dl,
+  dlPct,
+  dlBytes,
+  dlSpeed,
+  installing,
+  downloadStop,
+  downloadStopBusy,
+  onResume,
+  onPause,
+  onCancel,
+}: {
+  scene: string;
+  scopeRef: RefObject<HTMLDivElement | null>;
+  paused: PausedDownload | null;
+  /** Live progress (null when not transferring). */
+  dl: DownloadProgress | null;
+  /** Eased display figures (useCountUp), so the readouts glide. */
+  dlPct: number;
+  dlBytes: number;
+  dlSpeed: number;
+  /** Whether the operation is a fresh install (vs an in-place update). */
+  installing: boolean;
+  downloadStop: DownloadStopIntent | null;
+  downloadStopBusy: boolean;
+  onResume: () => void;
+  onPause: () => void;
+  onCancel: () => void;
+}) {
+  const { t } = useI18n();
+
+  // Paused reads from its captured snapshot; live runs from the eased `dl`.
+  const snap = paused ? paused.dl : dl;
+  const known = Boolean(snap && snap.total > 0);
+  const snapPct = snap && snap.total > 0 ? Math.min(100, (snap.downloaded / snap.total) * 100) : 0;
+  const pct = known ? Math.round(paused ? snapPct : dlPct) : null;
+  const barPct = paused ? snapPct : dlPct;
+  // Bytes are in → the uninterruptible install phase (gate/quit/atomic swap on
+  // mac, sideload/extract on Windows). Say so and drop the dead buttons rather
+  // than leave them greyed for no visible reason.
+  const finishing = !paused && Boolean(snap && snap.total > 0 && snap.downloaded >= snap.total);
+  // Pause only makes sense mid-transfer; cancel is the "abandon" out and works
+  // through the preparing phase too (a backend abort checkpoint honors it), but
+  // not once the install has begun.
+  const canPause =
+    !paused && Boolean(dl && dl.total > 0 && dl.downloaded < dl.total) && !downloadStopBusy;
+  const canCancel = !paused && !finishing && !downloadStopBusy;
+
+  const phase = paused
+    ? t("progress.paused.title")
+    : finishing
+      ? t("progress.finishing")
+      : snap
+        ? t("progress.downloadingFrom", { source: snap.source })
+        : t("progress.preparing");
+
+  return (
+    <div className="pop">
+      <TopBar />
+      <div className="scroll" ref={scopeRef}>
+        <div className="hero" style={{ marginTop: 24 }} key={scene}>
+          <Ring icon={paused ? "pause" : "loader"} spin={!paused} className="glow" />
+          <div className={`headline${paused ? "" : " shimmer"}`}>
+            {paused
+              ? t("progress.paused.title")
+              : installing
+                ? t("progress.installing")
+                : t("progress.title")}
+          </div>
+          {!paused ? (
+            <div className="sub" aria-live="polite">
+              {phase}
+            </div>
+          ) : null}
+          {pct !== null ? (
+            <div className="pctbig">
+              {pct}
+              <span className="pctsign">%</span>
+            </div>
+          ) : null}
+          <div
+            className="bar"
+            role="progressbar"
+            aria-label={installing ? t("progress.installing") : t("progress.title")}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={pct ?? undefined}
+            aria-valuetext={pct !== null ? `${pct}% · ${phase}` : phase}
+          >
+            <div
+              className={`bar-fill${pct === null ? " indeterminate" : ""}`}
+              style={pct === null ? undefined : { width: `${barPct}%` }}
+            />
+          </div>
+          {known && snap ? (
+            <div className="dlmeta">
+              {mib(paused ? snap.downloaded : dlBytes)} / {mib(snap.total)}
+              {!paused && dlSpeed > 0 ? ` · ${mib(dlSpeed)}/s` : ""}
+            </div>
+          ) : null}
+          <div className="progress-actions">
+            {paused ? (
+              <button className="btn primary" onClick={onResume}>
+                <Icon name="play" />
+                {t("progress.resume")}
+              </button>
+            ) : (
+              <button className="btn ghost" onClick={onPause} disabled={!canPause}>
+                <Icon name="pause" />
+                {downloadStop === "pause" ? t("progress.pausePending") : t("progress.pause")}
+              </button>
+            )}
+            <button
+              className="btn danger"
+              onClick={onCancel}
+              disabled={!paused && !canCancel}
+            >
+              <Icon name="close" />
+              {downloadStop === "cancel" ? t("progress.cancelPending") : t("progress.cancel")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/views/Settings.tsx
+++ b/src/app/views/Settings.tsx
@@ -8,6 +8,7 @@ import { useI18n, LANGS, type Lang, type TFn, type TKey } from "../i18n";
 import { useTheme, type ThemeMode } from "../theme";
 import { NavBar, Segmented, Toggle, radioNavTarget } from "../components";
 import { isWindows } from "../platform";
+import { samePath } from "../paths";
 import { Sheet } from "../Sheet";
 import { useSettingsSaver } from "./useSettingsSaver";
 
@@ -78,12 +79,6 @@ function formatInterval(seconds: number, t: TFn) {
     parts.seconds ? `${parts.seconds}${t("settings.general.intervalSecondsSuffix")}` : "",
   ].filter(Boolean);
   return labels.join(" ") || `1${t("settings.general.intervalMinutesSuffix")}`;
-}
-
-function samePath(a: string, b: string): boolean {
-  const norm = (value: string) =>
-    value.trim().replace(/[\\/]+$/, "").replace(/\//g, "\\").toLowerCase();
-  return norm(a) === norm(b);
 }
 
 export function Settings({

--- a/src/app/views/WinHome.test.tsx
+++ b/src/app/views/WinHome.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listen } from "@tauri-apps/api/event";
 
 import { managerApi } from "../../services/managerApi";
 import type {
@@ -237,5 +239,41 @@ describe("WinHome state machine", () => {
     );
     // Switching re-plans so the route (and the banner) can settle.
     await waitFor(() => expect(api.winPlanUpdate.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+
+  it("closes the install-dir sheet when a focus re-check finds the install drifted", async () => {
+    const user = userEvent.setup();
+    // Capture the focus-recheck listener so the test can fire it.
+    let onFocus: (() => void) | undefined;
+    vi.mocked(listen).mockImplementation((event: string, cb: unknown) => {
+      if (event === "tauri://focus") onFocus = cb as () => void;
+      return Promise.resolve(() => {});
+    });
+    // Portable fresh-install: no install yet, so clicking install opens the
+    // install-dir sheet instead of running straight away.
+    api.getSettings.mockResolvedValue(settings({ windowsInstallMode: "portable" }));
+    api.winStatus.mockResolvedValue({ installed: null, status: "none" });
+    api.winPlanUpdate.mockResolvedValue(
+      report({ installed: null, plan: { ...PLAN_UPDATE, route: "portable-fallback" } }),
+    );
+    renderWinHome();
+
+    await user.click(await screen.findByRole("button", { name: /安装 Codex/ }));
+    // The location sheet is up (fresh portable install needs a target).
+    expect(await screen.findByText("选择安装位置")).toBeInTheDocument();
+
+    // Codex appears out-of-band; the focus probe now sees a managed install —
+    // an identity change from the null snapshot the sheet was built against.
+    api.winStatus.mockResolvedValue(STATUS_MANAGED);
+    await waitFor(() => expect(onFocus).toBeDefined());
+    await act(async () => {
+      onFocus?.();
+      await Promise.resolve();
+    });
+
+    // The stale install-dir sheet must be gone — otherwise its 使用当前位置 /
+    // 浏览 buttons could still run install against the vanished snapshot,
+    // bypassing the external→adopt boundary.
+    await waitFor(() => expect(screen.queryByText("选择安装位置")).not.toBeInTheDocument());
   });
 });

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { listen } from "@tauri-apps/api/event";
 
 import {
   errorCode,
@@ -10,7 +9,6 @@ import {
 } from "../../services/managerApi";
 import type {
   AppSettings,
-  DownloadProgress,
   WinInstallStatus,
   WinPerformReport,
   WinUpdateReport,
@@ -20,8 +18,8 @@ import { userErrorMessage } from "../errorCopy";
 import { Icon, CodexGlyph } from "../icons";
 import { useI18n, dirOf, type TKey } from "../i18n";
 import { Ring, TopBar, ResultBanner, ErrorHero } from "../components";
-import { useCountUp } from "../useCountUp";
 import { mib, fmtDateTime } from "../format";
+import { samePath, normalizePath } from "../paths";
 import { useHomeMotion } from "../motion";
 import { Sheet } from "../Sheet";
 import { skippedUpdateMatches, winSkippedUpdateCandidate } from "../skippedUpdate";
@@ -29,15 +27,11 @@ import {
   ManualExistingInstallSheet,
   type ManualExistingCandidate,
 } from "./ManualExistingInstall";
-
-function samePath(a: string, b: string): boolean {
-  const norm = (value: string) =>
-    value.trim().replace(/[\\/]+$/, "").replace(/\//g, "\\").toLowerCase();
-  return norm(a) === norm(b);
-}
+import { ProgressScreen, type PausedDownload } from "./ProgressScreen";
+import { useDownloadProgress } from "./useDownloadProgress";
+import { useFocusRecheck, installIdentity } from "./useFocusRecheck";
 
 type Kind = "loading" | "error" | "none" | "idle" | "update" | "external" | "uptodate";
-type DownloadStopIntent = "pause" | "cancel";
 
 // Windows counterpart of MacHome — same design system + state machine, driven by
 // the win_* backend (codex-win-engine): MSIX sideload or portable fallback.
@@ -65,22 +59,10 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const [manualExistingError, setManualExistingError] = useState<string | null>(null);
   const [statusLoaded, setStatusLoaded] = useState(false);
   const [statusFailed, setStatusFailed] = useState(false);
-  const [dl, setDl] = useState<DownloadProgress | null>(null);
-  const [speed, setSpeed] = useState(0);
-  const dlSample = useRef<{ t: number; bytes: number } | null>(null);
-  const [downloadStop, setDownloadStop] = useState<DownloadStopIntent | null>(null);
-  const [downloadStopBusy, setDownloadStopBusy] = useState(false);
-  const downloadStopRef = useRef<DownloadStopIntent | null>(null);
-  // Latest live progress, read at pause time to snapshot the paused figures.
-  const dlRef = useRef<DownloadProgress | null>(null);
   // A paused download: the progress screen stays up (not routed home) offering
   // 〔继续〕/〔取消〕. `installRoot` is preserved so a paused fresh install
   // resumes into the same chosen location.
-  const [paused, setPaused] = useState<{
-    kind: "perform" | "install";
-    dl: DownloadProgress | null;
-    installRoot?: string;
-  } | null>(null);
+  const [paused, setPaused] = useState<(PausedDownload & { installRoot?: string }) | null>(null);
   const scopeRef = useRef<HTMLDivElement>(null);
   const confirmTitleId = useId();
   const confirmBodyId = useId();
@@ -88,64 +70,29 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const installDirBodyId = useId();
   const manualExistingTitleId = useId();
   const manualExistingBodyId = useId();
-  // Smoothly roll the live download figures instead of snapping per event.
-  const dlPctTarget = dl && dl.total > 0 ? Math.min(100, (dl.downloaded / dl.total) * 100) : 0;
-  const dlPct = useCountUp(dlPctTarget);
-  const dlBytes = useCountUp(dl?.downloaded ?? 0);
-  const dlSpeed = useCountUp(speed);
 
-  const onDlProgress = useCallback((event: { payload: DownloadProgress }) => {
-    const p = event.payload;
-    setDl(p);
-    dlRef.current = p;
-    const now = Date.now();
-    const prev = dlSample.current;
-    if (!prev) {
-      dlSample.current = { t: now, bytes: p.downloaded };
-    } else if (now > prev.t + 400) {
-      setSpeed((p.downloaded - prev.bytes) / ((now - prev.t) / 1000));
-      dlSample.current = { t: now, bytes: p.downloaded };
-    }
-  }, []);
-
-  const startDlListen = useCallback(async () => {
-    setDl(null);
-    dlRef.current = null;
-    setSpeed(0);
-    dlSample.current = null;
-    try {
-      return await listen<DownloadProgress>("win://download-progress", onDlProgress);
-    } catch {
-      return () => {};
-    }
-  }, [onDlProgress]);
-
-  const requestDownloadStop = useCallback(
-    async (intent: DownloadStopIntent) => {
-      setActionError(null);
-      setDownloadStop(intent);
-      setDownloadStopBusy(true);
-      downloadStopRef.current = intent;
-      try {
-        const active =
-          intent === "pause"
-            ? await managerApi.winPauseDownload()
-            : await managerApi.winCancelDownload();
-        if (!active) {
-          downloadStopRef.current = null;
-          setDownloadStop(null);
-          setDownloadStopBusy(false);
-          setActionError(t("progress.cannotCancel"));
-        }
-      } catch (cause) {
-        downloadStopRef.current = null;
-        setDownloadStop(null);
-        setDownloadStopBusy(false);
-        setActionError(userErrorMessage(cause, t));
-      }
-    },
-    [t],
-  );
+  // Live download state machine, shared with the mac home; only the channel +
+  // stop commands differ.
+  const {
+    dl,
+    setDl,
+    dlRef,
+    dlPct,
+    dlBytes,
+    dlSpeed,
+    downloadStop,
+    downloadStopBusy,
+    downloadStopRef,
+    startDlListen,
+    requestDownloadStop,
+    resetStop,
+  } = useDownloadProgress({
+    eventName: "win://download-progress",
+    pauseDownload: () => managerApi.winPauseDownload(),
+    cancelDownload: () => managerApi.winCancelDownload(),
+    cannotCancelMessage: t("progress.cannotCancel"),
+    onError: setActionError,
+  });
 
   const check = useCallback(async () => {
     setBusy("plan");
@@ -195,6 +142,12 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     return () => window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged);
   }, []);
 
+  // The snapshot/busy values the focus listener (a long-lived subscription)
+  // reads — refs so the subscription doesn't tear down on every state change.
+  const reportRef = useRef<WinUpdateReport | null>(null);
+  useEffect(() => {
+    reportRef.current = report;
+  }, [report]);
   const busyRef = useRef(busy);
   useEffect(() => {
     busyRef.current = busy;
@@ -203,6 +156,37 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   useEffect(() => {
     checkRef.current = check;
   }, [check]);
+
+  // Window focus → silently re-detect the local install and re-check if the
+  // install identity (version OR path) drifted out-of-band. Parity with the mac
+  // home, which has had this since the atomic-snapshot rework; without it the
+  // Windows card can show a stale version / "managed" badge after Codex is
+  // updated or removed externally, until the next periodic check.
+  useFocusRecheck<WinInstallStatus>({
+    fetchStatus: () => managerApi.winStatus(),
+    onStatus: (st) => {
+      setStatus(st);
+      setStatusLoaded(true);
+      setStatusFailed(false);
+    },
+    hasChecked: () => reportRef.current != null,
+    checkedIdentity: () => installIdentity(reportRef.current?.installed ?? null, normalizePath),
+    identityOf: (st) => installIdentity(st.installed ?? null, normalizePath),
+    isBusy: () => busyRef.current != null,
+    onIdentityChanged: () => {
+      // Drop EVERY sheet built for the OLD target before re-checking: the
+      // confirm sheet, the fresh-install location sheet, and the manual
+      // existing-install picker. Any of them could otherwise let a click run
+      // install/perform against a snapshot the user never saw — bypassing the
+      // freshly-refreshed external→adopt boundary. The user re-confirms against
+      // the re-checked card.
+      setConfirmOpen(false);
+      setInstallDirOpen(false);
+      setManualExistingOpen(false);
+      setManualExistingCandidate(null);
+      void check();
+    },
+  });
 
   useEffect(() => {
     if (!settings.periodicCheck) return;
@@ -302,13 +286,10 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       } finally {
         unlisten();
         setBusy(null);
-        setDl(null);
-        setDownloadStop(null);
-        setDownloadStopBusy(false);
-        downloadStopRef.current = null;
+        resetStop();
       }
     },
-    [status, report, refreshStatus, check, startDlListen, t],
+    [status, report, refreshStatus, check, startDlListen, resetStop, t],
   );
 
   // 〔继续〕from the paused state — re-run the same operation (same install
@@ -559,92 +540,25 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   useHomeMotion(scopeRef, scene, { splitHeadline, success });
 
   if (progressing || paused) {
-    const installing = paused ? paused.kind === "install" : busy === "install";
-    const snap = paused ? paused.dl : dl;
-    const known = Boolean(snap && snap.total > 0);
-    const snapPct = snap && snap.total > 0 ? Math.min(100, (snap.downloaded / snap.total) * 100) : 0;
-    const pct = known ? Math.round(paused ? snapPct : dlPct) : null;
-    const barPct = paused ? snapPct : dlPct;
-    // Bytes are in → the uninterruptible install phase (sideload / portable
-    // extract). Say so and drop the dead buttons rather than grey them silently.
-    const finishing = !paused && Boolean(snap && snap.total > 0 && snap.downloaded >= snap.total);
-    // Pause only mid-transfer; cancel is the "abandon" out and works through the
-    // preparing phase too (a backend abort checkpoint honors it), but not once
-    // the install has begun.
-    const canPause =
-      !paused && Boolean(dl && dl.total > 0 && dl.downloaded < dl.total) && !downloadStopBusy;
-    const canCancel = !paused && !finishing && !downloadStopBusy;
     return (
-      <div className="pop">
-        <TopBar />
-        <div className="scroll" ref={scopeRef}>
-          <div className="hero" style={{ marginTop: 24 }} key={scene}>
-            <Ring icon={paused ? "pause" : "loader"} spin={!paused} className="glow" />
-            <div className={`headline${paused ? "" : " shimmer"}`}>
-              {paused
-                ? t("progress.paused.title")
-                : installing
-                  ? t("progress.installing")
-                  : t("progress.title")}
-            </div>
-            {!paused ? (
-              <div className="sub">
-                {finishing
-                  ? t("progress.finishing")
-                  : snap
-                    ? t("progress.downloadingFrom", { source: snap.source })
-                    : t("progress.preparing")}
-              </div>
-            ) : null}
-            {pct !== null ? (
-              <div className="pctbig">
-                {pct}
-                <span className="pctsign">%</span>
-              </div>
-            ) : null}
-            <div className="bar">
-              <div
-                className={`bar-fill${pct === null ? " indeterminate" : ""}`}
-                style={pct === null ? undefined : { width: `${barPct}%` }}
-              />
-            </div>
-            {known && snap ? (
-              <div className="dlmeta">
-                {mib(paused ? snap.downloaded : dlBytes)} / {mib(snap.total)}
-                {!paused && dlSpeed > 0 ? ` · ${mib(dlSpeed)}/s` : ""}
-              </div>
-            ) : null}
-            <div className="progress-actions">
-              {paused ? (
-                <button className="btn primary" onClick={resumeDownload}>
-                  <Icon name="play" />
-                  {t("progress.resume")}
-                </button>
-              ) : (
-                <button
-                  className="btn ghost"
-                  onClick={() => void requestDownloadStop("pause")}
-                  disabled={!canPause}
-                >
-                  <Icon name="pause" />
-                  {downloadStop === "pause" ? t("progress.pausePending") : t("progress.pause")}
-                </button>
-              )}
-              <button
-                className="btn danger"
-                onClick={() => {
-                  if (paused) cancelPausedDownload();
-                  else void requestDownloadStop("cancel");
-                }}
-                disabled={!paused && !canCancel}
-              >
-                <Icon name="close" />
-                {downloadStop === "cancel" ? t("progress.cancelPending") : t("progress.cancel")}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <ProgressScreen
+        scene={scene}
+        scopeRef={scopeRef}
+        paused={paused}
+        dl={dl}
+        dlPct={dlPct}
+        dlBytes={dlBytes}
+        dlSpeed={dlSpeed}
+        installing={paused ? paused.kind === "install" : busy === "install"}
+        downloadStop={downloadStop}
+        downloadStopBusy={downloadStopBusy}
+        onResume={resumeDownload}
+        onPause={() => void requestDownloadStop("pause")}
+        onCancel={() => {
+          if (paused) void cancelPausedDownload();
+          else void requestDownloadStop("cancel");
+        }}
+      />
     );
   }
 

--- a/src/app/views/useDownloadProgress.ts
+++ b/src/app/views/useDownloadProgress.ts
@@ -1,0 +1,114 @@
+import { useCallback, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+import type { DownloadProgress } from "../../shared/types";
+import { userErrorMessage } from "../errorCopy";
+import { useI18n } from "../i18n";
+import { useCountUp } from "../useCountUp";
+import type { DownloadStopIntent } from "./ProgressScreen";
+
+/** The live-download state machine shared by the Mac and Windows homes: the
+ *  progress bytes + eased readouts, the pause/cancel intent, and the backend
+ *  stop request. Platform differences are injected — the event channel name and
+ *  the pause/cancel commands. Errors surface through `onError` so the host view
+ *  can drive its own banner. */
+export function useDownloadProgress(opts: {
+  eventName: string;
+  pauseDownload: () => Promise<boolean>;
+  cancelDownload: () => Promise<boolean>;
+  cannotCancelMessage: string;
+  onError: (message: string | null) => void;
+}) {
+  const { eventName, pauseDownload, cancelDownload, cannotCancelMessage, onError } = opts;
+  const { t } = useI18n();
+
+  const [dl, setDl] = useState<DownloadProgress | null>(null);
+  const [speed, setSpeed] = useState(0);
+  const dlSample = useRef<{ t: number; bytes: number } | null>(null);
+  const [downloadStop, setDownloadStop] = useState<DownloadStopIntent | null>(null);
+  const [downloadStopBusy, setDownloadStopBusy] = useState(false);
+  const downloadStopRef = useRef<DownloadStopIntent | null>(null);
+  // Latest live progress, read at pause time to snapshot the paused figures
+  // (the `dl` state is cleared when the perform/install call unwinds).
+  const dlRef = useRef<DownloadProgress | null>(null);
+
+  // Smoothly roll the live figures instead of snapping on every progress event.
+  const dlPctTarget = dl && dl.total > 0 ? Math.min(100, (dl.downloaded / dl.total) * 100) : 0;
+  const dlPct = useCountUp(dlPctTarget);
+  const dlBytes = useCountUp(dl?.downloaded ?? 0);
+  const dlSpeed = useCountUp(speed);
+
+  const onDlProgress = useCallback((event: { payload: DownloadProgress }) => {
+    const p = event.payload;
+    setDl(p);
+    dlRef.current = p;
+    const now = Date.now();
+    const prev = dlSample.current;
+    if (!prev) {
+      dlSample.current = { t: now, bytes: p.downloaded };
+    } else if (now > prev.t + 400) {
+      setSpeed((p.downloaded - prev.bytes) / ((now - prev.t) / 1000));
+      dlSample.current = { t: now, bytes: p.downloaded };
+    }
+  }, []);
+
+  const startDlListen = useCallback(async () => {
+    setDl(null);
+    dlRef.current = null;
+    setSpeed(0);
+    dlSample.current = null;
+    try {
+      return await listen<DownloadProgress>(eventName, onDlProgress);
+    } catch {
+      // Non-Tauri (web preview): no event bus — nothing to clean up.
+      return () => {};
+    }
+  }, [eventName, onDlProgress]);
+
+  const requestDownloadStop = useCallback(
+    async (intent: DownloadStopIntent) => {
+      onError(null);
+      setDownloadStop(intent);
+      setDownloadStopBusy(true);
+      downloadStopRef.current = intent;
+      try {
+        const active = intent === "pause" ? await pauseDownload() : await cancelDownload();
+        if (!active) {
+          downloadStopRef.current = null;
+          setDownloadStop(null);
+          setDownloadStopBusy(false);
+          onError(cannotCancelMessage);
+        }
+      } catch (cause) {
+        downloadStopRef.current = null;
+        setDownloadStop(null);
+        setDownloadStopBusy(false);
+        onError(userErrorMessage(cause, t));
+      }
+    },
+    [pauseDownload, cancelDownload, cannotCancelMessage, onError, t],
+  );
+
+  // Clear the transfer + stop state when a perform/install call unwinds.
+  const resetStop = useCallback(() => {
+    setDl(null);
+    setDownloadStop(null);
+    setDownloadStopBusy(false);
+    downloadStopRef.current = null;
+  }, []);
+
+  return {
+    dl,
+    setDl,
+    dlRef,
+    dlPct,
+    dlBytes,
+    dlSpeed,
+    downloadStop,
+    downloadStopBusy,
+    downloadStopRef,
+    startDlListen,
+    requestDownloadStop,
+    resetStop,
+  };
+}

--- a/src/app/views/useFocusRecheck.test.ts
+++ b/src/app/views/useFocusRecheck.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizePath } from "../paths";
+import { installIdentity } from "./useFocusRecheck";
+
+describe("installIdentity", () => {
+  it("is null for an absent install", () => {
+    expect(installIdentity(null)).toBeNull();
+    expect(installIdentity(undefined)).toBeNull();
+  });
+
+  it("keys mac installs on build + raw (case-sensitive) path", () => {
+    const a = installIdentity({ build: 100, path: "/Applications/Codex.app" });
+    const b = installIdentity({ build: 100, path: "/Applications/codex.app" });
+    // Mac paths are case-sensitive — these are DIFFERENT installs.
+    expect(a).not.toBe(b);
+    expect(installIdentity({ build: 101, path: "/Applications/Codex.app" })).not.toBe(a);
+  });
+
+  it("folds Windows path casing / separators so a cosmetic diff isn't drift", () => {
+    const a = installIdentity(
+      { version: "1.0.0", path: "C:\\Program Files\\Codex" },
+      normalizePath,
+    );
+    const b = installIdentity(
+      { version: "1.0.0", path: "c:/program files/codex/" },
+      normalizePath,
+    );
+    // Same install, different spelling — must be the SAME identity.
+    expect(a).toBe(b);
+    // A real version change is still drift.
+    expect(installIdentity({ version: "2.0.0", path: "C:\\Program Files\\Codex" }, normalizePath)).not.toBe(a);
+  });
+});

--- a/src/app/views/useFocusRecheck.ts
+++ b/src/app/views/useFocusRecheck.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, type RefObject } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Window focus → silently re-detect the local install (milliseconds, no
+ * network). If the install identity (version/build + path) no longer matches
+ * the snapshot on screen — Codex was updated / downgraded / removed / moved
+ * out-of-band while we weren't looking — run the full re-check so the card
+ * corrects itself instead of waiting to fail the perform-time guard.
+ *
+ * Shared by both platform homes (previously only the mac home had it). The
+ * listener installs ONCE and reads the latest callbacks via refs, so it never
+ * tears down on a state change; non-Tauri (web preview / tests) is a no-op.
+ */
+export function useFocusRecheck<S extends { installed: unknown }>(opts: {
+  /** Local, network-free status probe (macStatus / winStatus). */
+  fetchStatus: () => Promise<S>;
+  /** Apply the fresh status (setStatus / setStatusLoaded / clear failed). */
+  onStatus: (status: S) => void;
+  /** Have we planned at least once? Gate on this, not on a non-null install,
+   *  or the none→installed transition is missed. */
+  hasChecked: () => boolean;
+  /** Stable identity of the last CHECKED install (build/version + path). */
+  checkedIdentity: () => string | null;
+  /** Stable identity of a freshly-probed install. */
+  identityOf: (status: S) => string | null;
+  /** True while an operation is in flight — skip the probe. */
+  isBusy: () => boolean;
+  /** The identity drifted: drop any open confirm sheet + re-check. */
+  onIdentityChanged: () => void;
+}) {
+  // Stash the latest callbacks so the focus listener installs once and never
+  // re-subscribes — mirroring the original ref-driven effect.
+  const ref = useRef(opts);
+  ref.current = opts;
+
+  useEffect(() => {
+    let last = 0;
+    let un: (() => void) | undefined;
+    void (async () => {
+      try {
+        un = await listen("tauri://focus", () => {
+          const now = Date.now();
+          if (ref.current.isBusy() || now - last < 3000) return;
+          last = now;
+          void (async () => {
+            try {
+              const st = await ref.current.fetchStatus();
+              ref.current.onStatus(st);
+              if (
+                ref.current.hasChecked() &&
+                ref.current.checkedIdentity() !== ref.current.identityOf(st)
+              ) {
+                ref.current.onIdentityChanged();
+              }
+            } catch {
+              // Transient/unsupported — the next explicit check will surface it.
+            }
+          })();
+        });
+      } catch {
+        // Non-Tauri (web preview): no event bus — nothing to clean up.
+      }
+    })();
+    return () => un?.();
+  }, []);
+}
+
+/** Stable identity string for an install: `null` when absent, else the pieces
+ *  whose change should force a re-plan (version/build + path). Accepts either
+ *  platform's installed shape — mac keys on `build`, Windows on `version`.
+ *  `normalizePath` folds cosmetic path differences (Windows returns the same
+ *  root with mixed casing / separators); mac omits it since its paths are
+ *  case-sensitive, so a raw compare is correct there. */
+export function installIdentity(
+  installed: { path: string; build?: number; version?: string } | null | undefined,
+  normalizePath: (path: string) => string = (path) => path,
+): string | null {
+  if (!installed) return null;
+  const stamp = installed.build != null ? String(installed.build) : installed.version ?? "";
+  return `${stamp}|${normalizePath(installed.path)}`;
+}


### PR DESCRIPTION
## Summary
The Mac and Windows homes were ~60% duplicated and had already drifted — Windows lacked the focus re-check the mac home gained in the atomic-snapshot rework. This extracts the shared surface and closes the gap.

**New shared modules**
- `ProgressScreen` — the full-screen download/install view (was byte-for-byte identical in both homes). Now carries progressbar accessibility: `role="progressbar"` + `aria-value{min,max,now,text}` and an `aria-live` phase line, so assistive tech can follow a destructive install/update (closes the review's P1 progress-bar gap).
- `useDownloadProgress` — the live-bytes + pause/cancel state machine, with the event channel and stop commands injected per platform.
- `useFocusRecheck` + `installIdentity` — window-focus re-detect; installs the listener once (latest-ref pattern) and re-checks when the install identity drifts.

**Behavior fixes**
- **WinHome now has the focus re-check** (parity with mac — closes review finding M1): after Codex is updated / removed / moved out-of-band, the card self-corrects instead of showing a stale version / "managed" badge until the next periodic check.
- On identity drift WinHome closes **all** stale sheets (confirm + install-dir + manual-existing), not just confirm, so a click in a stale sheet can't run install/perform past the external→adopt boundary.
- Windows install identity **normalizes the path** (casing / separators) so a cosmetic difference isn't misread as drift; mac stays case-sensitive.

`samePath` / `normalizePath` moved to `paths.ts` (shared by WinHome + Settings).

Home 1044→887 lines, WinHome 1015→929.

## Verification
- `tsc --noEmit` clean, 69/69 vitest passing (14 new/changed), production build OK.
- New tests: progressbar a11y assertion; focus-recheck closes the install-dir sheet on drift (genuinely depends on the fix); `installIdentity` path normalization (mac case-sensitive, Windows folded).
- Browser preview: fresh server restart → zero console errors, home renders.
- `codex review --uncommitted` iterated to no findings — it caught two real bugs I introduced (stale install-dir sheet bypassing the adopt boundary; un-normalized Windows path misread as drift), both fixed + regression-tested.