### PR TITLE
fix(ui): restore headline spacing after animation

### DIFF
--- a/src/app/motion.test.tsx
+++ b/src/app/motion.test.tsx
@@ -1,0 +1,78 @@
+import { render } from "@testing-library/react";
+import { useRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const revert = vi.fn();
+  const headline = { getAttribute: vi.fn(() => null) };
+  const fromTo = vi.fn();
+  const timeline = { fromTo };
+
+  return {
+    fromTo,
+    headline,
+    revert,
+    timeline,
+    timelineOptions: undefined as { onComplete?: () => void } | undefined,
+  };
+});
+
+vi.mock("@gsap/react", () => ({
+  useGSAP: (setup: () => void) => setup(),
+}));
+
+vi.mock("gsap", () => ({
+  default: {
+    matchMedia: () => ({ add: (_query: string, setup: () => void) => setup() }),
+    registerPlugin: vi.fn(),
+    timeline: (options: { onComplete?: () => void }) => {
+      mocks.timelineOptions = options;
+      return mocks.timeline;
+    },
+    utils: {
+      selector: () => (selector: string) =>
+        selector === ".hero .headline" ? [mocks.headline] : [],
+    },
+  },
+}));
+
+vi.mock("gsap/CustomEase", () => ({
+  CustomEase: { create: vi.fn() },
+}));
+
+vi.mock("gsap/DrawSVGPlugin", () => ({
+  DrawSVGPlugin: {},
+}));
+
+vi.mock("gsap/SplitText", () => ({
+  SplitText: {
+    create: vi.fn(() => ({ chars: [mocks.headline], revert: mocks.revert })),
+  },
+}));
+
+import { useHomeMotion } from "./motion";
+
+function Harness() {
+  const scope = useRef<HTMLDivElement>(null);
+  useHomeMotion(scope, "external", { splitHeadline: true, success: false });
+  return <div ref={scope} />;
+}
+
+describe("useHomeMotion", () => {
+  beforeEach(() => {
+    mocks.fromTo.mockClear();
+    mocks.revert.mockClear();
+    mocks.timelineOptions = undefined;
+  });
+
+  it("restores the original headline markup after the scene entrance completes", () => {
+    render(<Harness />);
+
+    expect(mocks.revert).not.toHaveBeenCalled();
+    expect(mocks.timelineOptions?.onComplete).toBeTypeOf("function");
+
+    mocks.timelineOptions?.onComplete?.();
+
+    expect(mocks.revert).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/motion.ts
+++ b/src/app/motion.ts
@@ -56,7 +56,14 @@ export function useHomeMotion(
         // .btn:disabled fade and the :active press transform).
         const CLEAR = "transform,opacity,visibility";
         let split: SplitText | undefined;
-        const tl = gsap.timeline({ defaults: { ease: "cam-out", duration: 0.58 } });
+        const tl = gsap.timeline({
+          defaults: { ease: "cam-out", duration: 0.58 },
+          // SplitText leaves every glyph in its own inline-block. That is useful
+          // during the reveal, but keeping it afterward changes kerning and CJK
+          // fallback spacing on Windows. Restore the original text once the
+          // complete scene entrance has settled.
+          onComplete: () => split?.revert(),
+        });
         // fromTo with EXPLICIT end states (not from(): persistent sibling nodes
         // like .actions/.list.meta aren't remounted with the keyed hero, and a
         // bare from() would read a leftover inline opacity:0 as the end target


### PR DESCRIPTION
## Summary
- restore the original headline markup after the GSAP entrance finishes
- prevent SplitText wrappers from altering mixed CJK/Latin spacing on Windows
- add a regression test for the animation completion lifecycle

## Validation
- npm test
- npm run check
- npm run lint
- npm run build
- Codex review: no findings
- browser QA in normal and Windows-emulated rendering

Fixes #139