### PR TITLE
fix: follow Codex lineage through the ChatGPT rebrand by bundle/package identity

### DIFF
--- a/crates/codex-mac-engine/src/bin/mac_live_test.rs
+++ b/crates/codex-mac-engine/src/bin/mac_live_test.rs
@@ -41,7 +41,7 @@ fn main() {
         exit(2);
     }
     let before = build_of(&install);
-    let was_running = swap::codex_running();
+    let was_running = swap::codex_running_at(&install);
     println!("真实安装根: /Applications/Codex.app  build={before}  running={was_running}");
 
     let stage_dir = std::env::temp_dir().join("codex-live-test");

--- a/crates/codex-mac-engine/src/codesign.rs
+++ b/crates/codex-mac-engine/src/codesign.rs
@@ -140,7 +140,31 @@ pub fn assess_gatekeeper(app: &Path) -> Result<(), EngineError> {
     Ok(())
 }
 
-/// Full post-apply gate: signature intact + correct team + Gatekeeper accepts.
+/// Assert the bundle IS the Codex product. Team ID alone cannot do this:
+/// ChatGPT Classic (`com.openai.chat`) is signed by the same OpenAI team, so
+/// once bundles are no longer identified by name this is what keeps a Classic
+/// bundle from ever passing the gate. Runs after `verify_signature`, which
+/// seals `Info.plist`, so the identifier read here is signature-backed.
+pub fn require_codex_bundle_identity(app: &Path) -> Result<(), EngineError> {
+    let id = crate::sys::read_bundle_identifier(&app.to_string_lossy()).ok_or_else(|| {
+        EngineError::Verify("bundle has no readable CFBundleIdentifier".to_string())
+    })?;
+    if id == crate::sys::CODEX_BUNDLE_ID {
+        return Ok(());
+    }
+    let hint = if id == "com.openai.chat" {
+        " (this is ChatGPT Classic — a different product this tool never manages)"
+    } else {
+        ""
+    };
+    Err(EngineError::Verify(format!(
+        "CFBundleIdentifier mismatch: got {id}, expected {}{hint}",
+        crate::sys::CODEX_BUNDLE_ID
+    )))
+}
+
+/// Full post-apply gate: signature intact + Codex product identity + correct
+/// team + Gatekeeper accepts.
 pub fn gate_reconstructed(app: &Path) -> Result<(), EngineError> {
     let app_name = app
         .file_name()
@@ -149,6 +173,10 @@ pub fn gate_reconstructed(app: &Path) -> Result<(), EngineError> {
     log::info!("codesign Gatekeeper gate start path={app_name}");
     if let Err(err) = verify_signature(app) {
         log::error!("codesign gate failed path={app_name} error={err}");
+        return Err(err);
+    }
+    if let Err(err) = require_codex_bundle_identity(app) {
+        log::error!("bundle identity gate failed path={app_name} error={err}");
         return Err(err);
     }
     let team = match team_identifier(app) {

--- a/crates/codex-mac-engine/src/lib.rs
+++ b/crates/codex-mac-engine/src/lib.rs
@@ -32,7 +32,7 @@ pub use download::{
 };
 pub use network::NetworkConfig;
 pub use plan::{plan_update, UpdatePlan, UpdateStrategy};
-pub use swap::{install_gated_bundle, quit_codex, relaunch, rollback, swap_in_place};
+pub use swap::{install_gated_bundle, quit_codex_at, relaunch, rollback, swap_in_place};
 pub use sys::CODEX_BUNDLE_ID;
 pub use verify::{verify_sparkle, SPARKLE_ED_PUBKEY_B64};
 

--- a/crates/codex-mac-engine/src/lib.rs
+++ b/crates/codex-mac-engine/src/lib.rs
@@ -33,6 +33,7 @@ pub use download::{
 pub use network::NetworkConfig;
 pub use plan::{plan_update, UpdatePlan, UpdateStrategy};
 pub use swap::{install_gated_bundle, quit_codex, relaunch, rollback, swap_in_place};
+pub use sys::CODEX_BUNDLE_ID;
 pub use verify::{verify_sparkle, SPARKLE_ED_PUBKEY_B64};
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/codex-mac-engine/src/swap.rs
+++ b/crates/codex-mac-engine/src/swap.rs
@@ -50,8 +50,15 @@ fn applescript_quote(literal: &str) -> String {
 /// several coexist. The main process's argv[0] is the bundle's
 /// `Contents/MacOS/<CFBundleExecutable>` absolute path, so a prefix match on
 /// that pins the exact instance we manage.
+///
+/// The path is canonicalized first: argv[0] holds the RESOLVED path, so a
+/// symlinked install root (or parent) would otherwise never match and the
+/// quit-before-swap protection would be silently skipped.
 pub fn codex_running_at(install_app: &Path) -> bool {
-    let app = install_app.to_string_lossy();
+    let canonical = install_app
+        .canonicalize()
+        .unwrap_or_else(|_| install_app.to_path_buf());
+    let app = canonical.to_string_lossy();
     let Some(exe) = crate::sys::read_bundle_executable(&app) else {
         // No readable bundle at the path (e.g. already removed) — not running.
         return false;
@@ -87,24 +94,29 @@ fn tell_codex_at(install_app: &Path, verb: &str) -> std::io::Result<std::process
 /// grace period we therefore `activate` Codex — bringing the pending dialog
 /// frontmost so the user can answer it — and keep waiting until the timeout.
 pub fn quit_codex_at(install_app: &Path, timeout_secs: u64) -> Result<(), EngineError> {
-    if !codex_running_at(install_app) {
+    // Resolve symlinks once so detection (argv[0] holds the real path) and the
+    // AppleScript address agree on the same concrete bundle.
+    let install_app = install_app
+        .canonicalize()
+        .unwrap_or_else(|_| install_app.to_path_buf());
+    if !codex_running_at(&install_app) {
         return Ok(());
     }
     log::info!(
         "requesting Codex graceful quit timeout={timeout_secs} path={}",
         install_app.display()
     );
-    let _ = tell_codex_at(install_app, "quit");
+    let _ = tell_codex_at(&install_app, "quit");
 
     // 250ms ticks; if Codex is still running after ~5s it is most likely
     // waiting on its quit-confirmation dialog — surface it.
     let activate_tick = 5 * 4;
     for tick in 0..(timeout_secs * 4) {
-        if !codex_running_at(install_app) {
+        if !codex_running_at(&install_app) {
             return Ok(());
         }
         if tick == activate_tick {
-            let _ = tell_codex_at(install_app, "activate");
+            let _ = tell_codex_at(&install_app, "activate");
         }
         std::thread::sleep(std::time::Duration::from_millis(250));
     }

--- a/crates/codex-mac-engine/src/swap.rs
+++ b/crates/codex-mac-engine/src/swap.rs
@@ -71,6 +71,28 @@ pub fn codex_running_at(install_app: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Is a live process running out of an App Translocation mount for a bundle
+/// with this name? Translocated instances do NOT move back when the original
+/// bundle is de-quarantined or relocated, so they stay invisible to
+/// `codex_running_at`'s path-scoped match. Matching is by bundle basename
+/// (the tightest anchor a randomized mount allows), which can also hit a
+/// translocated ChatGPT Classic — an acceptable false positive: callers only
+/// use this to REFUSE managing until the instance exits.
+pub fn translocated_instance_running(install_app: &Path) -> bool {
+    let Some(bundle_name) = install_app.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let pattern = format!(
+        "/AppTranslocation/.*/{}/Contents/MacOS/",
+        ere_escape(bundle_name)
+    );
+    Command::new(PGREP)
+        .args(["-f", &pattern])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 /// Send `quit`/`activate` to the app bundle AT THIS PATH. AppleScript's
 /// `tell application "<POSIX path>"` addresses that specific bundle, unlike
 /// `tell application id`, which lets LaunchServices pick any install of the

--- a/crates/codex-mac-engine/src/swap.rs
+++ b/crates/codex-mac-engine/src/swap.rs
@@ -18,35 +18,67 @@ use crate::EngineError;
 
 const OPEN: &str = "/usr/bin/open";
 const OSASCRIPT: &str = "/usr/bin/osascript";
+const PGREP: &str = "/usr/bin/pgrep";
 
-/// Is the Codex lineage app currently running?
+/// Escape a literal string for use inside a POSIX extended regular expression
+/// (the pattern language `pgrep -f` matches against).
+fn ere_escape(literal: &str) -> String {
+    let mut escaped = String::with_capacity(literal.len());
+    for ch in literal.chars() {
+        if matches!(
+            ch,
+            '\\' | '^' | '$' | '.' | '[' | ']' | '|' | '(' | ')' | '*' | '+' | '?' | '{' | '}'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+/// Escape a literal for embedding in a double-quoted AppleScript string.
+fn applescript_quote(literal: &str) -> String {
+    literal.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Is THIS install of Codex currently running?
 ///
-/// Addressed by bundle id, not process name: the ChatGPT-brand merge renamed
-/// the executable (`Codex` → `ChatGPT`), and a name match would both miss the
-/// renamed Codex and hit ChatGPT Classic (whose process is also `ChatGPT`).
-/// AppleScript's `running` property is read without launching the target.
-pub fn codex_running() -> bool {
-    let script = format!(
-        r#"application id "{}" is running"#,
-        crate::sys::CODEX_BUNDLE_ID
-    );
-    Command::new(OSASCRIPT)
-        .args(["-e", &script])
+/// Addressed by the install's own executable path, not by process name or
+/// bundle id: the brand merge renamed the executable (`Codex` → `ChatGPT`,
+/// same as ChatGPT Classic's process), and bundle-id addressing resolves via
+/// LaunchServices, which may pick a DIFFERENT install of the same id when
+/// several coexist. The main process's argv[0] is the bundle's
+/// `Contents/MacOS/<CFBundleExecutable>` absolute path, so a prefix match on
+/// that pins the exact instance we manage.
+pub fn codex_running_at(install_app: &Path) -> bool {
+    let app = install_app.to_string_lossy();
+    let Some(exe) = crate::sys::read_bundle_executable(&app) else {
+        // No readable bundle at the path (e.g. already removed) — not running.
+        return false;
+    };
+    let pattern = format!("^{}( |$)", ere_escape(&format!("{app}/Contents/MacOS/{exe}")));
+    Command::new(PGREP)
+        .args(["-f", &pattern])
         .output()
-        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
+        .map(|o| o.status.success())
         .unwrap_or(false)
 }
 
-fn tell_codex(verb: &str) -> std::io::Result<std::process::ExitStatus> {
+/// Send `quit`/`activate` to the app bundle AT THIS PATH. AppleScript's
+/// `tell application "<POSIX path>"` addresses that specific bundle, unlike
+/// `tell application id`, which lets LaunchServices pick any install of the
+/// id. Callers must gate on `codex_running_at` first: telling a non-running
+/// app launches it.
+fn tell_codex_at(install_app: &Path, verb: &str) -> std::io::Result<std::process::ExitStatus> {
     let script = format!(
-        r#"tell application id "{}" to {verb}"#,
-        crate::sys::CODEX_BUNDLE_ID
+        r#"tell application "{}" to {verb}"#,
+        applescript_quote(&install_app.to_string_lossy())
     );
     Command::new(OSASCRIPT).args(["-e", &script]).status()
 }
 
-/// Ask Codex to quit gracefully (AppleScript), polling up to `timeout_secs`.
-/// Never force-kills.
+/// Ask the Codex install at `install_app` to quit gracefully (AppleScript),
+/// polling up to `timeout_secs`. Never force-kills.
 ///
 /// Codex may answer the quit event with its own in-app confirmation dialog
 /// instead of quitting (e.g. "Quit Codex? Enabled automations won't run…"
@@ -54,22 +86,25 @@ fn tell_codex(verb: &str) -> std::io::Result<std::process::ExitStatus> {
 /// on a window the user never sees, so the quit silently stalls. After a short
 /// grace period we therefore `activate` Codex — bringing the pending dialog
 /// frontmost so the user can answer it — and keep waiting until the timeout.
-pub fn quit_codex(timeout_secs: u64) -> Result<(), EngineError> {
-    if !codex_running() {
+pub fn quit_codex_at(install_app: &Path, timeout_secs: u64) -> Result<(), EngineError> {
+    if !codex_running_at(install_app) {
         return Ok(());
     }
-    log::info!("requesting Codex graceful quit timeout={timeout_secs}");
-    let _ = tell_codex("quit");
+    log::info!(
+        "requesting Codex graceful quit timeout={timeout_secs} path={}",
+        install_app.display()
+    );
+    let _ = tell_codex_at(install_app, "quit");
 
     // 250ms ticks; if Codex is still running after ~5s it is most likely
     // waiting on its quit-confirmation dialog — surface it.
     let activate_tick = 5 * 4;
     for tick in 0..(timeout_secs * 4) {
-        if !codex_running() {
+        if !codex_running_at(install_app) {
             return Ok(());
         }
         if tick == activate_tick {
-            let _ = tell_codex("activate");
+            let _ = tell_codex_at(install_app, "activate");
         }
         std::thread::sleep(std::time::Duration::from_millis(250));
     }
@@ -204,7 +239,7 @@ pub fn install_gated_bundle(
 ) -> Result<(), EngineError> {
     crate::codesign::gate_reconstructed(new_app)?;
     if manage_process {
-        quit_codex(30)?;
+        quit_codex_at(install_app, 30)?;
     }
     swap_in_place(install_app, new_app, backup_app)?;
     if manage_process {

--- a/crates/codex-mac-engine/src/swap.rs
+++ b/crates/codex-mac-engine/src/swap.rs
@@ -18,15 +18,31 @@ use crate::EngineError;
 
 const OPEN: &str = "/usr/bin/open";
 const OSASCRIPT: &str = "/usr/bin/osascript";
-const PGREP: &str = "/usr/bin/pgrep";
 
-/// Is a process named `Codex` currently running?
+/// Is the Codex lineage app currently running?
+///
+/// Addressed by bundle id, not process name: the ChatGPT-brand merge renamed
+/// the executable (`Codex` → `ChatGPT`), and a name match would both miss the
+/// renamed Codex and hit ChatGPT Classic (whose process is also `ChatGPT`).
+/// AppleScript's `running` property is read without launching the target.
 pub fn codex_running() -> bool {
-    Command::new(PGREP)
-        .args(["-x", "Codex"])
+    let script = format!(
+        r#"application id "{}" is running"#,
+        crate::sys::CODEX_BUNDLE_ID
+    );
+    Command::new(OSASCRIPT)
+        .args(["-e", &script])
         .output()
-        .map(|o| o.status.success())
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
         .unwrap_or(false)
+}
+
+fn tell_codex(verb: &str) -> std::io::Result<std::process::ExitStatus> {
+    let script = format!(
+        r#"tell application id "{}" to {verb}"#,
+        crate::sys::CODEX_BUNDLE_ID
+    );
+    Command::new(OSASCRIPT).args(["-e", &script]).status()
 }
 
 /// Ask Codex to quit gracefully (AppleScript), polling up to `timeout_secs`.
@@ -43,9 +59,7 @@ pub fn quit_codex(timeout_secs: u64) -> Result<(), EngineError> {
         return Ok(());
     }
     log::info!("requesting Codex graceful quit timeout={timeout_secs}");
-    let _ = Command::new(OSASCRIPT)
-        .args(["-e", r#"tell application "Codex" to quit"#])
-        .status();
+    let _ = tell_codex("quit");
 
     // 250ms ticks; if Codex is still running after ~5s it is most likely
     // waiting on its quit-confirmation dialog — surface it.
@@ -55,9 +69,7 @@ pub fn quit_codex(timeout_secs: u64) -> Result<(), EngineError> {
             return Ok(());
         }
         if tick == activate_tick {
-            let _ = Command::new(OSASCRIPT)
-                .args(["-e", r#"tell application "Codex" to activate"#])
-                .status();
+            let _ = tell_codex("activate");
         }
         std::thread::sleep(std::time::Duration::from_millis(250));
     }

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -224,6 +224,38 @@ fn read_bundle_build(app: &str) -> Option<u64> {
     String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
+/// Does the bundle carry macOS's quarantine attribute? A quarantined app is
+/// launched through App Translocation (a randomized `/private/var/folders/…`
+/// mount), so its running process can NOT be located from the bundle's own
+/// path — none of our run/quit protections can safely target it. Such bundles
+/// are rejected at adoption time rather than mismanaged later.
+#[cfg(target_os = "macos")]
+pub fn has_quarantine_attribute(app: &str) -> bool {
+    use std::ffi::CString;
+    let Ok(cpath) = CString::new(app) else {
+        return false;
+    };
+    let Ok(cname) = CString::new("com.apple.quarantine") else {
+        return false;
+    };
+    let size = unsafe {
+        libc::getxattr(
+            cpath.as_ptr(),
+            cname.as_ptr(),
+            std::ptr::null_mut(),
+            0,
+            0,
+            0,
+        )
+    };
+    size >= 0
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn has_quarantine_attribute(_app: &str) -> bool {
+    false
+}
+
 /// Read a bundle's `CFBundleExecutable` — the main binary's name under
 /// `Contents/MacOS/`. Needed to address the RUNNING instance of a specific
 /// install by executable path (the name changed `Codex` → `ChatGPT` in the

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -224,13 +224,17 @@ fn read_bundle_build(app: &str) -> Option<u64> {
     String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
-/// Does the bundle carry macOS's quarantine attribute? A quarantined app is
-/// launched through App Translocation (a randomized `/private/var/folders/…`
-/// mount), so its running process can NOT be located from the bundle's own
-/// path — none of our run/quit protections can safely target it. Such bundles
-/// are rejected at adoption time rather than mismanaged later.
+/// Would this bundle run through App Translocation (a randomized
+/// `/private/var/folders/…` mount, where its running process cannot be
+/// located from the bundle's own path)?
+///
+/// Translocation only applies to quarantined bundles Gatekeeper has NOT yet
+/// user-approved. The quarantine xattr itself routinely SURVIVES on perfectly
+/// normal installs — it stays after the Finder move to /Applications and
+/// after first-launch approval — so its mere presence must not disqualify a
+/// bundle; only the missing approval flag does.
 #[cfg(target_os = "macos")]
-pub fn has_quarantine_attribute(app: &str) -> bool {
+pub fn is_translocation_risk(app: &str) -> bool {
     use std::ffi::CString;
     let Ok(cpath) = CString::new(app) else {
         return false;
@@ -248,12 +252,46 @@ pub fn has_quarantine_attribute(app: &str) -> bool {
             0,
         )
     };
-    size >= 0
+    if size < 0 {
+        // No quarantine attribute at all — no translocation.
+        return false;
+    }
+    let mut buf = vec![0_u8; size as usize];
+    let read = unsafe {
+        libc::getxattr(
+            cpath.as_ptr(),
+            cname.as_ptr(),
+            buf.as_mut_ptr().cast(),
+            buf.len(),
+            0,
+            0,
+        )
+    };
+    if read < 0 {
+        // Attribute exists but is unreadable — treat as risky (the adoption
+        // error explains how to clear it).
+        return true;
+    }
+    buf.truncate(read as usize);
+    quarantine_flags_indicate_translocation(&String::from_utf8_lossy(&buf))
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn has_quarantine_attribute(_app: &str) -> bool {
+pub fn is_translocation_risk(_app: &str) -> bool {
     false
+}
+
+/// The quarantine xattr value is `flags;timestamp;agent;uuid` with hex flags.
+/// `QTN_FLAG_USER_APPROVED` (0x0040, libquarantine qtn.h) is set once the user
+/// approved the app at first launch — approved bundles do not translocate.
+/// Unparseable values are treated as risky (fail closed, with guidance).
+fn quarantine_flags_indicate_translocation(value: &str) -> bool {
+    const QTN_FLAG_USER_APPROVED: u32 = 0x0040;
+    let flags_hex = value.split(';').next().unwrap_or("").trim();
+    match u32::from_str_radix(flags_hex, 16) {
+        Ok(flags) => flags & QTN_FLAG_USER_APPROVED == 0,
+        Err(_) => true,
+    }
 }
 
 /// Read a bundle's `CFBundleExecutable` — the main binary's name under
@@ -323,6 +361,32 @@ pub fn read_bundle_short_version(app: &str) -> Option<String> {
         None
     } else {
         Some(v)
+    }
+}
+
+#[cfg(test)]
+mod quarantine_tests {
+    use super::quarantine_flags_indicate_translocation;
+
+    #[test]
+    fn approved_quarantine_is_not_a_translocation_risk() {
+        // Typical post-approval value: 0x0040 (QTN_FLAG_USER_APPROVED) set.
+        assert!(!quarantine_flags_indicate_translocation(
+            "00c3;68701c2a;Chrome;A1B2C3"
+        ));
+        assert!(!quarantine_flags_indicate_translocation("0041;0;Safari;"));
+    }
+
+    #[test]
+    fn unapproved_or_garbled_quarantine_is_risky() {
+        // Fresh download, never launched: approved bit clear.
+        assert!(quarantine_flags_indicate_translocation(
+            "0083;68701c2a;Chrome;A1B2C3"
+        ));
+        assert!(quarantine_flags_indicate_translocation("0002;0;curl;"));
+        // Unparseable flags fail closed.
+        assert!(quarantine_flags_indicate_translocation("not-hex;x;y;z"));
+        assert!(quarantine_flags_indicate_translocation(""));
     }
 }
 

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -282,14 +282,20 @@ pub fn is_translocation_risk(_app: &str) -> bool {
 }
 
 /// The quarantine xattr value is `flags;timestamp;agent;uuid` with hex flags.
-/// `QTN_FLAG_USER_APPROVED` (0x0040, libquarantine qtn.h) is set once the user
-/// approved the app at first launch — approved bundles do not translocate.
-/// Unparseable values are treated as risky (fail closed, with guidance).
+/// macOS translocates a bundle iff the TRANSLOCATE flag (0x0080) is set AND
+/// the DO_NOT_TRANSLOCATE flag (0x0100) is clear. The user-approved flag
+/// (0x0040) is irrelevant — `00c3` (approved, 0x0080 set) still translocates.
+/// Verified empirically against `SecTranslocateURLShouldRunTranslocated` for
+/// nine flag combinations (0083/00c3/0080 → translocate; 0381/0181/0143/0100/
+/// 0043/0001 → not). Unparseable values fail closed (risky, with guidance).
 fn quarantine_flags_indicate_translocation(value: &str) -> bool {
-    const QTN_FLAG_USER_APPROVED: u32 = 0x0040;
+    const QTN_FLAG_TRANSLOCATE: u32 = 0x0080;
+    const QTN_FLAG_DO_NOT_TRANSLOCATE: u32 = 0x0100;
     let flags_hex = value.split(';').next().unwrap_or("").trim();
     match u32::from_str_radix(flags_hex, 16) {
-        Ok(flags) => flags & QTN_FLAG_USER_APPROVED == 0,
+        Ok(flags) => {
+            flags & QTN_FLAG_TRANSLOCATE != 0 && flags & QTN_FLAG_DO_NOT_TRANSLOCATE == 0
+        }
         Err(_) => true,
     }
 }
@@ -368,23 +374,27 @@ pub fn read_bundle_short_version(app: &str) -> Option<String> {
 mod quarantine_tests {
     use super::quarantine_flags_indicate_translocation;
 
+    // Expected values below match SecTranslocateURLShouldRunTranslocated
+    // observed on a real bundle for each flag combination.
     #[test]
-    fn approved_quarantine_is_not_a_translocation_risk() {
-        // Typical post-approval value: 0x0040 (QTN_FLAG_USER_APPROVED) set.
-        assert!(!quarantine_flags_indicate_translocation(
-            "00c3;68701c2a;Chrome;A1B2C3"
-        ));
-        assert!(!quarantine_flags_indicate_translocation("0041;0;Safari;"));
+    fn translocates_only_with_translocate_set_and_do_not_translocate_clear() {
+        assert!(quarantine_flags_indicate_translocation("0083;t;a;u"));
+        assert!(quarantine_flags_indicate_translocation("00c3;t;a;u")); // approved bit does NOT exempt
+        assert!(quarantine_flags_indicate_translocation("0080;t;a;u"));
     }
 
     #[test]
-    fn unapproved_or_garbled_quarantine_is_risky() {
-        // Fresh download, never launched: approved bit clear.
-        assert!(quarantine_flags_indicate_translocation(
-            "0083;68701c2a;Chrome;A1B2C3"
-        ));
-        assert!(quarantine_flags_indicate_translocation("0002;0;curl;"));
-        // Unparseable flags fail closed.
+    fn does_not_translocate_without_flag_or_with_exemption() {
+        assert!(!quarantine_flags_indicate_translocation("0381;t;a;u")); // Finder-copy shape
+        assert!(!quarantine_flags_indicate_translocation("0181;t;a;u"));
+        assert!(!quarantine_flags_indicate_translocation("0143;t;a;u"));
+        assert!(!quarantine_flags_indicate_translocation("0100;t;a;u"));
+        assert!(!quarantine_flags_indicate_translocation("0043;t;a;u"));
+        assert!(!quarantine_flags_indicate_translocation("0001;t;a;u"));
+    }
+
+    #[test]
+    fn garbled_quarantine_fails_closed() {
         assert!(quarantine_flags_indicate_translocation("not-hex;x;y;z"));
         assert!(quarantine_flags_indicate_translocation(""));
     }

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -104,25 +104,66 @@ pub fn fetch_text_timeout_with_network(
     text_from_curl(url, output)
 }
 
-/// Locate an installed `Codex.app` and read its `CFBundleVersion` (build number).
+/// The Codex product's stable bundle identifier — the trust anchor for "is
+/// this the Codex lineage?". The upstream ChatGPT-brand merge renamed the
+/// bundle (`Codex.app` → `ChatGPT.app`) and its executable while keeping this
+/// ID, so names can no longer identify the product. ChatGPT Classic
+/// (`com.openai.chat`) shares the display name and signing team but is a
+/// different product and must never match.
+pub const CODEX_BUNDLE_ID: &str = "com.openai.codex";
+
+/// Bundle names the Codex lineage ships under (pre/post the ChatGPT rebrand).
+/// The canonical name comes first so, per root, a canonical install wins ties.
+const CANDIDATE_BUNDLE_NAMES: [&str; 2] = ["Codex.app", "ChatGPT.app"];
+
+/// Locate an installed Codex and read its `CFBundleVersion` (build number).
 ///
-/// Returns `(app_path, build)` for the first candidate found, or `None`.
+/// Candidates are identity-gated on `CFBundleIdentifier == com.openai.codex`,
+/// so a ChatGPT Classic at `/Applications/ChatGPT.app` is never picked up.
+/// Returns `(app_path, build)` for the first (canonical-order) match; when
+/// several lineage installs coexist the canonical path wins and the ambiguity
+/// is surfaced via `installed_codex_candidates` + a warning here.
 pub fn installed_codex_build() -> Option<(String, u64)> {
+    let candidates = installed_codex_candidates();
+    if candidates.len() > 1 {
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        log::warn!(
+            "multiple Codex-lineage installs detected, preferring canonical path candidates={paths:?}"
+        );
+    }
+    candidates.into_iter().next()
+}
+
+/// Every Codex-lineage install found at the known roots, canonical order.
+/// More than one entry means the user has ambiguous installs (e.g. an old
+/// `Codex.app` plus a hand-dragged `ChatGPT.app` from the official DMG).
+pub fn installed_codex_candidates() -> Vec<(String, u64)> {
     candidate_app_paths()
         .into_iter()
-        .find_map(|app| installed_codex_build_at_path(&app))
+        .filter_map(|app| installed_codex_build_at_path(&app))
+        .collect()
 }
 
 pub fn installed_codex_build_at_path(app: &str) -> Option<(String, u64)> {
+    if read_bundle_identifier(app).as_deref() != Some(CODEX_BUNDLE_ID) {
+        return None;
+    }
     read_bundle_build(app).map(|build| (app.to_string(), build))
 }
 
 fn candidate_app_paths() -> Vec<String> {
-    let mut paths = vec!["/Applications/Codex.app".to_string()];
+    let mut roots = vec!["/Applications".to_string()];
     if let Ok(home) = std::env::var("HOME") {
-        paths.push(format!("{home}/Applications/Codex.app"));
+        roots.push(format!("{home}/Applications"));
     }
-    paths
+    roots
+        .into_iter()
+        .flat_map(|root| {
+            CANDIDATE_BUNDLE_NAMES
+                .iter()
+                .map(move |name| format!("{root}/{name}"))
+        })
+        .collect()
 }
 
 /// Best-effort architecture of an installed Codex.app, read from its Mach-O
@@ -183,6 +224,28 @@ fn read_bundle_build(app: &str) -> Option<u64> {
     String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
+/// Read a bundle's `CFBundleIdentifier` — the product-identity anchor (see
+/// `CODEX_BUNDLE_ID`). Returns `None` when the bundle or key is missing.
+pub fn read_bundle_identifier(app: &str) -> Option<String> {
+    let plist = format!("{app}/Contents/Info.plist");
+    if !Path::new(&plist).exists() {
+        return None;
+    }
+    let output = Command::new("/usr/libexec/PlistBuddy")
+        .args(["-c", "Print :CFBundleIdentifier", &plist])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if id.is_empty() {
+        None
+    } else {
+        Some(id)
+    }
+}
+
 /// Read the human-facing version string (`CFBundleShortVersionString`, e.g.
 /// `26.602.40724`) of an installed bundle. This is what we show the user; the
 /// build number (`CFBundleVersion`) is what Sparkle compares. Returns `None` if
@@ -204,5 +267,67 @@ pub fn read_bundle_short_version(app: &str) -> Option<String> {
         None
     } else {
         Some(v)
+    }
+}
+
+// PlistBuddy only exists on macOS, so the identity-gate tests are mac-only
+// (the Windows CI job still compiles this module).
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_fake_app(root: &Path, name: &str, bundle_id: &str, build: u64) -> String {
+        let app = root.join(name);
+        fs::create_dir_all(app.join("Contents")).unwrap();
+        let plist = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_id}</string>
+    <key>CFBundleVersion</key>
+    <string>{build}</string>
+</dict>
+</plist>
+"#
+        );
+        fs::write(app.join("Contents/Info.plist"), plist).unwrap();
+        app.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn identity_gate_accepts_codex_lineage_under_any_bundle_name() {
+        let root = std::env::temp_dir().join(format!("codex-sys-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+
+        // Post-rebrand shape: the bundle is named ChatGPT.app but carries the
+        // Codex bundle id — it must be detected.
+        let renamed = write_fake_app(&root, "ChatGPT.app", CODEX_BUNDLE_ID, 5059);
+        assert_eq!(
+            installed_codex_build_at_path(&renamed),
+            Some((renamed.clone(), 5059))
+        );
+        assert_eq!(read_bundle_identifier(&renamed).as_deref(), Some(CODEX_BUNDLE_ID));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn identity_gate_rejects_chatgpt_classic() {
+        let root = std::env::temp_dir().join(format!("codex-sys-classic-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+
+        // ChatGPT Classic: same bundle name the rebranded Codex uses, different
+        // product identity — must never be treated as an install.
+        let classic = write_fake_app(&root, "ChatGPT.app", "com.openai.chat", 42);
+        assert_eq!(installed_codex_build_at_path(&classic), None);
+
+        // A Codex-named impostor with a foreign id is rejected too.
+        let impostor = write_fake_app(&root, "Codex.app", "com.example.fake", 7);
+        assert_eq!(installed_codex_build_at_path(&impostor), None);
+
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -224,6 +224,30 @@ fn read_bundle_build(app: &str) -> Option<u64> {
     String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
+/// Read a bundle's `CFBundleExecutable` — the main binary's name under
+/// `Contents/MacOS/`. Needed to address the RUNNING instance of a specific
+/// install by executable path (the name changed `Codex` → `ChatGPT` in the
+/// brand merge, so it must be read per-bundle, never assumed).
+pub fn read_bundle_executable(app: &str) -> Option<String> {
+    let plist = format!("{app}/Contents/Info.plist");
+    if !Path::new(&plist).exists() {
+        return None;
+    }
+    let output = Command::new("/usr/libexec/PlistBuddy")
+        .args(["-c", "Print :CFBundleExecutable", &plist])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let exe = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if exe.is_empty() {
+        None
+    } else {
+        Some(exe)
+    }
+}
+
 /// Read a bundle's `CFBundleIdentifier` — the product-identity anchor (see
 /// `CODEX_BUNDLE_ID`). Returns `None` when the bundle or key is missing.
 pub fn read_bundle_identifier(app: &str) -> Option<String> {

--- a/crates/codex-mac-engine/src/sys.rs
+++ b/crates/codex-mac-engine/src/sys.rs
@@ -253,8 +253,11 @@ pub fn is_translocation_risk(app: &str) -> bool {
         )
     };
     if size < 0 {
-        // No quarantine attribute at all — no translocation.
-        return false;
+        // Only a definitive "attribute does not exist" is safe. Any other
+        // failure (EACCES via an ACL, EIO, …) leaves the quarantine state
+        // unknown — fail closed rather than let an 0083-quarantined bundle
+        // through on a read error.
+        return std::io::Error::last_os_error().raw_os_error() != Some(libc::ENOATTR);
     }
     let mut buf = vec![0_u8; size as usize];
     let read = unsafe {

--- a/crates/codex-win-engine/src/app_version.rs
+++ b/crates/codex-win-engine/src/app_version.rs
@@ -7,15 +7,44 @@ use serde_json::Value;
 
 const MAX_ASAR_HEADER_BYTES: u32 = 16 * 1024 * 1024;
 
+/// The Codex Electron app's npm package name — a package-level identity marker
+/// that survives inside `resources/app.asar` of any unpacked payload. Verified
+/// on the real 26.707.31428 MSIX and the 26.707.30751 macOS bundle (both
+/// post-rebrand: `name` stayed `openai-codex-electron` while display names
+/// moved to ChatGPT). Used to recognize manifest-less portable roots, where the
+/// MSIX's package-level signature is not available and the inner executables
+/// carry no embedded Authenticode.
+pub const CODEX_ASAR_PACKAGE_NAME: &str = "openai-codex-electron";
+
 #[derive(Debug, Deserialize)]
 struct PackageJson {
     version: String,
+    #[serde(default)]
+    name: Option<String>,
 }
 
 pub fn read_codex_app_version_from_install_root(root: &Path) -> Option<String> {
     for candidate in app_asar_candidates(root) {
-        if let Some(version) = read_codex_app_version_from_asar(&candidate) {
-            return Some(version);
+        if let Some(package) = read_package_json_from_asar(&candidate) {
+            let version = package.version.trim();
+            if !version.is_empty() {
+                return Some(version.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// The `name` field of the app payload's `package.json` (from `app.asar`),
+/// e.g. `openai-codex-electron`. `None` when no asar/package.json is readable.
+pub fn read_asar_package_name_from_install_root(root: &Path) -> Option<String> {
+    for candidate in app_asar_candidates(root) {
+        if let Some(package) = read_package_json_from_asar(&candidate) {
+            if let Some(name) = package.name.as_deref().map(str::trim) {
+                if !name.is_empty() {
+                    return Some(name.to_string());
+                }
+            }
         }
     }
     None
@@ -68,6 +97,12 @@ fn find_app_asar(root: &Path, depth: usize, max_depth: usize) -> Option<PathBuf>
 }
 
 pub fn read_codex_app_version_from_asar(path: &Path) -> Option<String> {
+    let package = read_package_json_from_asar(path)?;
+    let version = package.version.trim();
+    (!version.is_empty()).then(|| version.to_string())
+}
+
+fn read_package_json_from_asar(path: &Path) -> Option<PackageJson> {
     let (mut file, header, data_offset) = read_asar_header(path).ok()?;
     let entry = find_asar_entry(&header, &["package.json"])?;
     let offset = asar_entry_offset(entry)?;
@@ -76,9 +111,7 @@ pub fn read_codex_app_version_from_asar(path: &Path) -> Option<String> {
     file.seek(SeekFrom::Start(absolute_offset)).ok()?;
     let mut bytes = vec![0; size.try_into().ok()?];
     file.read_exact(&mut bytes).ok()?;
-    let package: PackageJson = serde_json::from_slice(&bytes).ok()?;
-    let version = package.version.trim();
-    (!version.is_empty()).then(|| version.to_string())
+    serde_json::from_slice(&bytes).ok()
 }
 
 fn read_asar_header(path: &Path) -> Result<(File, Value, u64), ()> {
@@ -180,23 +213,45 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    fn write_test_asar(path: &Path, package_json: &[u8]) {
-        let header_json = format!(
-            r#"{{"files":{{"package.json":{{"size":{},"offset":"0"}}}}}}"#,
-            package_json.len()
+    #[test]
+    fn reads_asar_package_name_from_install_root() {
+        let dir =
+            std::env::temp_dir().join(format!("codex-asar-name-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let resources = dir.join("resources");
+        std::fs::create_dir_all(&resources).unwrap();
+        write_test_asar(
+            &resources.join("app.asar"),
+            br#"{"version":"26.707.31428","name":"openai-codex-electron"}"#,
         );
-        let mut header = Vec::new();
-        header.extend_from_slice(&0_u32.to_le_bytes());
-        header.extend_from_slice(header_json.as_bytes());
-        while header.len() % 4 != 0 {
-            header.push(0);
-        }
 
-        let mut out = Vec::new();
-        out.extend_from_slice(&4_u32.to_le_bytes());
-        out.extend_from_slice(&(header.len() as u32).to_le_bytes());
-        out.extend_from_slice(&header);
-        out.extend_from_slice(package_json);
-        std::fs::write(path, out).unwrap();
+        assert_eq!(
+            read_asar_package_name_from_install_root(&dir).as_deref(),
+            Some(CODEX_ASAR_PACKAGE_NAME)
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
+}
+
+// Shared with sys.rs's manifest-less portable detection tests.
+#[cfg(test)]
+pub(crate) fn write_test_asar(path: &Path, package_json: &[u8]) {
+    let header_json = format!(
+        r#"{{"files":{{"package.json":{{"size":{},"offset":"0"}}}}}}"#,
+        package_json.len()
+    );
+    let mut header = Vec::new();
+    header.extend_from_slice(&0_u32.to_le_bytes());
+    header.extend_from_slice(header_json.as_bytes());
+    while header.len() % 4 != 0 {
+        header.push(0);
+    }
+
+    let mut out = Vec::new();
+    out.extend_from_slice(&4_u32.to_le_bytes());
+    out.extend_from_slice(&(header.len() as u32).to_le_bytes());
+    out.extend_from_slice(&header);
+    out.extend_from_slice(package_json);
+    std::fs::write(path, out).unwrap();
 }

--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -50,7 +50,7 @@ pub use msix::{
 pub use network::NetworkConfig;
 pub use plan::{plan_update, WinInstallRoute, WindowsUpdatePlan};
 pub use portable::{
-    close_codex_gracefully, close_codex_gracefully_for_root, install_portable_from_msix,
+    close_codex_gracefully_for_root, install_portable_from_msix, installed_app_exe,
     purge_codex_user_data, uninstall_portable, PortableInstallReport, PortableUninstallReport,
 };
 pub use sys::{

--- a/crates/codex-win-engine/src/msix.rs
+++ b/crates/codex-win-engine/src/msix.rs
@@ -53,6 +53,21 @@ pub fn is_framework_dependency(name: &str) -> bool {
         .any(|prefix| name.len() >= prefix.len() && name[..prefix.len()].eq_ignore_ascii_case(prefix))
 }
 
+/// The package-root-relative path of the app's entry executable, from the
+/// manifest's `<Application Executable="…">` (e.g. `app\ChatGPT.exe`). This is
+/// the authoritative entrypoint: the ChatGPT-brand merge switched it from
+/// `app\Codex.exe` to `app\ChatGPT.exe` while leaving a legacy `Codex.exe` in
+/// the payload, so guessing by file name would pick a non-entry binary.
+/// Returns `None` when the manifest declares no `<Application>` (never the
+/// case for real Codex packages, but tolerated for robustness).
+pub fn parse_appx_application_executable(xml: &str) -> Option<String> {
+    let doc = roxmltree::Document::parse(xml).ok()?;
+    doc.descendants()
+        .find(|node| node.has_tag_name("Application"))
+        .and_then(|node| node.attribute("Executable"))
+        .map(str::to_string)
+}
+
 pub fn parse_appx_manifest_xml(xml: &str) -> Result<MsixIdentity, EngineError> {
     let doc = roxmltree::Document::parse(xml)
         .map_err(|e| EngineError::Msix(format!("AppxManifest.xml: {e}")))?;
@@ -235,6 +250,29 @@ mod tests {
         assert_eq!(identity.name, "OpenAI.Codex");
         assert_eq!(identity.version, "26.602.3474.0");
         validate_codex_identity(&identity, "26.602.3474.0", Some("x64")).unwrap();
+    }
+
+    #[test]
+    fn parses_application_executable() {
+        // Post-rebrand shape observed on the real 26.707.3748.0 package: the
+        // entry is ChatGPT.exe even though a legacy Codex.exe ships alongside.
+        let xml = r#"
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=X" Version="26.707.3748.0" ProcessorArchitecture="x64" />
+  <Applications>
+    <Application Id="App" Executable="app/ChatGPT.exe" EntryPoint="Windows.FullTrustApplication" />
+  </Applications>
+</Package>"#;
+        assert_eq!(
+            parse_appx_application_executable(xml).as_deref(),
+            Some("app/ChatGPT.exe")
+        );
+
+        let no_application = r#"
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=X" Version="1.0.0.0" ProcessorArchitecture="x64" />
+</Package>"#;
+        assert_eq!(parse_appx_application_executable(no_application), None);
     }
 
     #[test]

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -131,10 +131,16 @@ fn find_exe_named(root: &Path, name: &str) -> Result<Option<PathBuf>, EngineErro
     Ok(None)
 }
 
-/// Locate the app's entry executable in an extracted MSIX. The manifest's
-/// `Application@Executable` is authoritative (resolved as a package-root
-/// relative path, then by basename); known entry names are the fallback for
-/// odd payload layouts or a manifest without an `<Application>`.
+/// Locate the app's entry executable in an extracted MSIX.
+///
+/// The manifest's `Application@Executable` is authoritative: when declared it
+/// is resolved as a package-root relative path, then by basename — and a
+/// declared entry that cannot be found is a hard error, NOT a fallback case.
+/// Falling back would silently select a non-entry binary (e.g. the legacy
+/// `Codex.exe` shipped next to the real `ChatGPT.exe`) when the true entry is
+/// missing or quarantined, and the install would then health-check the wrong
+/// binary. The known-name candidates only serve manifests with no
+/// `<Application>` declaration at all.
 fn find_app_exe(root: &Path, manifest_xml: &str) -> Result<PathBuf, EngineError> {
     if let Some(declared) = crate::msix::parse_appx_application_executable(manifest_xml) {
         // Manifest paths use either separator; resolve component-wise.
@@ -148,6 +154,9 @@ fn find_app_exe(root: &Path, manifest_xml: &str) -> Result<PathBuf, EngineError>
                 return Ok(found);
             }
         }
+        return Err(EngineError::Msix(format!(
+            "MSIX manifest declares entry executable '{declared}' but it is missing from the payload"
+        )));
     }
     for name in APP_EXE_CANDIDATES {
         if let Some(found) = find_exe_named(root, name)? {
@@ -162,18 +171,17 @@ fn find_app_exe(root: &Path, manifest_xml: &str) -> Result<PathBuf, EngineError>
 /// The entry executable of an installed portable root. Reads the payload's
 /// `AppxManifest.xml` (written at install time) for the declared executable's
 /// basename — the payload root is the exe's directory, so only the basename
-/// applies — and falls back to probing known entry names for older installs.
+/// applies. A declared-but-missing entry returns `None` (the install is
+/// broken; picking a leftover non-entry binary would mask that). The known
+/// entry names are probed only for roots without a declaring manifest.
 pub fn installed_app_exe(install_root: &Path) -> Option<PathBuf> {
     let manifest = install_root.join("AppxManifest.xml");
     if let Ok(xml) = fs::read_to_string(&manifest) {
         if let Some(declared) = crate::msix::parse_appx_application_executable(&xml) {
             let basename = declared.replace('\\', "/");
-            if let Some(name) = basename.rsplit('/').next() {
-                let exe = install_root.join(name);
-                if exe.is_file() {
-                    return Some(exe);
-                }
-            }
+            let name = basename.rsplit('/').next()?;
+            let exe = install_root.join(name);
+            return exe.is_file().then_some(exe);
         }
     }
     APP_EXE_CANDIDATES
@@ -889,6 +897,59 @@ mod tests {
         )
         .unwrap();
         assert_eq!(installed_app_exe(&root), Some(root.join("Codex.exe")));
+
+        // A declared-but-missing entry means the install is broken: never
+        // silently fall back to a leftover binary that happens to exist.
+        fs::write(
+            root.join("AppxManifest.xml"),
+            br#"<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=X" Version="1.0.0.0" ProcessorArchitecture="x64" />
+  <Applications><Application Id="App" Executable="app\Gone.exe" /></Applications>
+</Package>"#,
+        )
+        .unwrap();
+        assert_eq!(installed_app_exe(&root), None);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn install_fails_when_declared_entry_is_missing_from_payload() {
+        // Manifest declares app/ChatGPT.exe but the payload only carries the
+        // legacy app/Codex.exe (e.g. the entry was quarantined). Selecting the
+        // leftover binary would health-check the wrong thing — must error out.
+        let root = std::env::temp_dir().join(format!(
+            "codex-portable-missing-entry-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let msix = root.join("codex.msix");
+        {
+            let file = fs::File::create(&msix).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let opts = SimpleFileOptions::default();
+            zip.start_file("AppxManifest.xml", opts).unwrap();
+            zip.write_all(
+                br#"<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=OpenAI OpCo, LLC" Version="26.707.3748.0" ProcessorArchitecture="x64" />
+  <Applications>
+    <Application Id="App" Executable="app/ChatGPT.exe" EntryPoint="Windows.FullTrustApplication" />
+  </Applications>
+</Package>"#,
+            )
+            .unwrap();
+            zip.start_file("app/Codex.exe", opts).unwrap();
+            zip.write_all(b"legacy only").unwrap();
+            zip.finish().unwrap();
+        }
+
+        let install_root = root.join("Codex");
+        let err = install_portable_from_msix_inner(&msix, &install_root, false, false).unwrap_err();
+        assert!(
+            err.to_string().contains("missing from the payload"),
+            "unexpected error: {err}"
+        );
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -143,16 +143,14 @@ fn find_exe_named(root: &Path, name: &str) -> Result<Option<PathBuf>, EngineErro
 /// `<Application>` declaration at all.
 fn find_app_exe(root: &Path, manifest_xml: &str) -> Result<PathBuf, EngineError> {
     if let Some(declared) = crate::msix::parse_appx_application_executable(manifest_xml) {
-        // Manifest paths use either separator; resolve component-wise.
+        // Manifest paths use either separator; resolve component-wise. Only the
+        // exact declared path counts — matching a same-named file elsewhere in
+        // the package would select (and copy the parent directory of) a binary
+        // that is not the entry.
         let relative: PathBuf = declared.replace('\\', "/").split('/').collect();
         let direct = root.join(&relative);
         if direct.is_file() {
             return Ok(direct);
-        }
-        if let Some(name) = relative.file_name().and_then(|s| s.to_str()) {
-            if let Some(found) = find_exe_named(root, name)? {
-                return Ok(found);
-            }
         }
         return Err(EngineError::Msix(format!(
             "MSIX manifest declares entry executable '{declared}' but it is missing from the payload"

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -105,7 +105,12 @@ fn extract_msix(msix_path: &Path, dest: &Path) -> Result<String, EngineError> {
     manifest_xml.ok_or_else(|| EngineError::Msix("MSIX missing AppxManifest.xml".to_string()))
 }
 
-fn find_codex_exe(root: &Path) -> Result<PathBuf, EngineError> {
+/// Entry-executable basenames the Codex lineage has shipped, newest first.
+/// Post-merge packages keep a legacy `Codex.exe` next to the real entrypoint,
+/// so `ChatGPT.exe` must win when the manifest can't tell us (it normally can).
+const APP_EXE_CANDIDATES: [&str; 2] = ["ChatGPT.exe", "Codex.exe"];
+
+fn find_exe_named(root: &Path, name: &str) -> Result<Option<PathBuf>, EngineError> {
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
         for entry in fs::read_dir(&dir).map_err(|e| io_err("walk extracted MSIX", e))? {
@@ -117,15 +122,64 @@ fn find_codex_exe(root: &Path) -> Result<PathBuf, EngineError> {
             } else if path
                 .file_name()
                 .and_then(|s| s.to_str())
-                .is_some_and(|name| name.eq_ignore_ascii_case("Codex.exe"))
+                .is_some_and(|n| n.eq_ignore_ascii_case(name))
             {
-                return Ok(path);
+                return Ok(Some(path));
             }
         }
     }
+    Ok(None)
+}
+
+/// Locate the app's entry executable in an extracted MSIX. The manifest's
+/// `Application@Executable` is authoritative (resolved as a package-root
+/// relative path, then by basename); known entry names are the fallback for
+/// odd payload layouts or a manifest without an `<Application>`.
+fn find_app_exe(root: &Path, manifest_xml: &str) -> Result<PathBuf, EngineError> {
+    if let Some(declared) = crate::msix::parse_appx_application_executable(manifest_xml) {
+        // Manifest paths use either separator; resolve component-wise.
+        let relative: PathBuf = declared.replace('\\', "/").split('/').collect();
+        let direct = root.join(&relative);
+        if direct.is_file() {
+            return Ok(direct);
+        }
+        if let Some(name) = relative.file_name().and_then(|s| s.to_str()) {
+            if let Some(found) = find_exe_named(root, name)? {
+                return Ok(found);
+            }
+        }
+    }
+    for name in APP_EXE_CANDIDATES {
+        if let Some(found) = find_exe_named(root, name)? {
+            return Ok(found);
+        }
+    }
     Err(EngineError::Msix(
-        "MSIX did not contain Codex.exe".to_string(),
+        "MSIX did not contain an app entry executable (ChatGPT.exe / Codex.exe)".to_string(),
     ))
+}
+
+/// The entry executable of an installed portable root. Reads the payload's
+/// `AppxManifest.xml` (written at install time) for the declared executable's
+/// basename — the payload root is the exe's directory, so only the basename
+/// applies — and falls back to probing known entry names for older installs.
+pub fn installed_app_exe(install_root: &Path) -> Option<PathBuf> {
+    let manifest = install_root.join("AppxManifest.xml");
+    if let Ok(xml) = fs::read_to_string(&manifest) {
+        if let Some(declared) = crate::msix::parse_appx_application_executable(&xml) {
+            let basename = declared.replace('\\', "/");
+            if let Some(name) = basename.rsplit('/').next() {
+                let exe = install_root.join(name);
+                if exe.is_file() {
+                    return Some(exe);
+                }
+            }
+        }
+    }
+    APP_EXE_CANDIDATES
+        .into_iter()
+        .map(|name| install_root.join(name))
+        .find(|exe| exe.is_file())
 }
 
 fn prepare_portable_payload(
@@ -144,10 +198,10 @@ fn prepare_portable_payload(
 
     let manifest_xml = extract_msix(msix_path, &extracted)?;
     let identity = parse_appx_manifest_xml(&manifest_xml)?;
-    let exe = find_codex_exe(&extracted)?;
+    let exe = find_app_exe(&extracted, &manifest_xml)?;
     let exe_dir = exe
         .parent()
-        .ok_or_else(|| EngineError::Msix("Codex.exe had no parent directory".to_string()))?;
+        .ok_or_else(|| EngineError::Msix("app entry executable had no parent directory".to_string()))?;
 
     copy_dir_all(exe_dir, &payload)?;
     fs::write(payload.join("AppxManifest.xml"), manifest_xml)
@@ -194,25 +248,21 @@ fn run_powershell(script: &str) -> Result<String, EngineError> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+// The process filter matches by executable path under `root`, never by name
+// alone: post-merge the Codex entry process is `ChatGPT`, which is also the
+// process name of ChatGPT Classic — an unrooted name match would close the
+// wrong product. That is why there is no unfiltered close variant.
 #[cfg(windows)]
-fn request_codex_close_filtered(timeout_secs: u64, root: Option<&Path>) -> Result<(), EngineError> {
-    let root_filter = root
-        .map(|path| ps_quote(&path.to_string_lossy()))
-        .unwrap_or_else(|| "$null".to_string());
+fn request_codex_close_filtered(timeout_secs: u64, root: &Path) -> Result<(), EngineError> {
+    let root_filter = ps_quote(&root.to_string_lossy());
     let timeout = timeout_secs;
     let script = format!(
         r#"
 $RootFilter = {root_filter}
-if ($null -ne $RootFilter) {{
-  try {{ $RootFilter = [System.IO.Path]::GetFullPath($RootFilter).TrimEnd('\') }} catch {{}}
-}}
+try {{ $RootFilter = [System.IO.Path]::GetFullPath($RootFilter).TrimEnd('\') }} catch {{}}
 function Get-TargetCodexProcess {{
-  $all = Get-Process -Name Codex -ErrorAction SilentlyContinue
+  $all = Get-Process -Name Codex, ChatGPT -ErrorAction SilentlyContinue
   foreach ($p in $all) {{
-    if ($null -eq $RootFilter) {{
-      $p
-      continue
-    }}
     try {{
       $path = [string]$p.Path
       if (-not $path) {{ continue }}
@@ -285,27 +335,13 @@ while ((Get-Date) -lt $forceDeadline) {{
 }
 
 #[cfg(windows)]
-fn request_codex_close(timeout_secs: u64) -> Result<(), EngineError> {
-    request_codex_close_filtered(timeout_secs, None)
-}
-
-#[cfg(windows)]
 fn request_codex_close_for_root(timeout_secs: u64, root: &Path) -> Result<(), EngineError> {
-    request_codex_close_filtered(timeout_secs, Some(root))
-}
-
-#[cfg(not(windows))]
-fn request_codex_close(_timeout_secs: u64) -> Result<(), EngineError> {
-    Ok(())
+    request_codex_close_filtered(timeout_secs, root)
 }
 
 #[cfg(not(windows))]
 fn request_codex_close_for_root(_timeout_secs: u64, _root: &Path) -> Result<(), EngineError> {
     Ok(())
-}
-
-pub fn close_codex_gracefully(timeout_secs: u64) -> Result<(), EngineError> {
-    request_codex_close(timeout_secs)
 }
 
 pub fn close_codex_gracefully_for_root(timeout_secs: u64, root: &Path) -> Result<(), EngineError> {
@@ -314,7 +350,9 @@ pub fn close_codex_gracefully_for_root(timeout_secs: u64, root: &Path) -> Result
 
 #[cfg(windows)]
 fn create_start_menu_shortcut(install_root: &Path) -> Result<bool, EngineError> {
-    let exe = install_root.join("Codex.exe");
+    let Some(exe) = installed_app_exe(install_root) else {
+        return Ok(false);
+    };
     let Some(appdata) = std::env::var_os("APPDATA") else {
         return Ok(false);
     };
@@ -353,7 +391,8 @@ fn register_uninstall_entry(
     version: &str,
     estimated_size_kb: u64,
 ) -> Result<bool, EngineError> {
-    let exe = install_root.join("Codex.exe");
+    // Icon only — the entry works without one, so fall back to the legacy name.
+    let exe = installed_app_exe(install_root).unwrap_or_else(|| install_root.join("Codex.exe"));
     let uninstall_script = format!(
         "if ($env:APPDATA) {{ $Shortcut = Join-Path $env:APPDATA 'Microsoft\\Windows\\Start Menu\\Programs\\Codex.lnk'; Remove-Item -LiteralPath $Shortcut -Force -ErrorAction SilentlyContinue }}; Remove-Item -LiteralPath '{}' -Recurse -Force -ErrorAction SilentlyContinue; Remove-Item -LiteralPath 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Codex' -Recurse -Force -ErrorAction SilentlyContinue",
         install_root.to_string_lossy().replace('\'', "''")
@@ -496,13 +535,12 @@ fn rollback_install_error(
 }
 
 fn health_check_portable_install(install_root: &Path, launch: bool) -> Result<bool, EngineError> {
-    let exe = install_root.join("Codex.exe");
-    if !exe.is_file() {
-        return Err(EngineError::Install(format!(
-            "portable health check failed: {} is missing",
-            exe.display()
-        )));
-    }
+    let exe = installed_app_exe(install_root).ok_or_else(|| {
+        EngineError::Install(format!(
+            "portable health check failed: no app entry executable (ChatGPT.exe / Codex.exe) in {}",
+            install_root.display()
+        ))
+    })?;
     if !launch {
         return Ok(false);
     }
@@ -609,7 +647,7 @@ fn install_portable_from_msix_inner(
         }
     };
 
-    let exe = install_root.join("Codex.exe");
+    let installed_exe = installed_app_exe(install_root);
     let mut backup_path = None;
     if had_previous && backup.exists() {
         match fs::remove_dir_all(&backup) {
@@ -631,7 +669,7 @@ fn install_portable_from_msix_inner(
     Ok(PortableInstallReport {
         success: true,
         install_root: install_root.to_string_lossy().into_owned(),
-        executable_path: exe.exists().then(|| exe.to_string_lossy().into_owned()),
+        executable_path: installed_exe.map(|exe| exe.to_string_lossy().into_owned()),
         version,
         backup_path,
         shortcut_created,
@@ -748,6 +786,31 @@ mod tests {
         zip.finish().unwrap();
     }
 
+    fn write_fake_rebranded_msix(path: &Path) {
+        // Post-rebrand layout: manifest entry is app/ChatGPT.exe while a legacy
+        // Codex.exe still ships next to it (as on the real 26.707.x package).
+        let file = fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let opts = SimpleFileOptions::default();
+        zip.start_file("AppxManifest.xml", opts).unwrap();
+        zip.write_all(
+            br#"<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=OpenAI OpCo, LLC" Version="26.707.3748.0" ProcessorArchitecture="x64" />
+  <Applications>
+    <Application Id="App" Executable="app/ChatGPT.exe" EntryPoint="Windows.FullTrustApplication" />
+  </Applications>
+</Package>"#,
+        )
+        .unwrap();
+        zip.start_file("app/ChatGPT.exe", opts).unwrap();
+        zip.write_all(b"fake entry exe").unwrap();
+        zip.start_file("app/Codex.exe", opts).unwrap();
+        zip.write_all(b"legacy compat exe").unwrap();
+        zip.start_file("app/resources/app.asar", opts).unwrap();
+        zip.write_all(b"fake asar").unwrap();
+        zip.finish().unwrap();
+    }
+
     #[test]
     fn installs_portable_payload_from_msix_layout() {
         let root = std::env::temp_dir().join(format!("codex-portable-test-{}", std::process::id()));
@@ -763,6 +826,69 @@ mod tests {
         assert!(install_root.join("resources/app.asar").exists());
         assert!(install_root.join("AppxManifest.xml").exists());
         assert_eq!(report.version, "26.602.3474.0");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn installs_rebranded_portable_payload_by_manifest_entry() {
+        let root = std::env::temp_dir().join(format!(
+            "codex-portable-rebrand-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let msix = root.join("codex.msix");
+        let install_root = root.join("Codex");
+        write_fake_rebranded_msix(&msix);
+
+        let report = install_portable_from_msix_inner(&msix, &install_root, false, false).unwrap();
+        assert!(report.success);
+        // Payload root is the manifest entry's directory; both exes ride along.
+        assert!(install_root.join("ChatGPT.exe").exists());
+        assert!(install_root.join("Codex.exe").exists());
+        assert!(install_root.join("resources/app.asar").exists());
+        assert_eq!(report.version, "26.707.3748.0");
+        // The entry executable resolves to ChatGPT.exe, not the legacy binary.
+        assert_eq!(
+            installed_app_exe(&install_root),
+            Some(install_root.join("ChatGPT.exe"))
+        );
+        assert_eq!(
+            report.executable_path.as_deref(),
+            Some(install_root.join("ChatGPT.exe").to_string_lossy().as_ref())
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn installed_app_exe_prefers_manifest_then_known_names() {
+        let root = std::env::temp_dir().join(format!(
+            "codex-portable-exe-probe-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        // No manifest, legacy layout → Codex.exe via known-name probe.
+        fs::write(root.join("Codex.exe"), b"legacy").unwrap();
+        assert_eq!(installed_app_exe(&root), Some(root.join("Codex.exe")));
+
+        // Both names present without a manifest → the newer entry name wins.
+        fs::write(root.join("ChatGPT.exe"), b"entry").unwrap();
+        assert_eq!(installed_app_exe(&root), Some(root.join("ChatGPT.exe")));
+
+        // A manifest declaring the legacy entry overrides the probe order.
+        fs::write(
+            root.join("AppxManifest.xml"),
+            br#"<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=X" Version="1.0.0.0" ProcessorArchitecture="x64" />
+  <Applications><Application Id="App" Executable="app\Codex.exe" /></Applications>
+</Package>"#,
+        )
+        .unwrap();
+        assert_eq!(installed_app_exe(&root), Some(root.join("Codex.exe")));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -893,27 +893,58 @@ pub fn detect_portable_install(portable_root: &Path) -> Option<InstalledWindowsC
     // both pre- and post-rebrand portable payloads are recognized.
     let exe = crate::portable::installed_app_exe(portable_root)?;
     // Identity gate: an entry executable alone is not product identity — a
-    // ChatGPT Classic payload also ships a root-level ChatGPT.exe. Require the
-    // payload manifest (written by our installer) to declare exactly the Codex
-    // package identity; anything else is not a Codex install and must never be
-    // adopted, updated over, or replaced.
-    let identity = std::fs::read_to_string(portable_root.join("AppxManifest.xml"))
-        .ok()
-        .and_then(|xml| parse_appx_manifest_xml(&xml).ok())?;
-    if identity.name != crate::OPENAI_PACKAGE_IDENTITY {
-        log::debug!(
-            "portable root at {} declares identity {} (expected {}); not a Codex install",
-            portable_root.display(),
-            identity.name,
-            crate::OPENAI_PACKAGE_IDENTITY
-        );
-        return None;
-    }
+    // ChatGPT Classic payload also ships a root-level ChatGPT.exe.
+    //   - With a manifest present (our installer always writes one), it must
+    //     declare exactly the Codex package identity; a foreign or unparseable
+    //     manifest is never a Codex install.
+    //   - Without a manifest (a user-unpacked `app/` dir or a legacy adopted
+    //     root), fall back to Authenticode: the entry exe must carry a trusted
+    //     OpenAI signature. Weaker than the manifest gate but keeps the
+    //     long-supported self-extracted layout adoptable.
+    let identity = match std::fs::read_to_string(portable_root.join("AppxManifest.xml")) {
+        Ok(xml) => match parse_appx_manifest_xml(&xml) {
+            Ok(identity) if identity.name == crate::OPENAI_PACKAGE_IDENTITY => Some(identity),
+            Ok(identity) => {
+                log::debug!(
+                    "portable root at {} declares identity {} (expected {}); not a Codex install",
+                    portable_root.display(),
+                    identity.name,
+                    crate::OPENAI_PACKAGE_IDENTITY
+                );
+                return None;
+            }
+            Err(err) => {
+                log::debug!(
+                    "portable root at {} has an unparseable AppxManifest.xml ({err}); not a Codex install",
+                    portable_root.display()
+                );
+                return None;
+            }
+        },
+        Err(_) => {
+            let signed_by_openai = crate::authenticode::verify_openai_authenticode(&exe)
+                .map(|report| report.is_valid_openai())
+                .unwrap_or(false);
+            if !signed_by_openai {
+                log::debug!(
+                    "portable root at {} has no manifest and its entry exe lacks a trusted OpenAI signature; not a Codex install",
+                    portable_root.display()
+                );
+                return None;
+            }
+            None
+        }
+    };
 
     let installed = InstalledWindowsCodex {
         path: portable_root.to_string_lossy().into_owned(),
-        version: identity.version.clone(),
-        arch: Some(identity.processor_architecture.clone()),
+        version: identity
+            .as_ref()
+            .map(|identity| identity.version.clone())
+            .unwrap_or_else(|| "0.0.0.0".to_string()),
+        arch: identity
+            .as_ref()
+            .map(|identity| identity.processor_architecture.clone()),
         source: "portable".to_string(),
         package_family_name: None,
         installed_at: path_mtime_secs(&exe.to_string_lossy()),
@@ -1370,8 +1401,10 @@ mod portable_identity_tests {
 
     #[test]
     fn rejects_portable_without_manifest_identity() {
-        // An entry executable alone is not identity; without a parseable
-        // manifest the directory is not recognized as a Codex install.
+        // Without a manifest the gate falls back to Authenticode on the entry
+        // exe; this fake exe carries no trusted OpenAI signature, so the
+        // directory is not recognized as a Codex install. (A real user-unpacked
+        // official payload passes via its genuine signature on Windows.)
         let root = write_root("no-manifest", "Codex.exe", None);
         assert!(detect_portable_install(&root).is_none());
         cleanup(&root);

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -889,10 +889,9 @@ fn detect_msix_install() -> Option<InstalledWindowsCodex> {
 }
 
 pub fn detect_portable_install(portable_root: &Path) -> Option<InstalledWindowsCodex> {
-    let exe = portable_root.join("Codex.exe");
-    if !exe.exists() {
-        return None;
-    }
+    // Entry-exe aware (manifest-declared, ChatGPT.exe/Codex.exe fallback) so
+    // both pre- and post-rebrand portable payloads are recognized.
+    let exe = crate::portable::installed_app_exe(portable_root)?;
     let identity = std::fs::read_to_string(portable_root.join("AppxManifest.xml"))
         .ok()
         .and_then(|xml| parse_appx_manifest_xml(&xml).ok());
@@ -925,7 +924,14 @@ pub fn launch_codex_with_options(
     options: LaunchOptions,
 ) -> Result<(), EngineError> {
     if installed.source == "portable" {
-        let exe = Path::new(&installed.path).join("Codex.exe");
+        let root = Path::new(&installed.path);
+        let exe = crate::portable::installed_app_exe(root)
+            .ok_or_else(|| {
+                EngineError::Io(format!(
+                    "no app entry executable (ChatGPT.exe / Codex.exe) in {}",
+                    root.display()
+                ))
+            })?;
         // CREATE_NO_WINDOW only suppresses a console flash; the GUI still shows.
         let mut command = hidden_command(exe);
         if options.disable_codex_self_updates {

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -898,9 +898,11 @@ pub fn detect_portable_install(portable_root: &Path) -> Option<InstalledWindowsC
     //     declare exactly the Codex package identity; a foreign or unparseable
     //     manifest is never a Codex install.
     //   - Without a manifest (a user-unpacked `app/` dir or a legacy adopted
-    //     root), fall back to Authenticode: the entry exe must carry a trusted
-    //     OpenAI signature. Weaker than the manifest gate but keeps the
-    //     long-supported self-extracted layout adoptable.
+    //     root), fall back to the payload's package-level identity: the
+    //     `name` in app.asar's package.json. MSIX-internal executables carry
+    //     no embedded Authenticode (integrity lives in the package-level
+    //     AppxSignature.p7x, which does not survive unpacking), so signature
+    //     checks cannot recognize these roots — the asar marker can.
     let identity = match std::fs::read_to_string(portable_root.join("AppxManifest.xml")) {
         Ok(xml) => match parse_appx_manifest_xml(&xml) {
             Ok(identity) if identity.name == crate::OPENAI_PACKAGE_IDENTITY => Some(identity),
@@ -922,13 +924,13 @@ pub fn detect_portable_install(portable_root: &Path) -> Option<InstalledWindowsC
             }
         },
         Err(_) => {
-            let signed_by_openai = crate::authenticode::verify_openai_authenticode(&exe)
-                .map(|report| report.is_valid_openai())
-                .unwrap_or(false);
-            if !signed_by_openai {
+            let asar_name = crate::app_version::read_asar_package_name_from_install_root(portable_root);
+            if asar_name.as_deref() != Some(crate::app_version::CODEX_ASAR_PACKAGE_NAME) {
                 log::debug!(
-                    "portable root at {} has no manifest and its entry exe lacks a trusted OpenAI signature; not a Codex install",
-                    portable_root.display()
+                    "portable root at {} has no manifest and its app payload name is {:?} (expected {}); not a Codex install",
+                    portable_root.display(),
+                    asar_name,
+                    crate::app_version::CODEX_ASAR_PACKAGE_NAME
                 );
                 return None;
             }
@@ -1401,11 +1403,41 @@ mod portable_identity_tests {
 
     #[test]
     fn rejects_portable_without_manifest_identity() {
-        // Without a manifest the gate falls back to Authenticode on the entry
-        // exe; this fake exe carries no trusted OpenAI signature, so the
-        // directory is not recognized as a Codex install. (A real user-unpacked
-        // official payload passes via its genuine signature on Windows.)
+        // Without a manifest the gate falls back to the app.asar package-name
+        // marker; this root has no asar at all, so it is not recognized.
         let root = write_root("no-manifest", "Codex.exe", None);
+        assert!(detect_portable_install(&root).is_none());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn accepts_manifestless_portable_with_codex_asar_marker() {
+        // A user-unpacked official `app/` dir: no package-root manifest, but
+        // the payload's asar carries the Codex package name — the supported
+        // self-extracted layout must stay detectable/adoptable.
+        let root = write_root("selfextracted", "ChatGPT.exe", None);
+        let resources = root.join("resources");
+        std::fs::create_dir_all(&resources).unwrap();
+        crate::app_version::write_test_asar(
+            &resources.join("app.asar"),
+            br#"{"version":"26.707.31428","name":"openai-codex-electron"}"#,
+        );
+        let installed = detect_portable_install(&root).expect("asar marker accepted");
+        assert_eq!(installed.version, "26.707.31428");
+        cleanup(&root);
+    }
+
+    #[test]
+    fn rejects_manifestless_portable_with_foreign_asar_name() {
+        // Same shape but a non-Codex Electron payload (e.g. an unpacked
+        // Classic): the asar package name differs, so it is never adopted.
+        let root = write_root("foreign-asar", "ChatGPT.exe", None);
+        let resources = root.join("resources");
+        std::fs::create_dir_all(&resources).unwrap();
+        crate::app_version::write_test_asar(
+            &resources.join("app.asar"),
+            br#"{"version":"1.2026.160","name":"chatgpt-desktop"}"#,
+        );
         assert!(detect_portable_install(&root).is_none());
         cleanup(&root);
     }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -892,17 +892,28 @@ pub fn detect_portable_install(portable_root: &Path) -> Option<InstalledWindowsC
     // Entry-exe aware (manifest-declared, ChatGPT.exe/Codex.exe fallback) so
     // both pre- and post-rebrand portable payloads are recognized.
     let exe = crate::portable::installed_app_exe(portable_root)?;
+    // Identity gate: an entry executable alone is not product identity — a
+    // ChatGPT Classic payload also ships a root-level ChatGPT.exe. Require the
+    // payload manifest (written by our installer) to declare exactly the Codex
+    // package identity; anything else is not a Codex install and must never be
+    // adopted, updated over, or replaced.
     let identity = std::fs::read_to_string(portable_root.join("AppxManifest.xml"))
         .ok()
-        .and_then(|xml| parse_appx_manifest_xml(&xml).ok());
+        .and_then(|xml| parse_appx_manifest_xml(&xml).ok())?;
+    if identity.name != crate::OPENAI_PACKAGE_IDENTITY {
+        log::debug!(
+            "portable root at {} declares identity {} (expected {}); not a Codex install",
+            portable_root.display(),
+            identity.name,
+            crate::OPENAI_PACKAGE_IDENTITY
+        );
+        return None;
+    }
 
     let installed = InstalledWindowsCodex {
         path: portable_root.to_string_lossy().into_owned(),
-        version: identity
-            .as_ref()
-            .map(|i| i.version.clone())
-            .unwrap_or_else(|| "0.0.0.0".to_string()),
-        arch: identity.as_ref().map(|i| i.processor_architecture.clone()),
+        version: identity.version.clone(),
+        arch: Some(identity.processor_architecture.clone()),
         source: "portable".to_string(),
         package_family_name: None,
         installed_at: path_mtime_secs(&exe.to_string_lossy()),
@@ -1307,5 +1318,62 @@ mod tests {
             reason: String::new(),
         };
         assert!(!inconsistent.should_route_portable());
+    }
+}
+
+#[cfg(test)]
+mod portable_identity_tests {
+    use super::detect_portable_install;
+    use std::path::Path;
+
+    fn write_root(name: &str, exe: &str, manifest: Option<&str>) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!("codex-sys-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join(exe), b"fake exe").unwrap();
+        if let Some(identity_name) = manifest {
+            std::fs::write(
+                root.join("AppxManifest.xml"),
+                format!(
+                    r#"<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="{identity_name}" Publisher="CN=OpenAI OpCo, LLC" Version="26.707.3748.0" ProcessorArchitecture="x64" />
+  <Applications><Application Id="App" Executable="app/{exe}" /></Applications>
+</Package>"#
+                ),
+            )
+            .unwrap();
+        }
+        root
+    }
+
+    fn cleanup(root: &Path) {
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn accepts_rebranded_portable_with_codex_identity() {
+        let root = write_root("rebrand", "ChatGPT.exe", Some("OpenAI.Codex"));
+        let installed = detect_portable_install(&root).expect("codex identity accepted");
+        assert_eq!(installed.version, "26.707.3748.0");
+        assert_eq!(installed.source, "portable");
+        cleanup(&root);
+    }
+
+    #[test]
+    fn rejects_portable_with_foreign_identity() {
+        // Same file shape as an unpacked ChatGPT Classic: entry exe + manifest,
+        // but the identity is not OpenAI.Codex — never a Codex install.
+        let root = write_root("classic", "ChatGPT.exe", Some("OpenAI.ChatGPT"));
+        assert!(detect_portable_install(&root).is_none());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn rejects_portable_without_manifest_identity() {
+        // An entry executable alone is not identity; without a parseable
+        // manifest the directory is not recognized as a Codex install.
+        let root = write_root("no-manifest", "Codex.exe", None);
+        assert!(detect_portable_install(&root).is_none());
+        cleanup(&root);
     }
 }

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -941,6 +941,27 @@ pub fn perform_macos_update_with_network(
         // (so its cancel flag never arms) yet reconstruct/gate still ran.
         check_update_abort()?;
 
+        // Re-verify the TARGET right before the destructive tail: the early
+        // consent check ran before download, and the bundle at this path may
+        // have been swapped in the meantime — e.g. replaced with a ChatGPT
+        // Classic, which the identity gate inside installed_codex_build_at_path
+        // rejects. Quitting/swapping whatever sits here now would destroy
+        // something the user never confirmed.
+        match sys::installed_codex_build_at_path(&installed.path) {
+            Some((_, build)) if build == expected.from_build => {}
+            Some((_, build)) => {
+                return Err(AppError::StaleExpectation(format!(
+                    "安装目标在确认后发生了变化（当前 build {build}，确认时为 {}）：请重新检查后再试",
+                    expected.from_build
+                )));
+            }
+            None => {
+                return Err(AppError::StaleExpectation(
+                    "安装目标在确认后被移除或替换为非 Codex 应用：请重新检查后再试".to_string(),
+                ));
+            }
+        }
+
         // 4b) graceful quit (never force-kill), then 5) atomic same-volume swap. If
         //     the swap fails after the quit, swap_in_place has restored the old
         //     bundle in place — bring the user's app back before surfacing the error.

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -281,13 +281,15 @@ pub fn detect_existing_install_at_path(path: &Path) -> Result<InstalledCodex, Ap
             ));
         }
     }
-    // A quarantined bundle runs via App Translocation (randomized path), so no
-    // run/quit protection can target its live process — refuse to manage it.
-    if sys::has_quarantine_attribute(&raw) {
+    // An unapproved-quarantined bundle runs via App Translocation (randomized
+    // path), so no run/quit protection can target its live process — refuse to
+    // manage it. Approved quarantine (the common state after first launch) is
+    // fine and must not be rejected.
+    if sys::is_translocation_risk(&raw) {
         return Err(AppError::Internal(
-            "所选应用带有 macOS 隔离属性（quarantine）：系统会通过 App Translocation 在随机路径运行它，\
-             无法安全地检测或退出运行中的实例。请先用 Finder 将它移动到「应用程序」文件夹\
-             （或运行 xattr -d com.apple.quarantine）后重试"
+            "所选应用带有未经批准的 macOS 隔离属性：系统会通过 App Translocation 在随机路径运行它，\
+             无法安全地检测或退出运行中的实例。请先双击打开一次该应用（完成 Gatekeeper 批准），\
+             或运行 xattr -d com.apple.quarantine 移除隔离属性后重试"
                 .to_string(),
         ));
     }

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -296,8 +296,21 @@ fn require_not_translocation_risk(app: &str) -> Result<(), AppError> {
     if sys::is_translocation_risk(app) {
         return Err(AppError::Internal(
             "该应用带有会触发 App Translocation 的 macOS 隔离属性：系统会在随机路径运行它，\
-             无法安全地检测或退出运行中的实例。请用 Finder 将它「移动」到其他位置再移回\
-             （移动会写入豁免标记），或运行 xattr -d com.apple.quarantine 移除隔离属性后重试"
+             无法安全地检测或退出运行中的实例。请先退出该应用，再用 Finder 将它「移动」到\
+             其他位置再移回（移动会写入豁免标记），或运行 xattr -d com.apple.quarantine \
+             移除隔离属性后重试"
+                .to_string(),
+        ));
+    }
+    // De-quarantining does not migrate an ALREADY-RUNNING translocated
+    // instance back — it stays on its randomized mount, invisible to the
+    // path-scoped quit check. Refuse until it exits. (Bundle-name matching may
+    // also catch a translocated ChatGPT Classic; quitting it too is a harmless
+    // ask compared to swapping under a live process.)
+    if codex_mac_engine::swap::translocated_instance_running(Path::new(app)) {
+        return Err(AppError::Internal(
+            "检测到该应用（或同名应用）仍有一个经 App Translocation 启动的实例在运行：\
+             它不会随隔离属性的清除而迁回原路径，无法被安全退出。请先退出该应用后重试"
                 .to_string(),
         ));
     }
@@ -1164,7 +1177,7 @@ pub fn mac_adopt() -> Result<MacInstallStatus, AppError> {
     // lineage installs coexisting that silently chooses for the user and every
     // later update/uninstall would act on a target they never confirmed.
     // Force the explicit path-picking flow instead.
-    let candidates = sys::installed_codex_candidates();
+    let mut candidates = sys::installed_codex_candidates();
     if candidates.len() > 1 {
         let paths: Vec<String> = candidates.into_iter().map(|(path, _)| path).collect();
         return Err(AppError::Internal(format!(
@@ -1172,8 +1185,13 @@ pub fn mac_adopt() -> Result<MacInstallStatus, AppError> {
             paths.join("、")
         )));
     }
-    let installed = detect_installed()
+    // Adopt exactly the install the ambiguity check saw — a second scan could
+    // pick a DIFFERENT path if another install appeared in between, recording
+    // provenance for something the user never looked at.
+    let (path, build) = candidates
+        .pop()
         .ok_or_else(|| AppError::Internal("no Codex detected to adopt".to_string()))?;
+    let installed = installed_from_path_build(path, build);
     // Same gate as the manual picker — ambient adoption must not manage a
     // bundle whose running instance cannot be located.
     require_not_translocation_risk(&installed.path)?;

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -17,8 +17,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use serde::Serialize;
 
 use codex_mac_engine::{
-    apply_delta, download, gate_reconstructed, parse_appcast, plan_update, quit_codex, relaunch,
-    rollback, swap::codex_running, swap_in_place, sys, verify_sparkle, Appcast, NetworkConfig,
+    apply_delta, download, gate_reconstructed, parse_appcast, plan_update, quit_codex_at, relaunch,
+    rollback, swap::codex_running_at, swap_in_place, sys, verify_sparkle, Appcast, NetworkConfig,
     UpdatePlan, UpdateStrategy,
 };
 
@@ -434,8 +434,8 @@ fn no_progress(_p: DownloadProgress) {}
 /// automations are enabled); the engine brings that dialog frontmost after a
 /// grace period, and if the user still hasn't confirmed by the timeout we say
 /// exactly what to click instead of a bare timeout. Never force-kills.
-fn quit_codex_gracefully() -> Result<(), AppError> {
-    quit_codex(30).map_err(|_| {
+fn quit_codex_gracefully(install_app: &Path) -> Result<(), AppError> {
+    quit_codex_at(install_app, 30).map_err(|_| {
         AppError::Engine(
             "Codex 未在限时内退出——它可能正在等待退出确认（如「Quit Codex?」对话框，已尝试将其带到前台）。\
              请在 Codex 中确认退出后重试；为保护进行中的会话，不会强制结束 Codex"
@@ -944,9 +944,9 @@ pub fn perform_macos_update_with_network(
         // 4b) graceful quit (never force-kill), then 5) atomic same-volume swap. If
         //     the swap fails after the quit, swap_in_place has restored the old
         //     bundle in place — bring the user's app back before surfacing the error.
-        let was_running = codex_running();
+        let was_running = codex_running_at(&install_path);
         log::info!("macOS perform step=quit");
-        quit_codex_gracefully()?;
+        quit_codex_gracefully(&install_path)?;
         log::info!("macOS perform step=swap");
         if let Err(err) = swap_in_place(&install_path, &out_app, &backup) {
             if was_running {
@@ -1405,7 +1405,7 @@ pub fn uninstall_macos(keep_codex_home: bool) -> Result<MacUninstallReport, AppE
         ));
     }
 
-    quit_codex_gracefully()?;
+    quit_codex_gracefully(&install_path)?;
 
     // Delete first: if we lack permission to remove the bundle (e.g. a root-owned
     // install), the managed record stays intact so the user can retry without

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -281,6 +281,16 @@ pub fn detect_existing_install_at_path(path: &Path) -> Result<InstalledCodex, Ap
             ));
         }
     }
+    // A quarantined bundle runs via App Translocation (randomized path), so no
+    // run/quit protection can target its live process — refuse to manage it.
+    if sys::has_quarantine_attribute(&raw) {
+        return Err(AppError::Internal(
+            "所选应用带有 macOS 隔离属性（quarantine）：系统会通过 App Translocation 在随机路径运行它，\
+             无法安全地检测或退出运行中的实例。请先用 Finder 将它移动到「应用程序」文件夹\
+             （或运行 xattr -d com.apple.quarantine）后重试"
+                .to_string(),
+        ));
+    }
     let (detected_path, build) = sys::installed_codex_build_at_path(&raw)
         .ok_or_else(|| AppError::Internal("无法读取所选 Codex 应用的版本信息".to_string()))?;
     Ok(installed_from_path_build(detected_path, build))
@@ -1138,6 +1148,18 @@ pub fn mac_install_status() -> MacInstallStatus {
 
 /// Adopt the detected install — record provenance after explicit user consent.
 pub fn mac_adopt() -> Result<MacInstallStatus, AppError> {
+    // Ambient adoption picks the canonical-order first install; with several
+    // lineage installs coexisting that silently chooses for the user and every
+    // later update/uninstall would act on a target they never confirmed.
+    // Force the explicit path-picking flow instead.
+    let candidates = sys::installed_codex_candidates();
+    if candidates.len() > 1 {
+        let paths: Vec<String> = candidates.into_iter().map(|(path, _)| path).collect();
+        return Err(AppError::Internal(format!(
+            "检测到多个 Codex 安装（{}）。请使用「选择已安装的 Codex」手动指定要管理的那一个",
+            paths.join("、")
+        )));
+    }
     let installed = detect_installed()
         .ok_or_else(|| AppError::Internal("no Codex detected to adopt".to_string()))?;
     let path = &installed.path;

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -281,21 +281,27 @@ pub fn detect_existing_install_at_path(path: &Path) -> Result<InstalledCodex, Ap
             ));
         }
     }
-    // An unapproved-quarantined bundle runs via App Translocation (randomized
-    // path), so no run/quit protection can target its live process — refuse to
-    // manage it. Approved quarantine (the common state after first launch) is
-    // fine and must not be rejected.
-    if sys::is_translocation_risk(&raw) {
-        return Err(AppError::Internal(
-            "所选应用带有未经批准的 macOS 隔离属性：系统会通过 App Translocation 在随机路径运行它，\
-             无法安全地检测或退出运行中的实例。请先双击打开一次该应用（完成 Gatekeeper 批准），\
-             或运行 xattr -d com.apple.quarantine 移除隔离属性后重试"
-                .to_string(),
-        ));
-    }
+    require_not_translocation_risk(&raw)?;
     let (detected_path, build) = sys::installed_codex_build_at_path(&raw)
         .ok_or_else(|| AppError::Internal("无法读取所选 Codex 应用的版本信息".to_string()))?;
     Ok(installed_from_path_build(detected_path, build))
+}
+
+/// Refuse paths macOS would run through App Translocation: the live process
+/// then sits on a randomized mount, every path-scoped run/quit protection is
+/// blind to it, and a swap/uninstall could act while the app is running.
+/// Checked at adoption AND re-checked right before each destructive tail
+/// (the attribute can appear later, e.g. after a re-download over the path).
+fn require_not_translocation_risk(app: &str) -> Result<(), AppError> {
+    if sys::is_translocation_risk(app) {
+        return Err(AppError::Internal(
+            "该应用带有会触发 App Translocation 的 macOS 隔离属性：系统会在随机路径运行它，\
+             无法安全地检测或退出运行中的实例。请用 Finder 将它「移动」到其他位置再移回\
+             （移动会写入豁免标记），或运行 xattr -d com.apple.quarantine 移除隔离属性后重试"
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn detect_managed_installed() -> Option<InstalledCodex> {
@@ -973,6 +979,10 @@ pub fn perform_macos_update_with_network(
                 ));
             }
         }
+        // The attribute can appear after adoption (e.g. the path was replaced
+        // by a fresh download) — a translocated live instance would be
+        // invisible to the quit check below.
+        require_not_translocation_risk(&installed.path)?;
 
         // 4b) graceful quit (never force-kill), then 5) atomic same-volume swap. If
         //     the swap fails after the quit, swap_in_place has restored the old
@@ -1164,6 +1174,9 @@ pub fn mac_adopt() -> Result<MacInstallStatus, AppError> {
     }
     let installed = detect_installed()
         .ok_or_else(|| AppError::Internal("no Codex detected to adopt".to_string()))?;
+    // Same gate as the manual picker — ambient adoption must not manage a
+    // bundle whose running instance cannot be located.
+    require_not_translocation_risk(&installed.path)?;
     let path = &installed.path;
     log::info!("macOS adopt external install path={path}");
     let mut store = ProvenanceStore::load();
@@ -1450,6 +1463,9 @@ pub fn uninstall_macos(keep_codex_home: bool) -> Result<MacUninstallReport, AppE
         ));
     }
 
+    // A translocated live instance would be invisible to the quit check —
+    // re-verify before the destructive delete, same as perform.
+    require_not_translocation_risk(&installed.path)?;
     quit_codex_gracefully(&install_path)?;
 
     // Delete first: if we lack permission to remove the bundle (e.g. a root-owned

--- a/src-tauri/src/app/mac_update.rs
+++ b/src-tauri/src/app/mac_update.rs
@@ -244,20 +244,45 @@ fn detect_installed() -> Option<InstalledCodex> {
 pub fn detect_existing_install_at_path(path: &Path) -> Result<InstalledCodex, AppError> {
     if !path.exists() {
         return Err(AppError::Internal(
-            "所选位置不存在，请选择已安装的 Codex.app".to_string(),
+            "所选位置不存在，请选择已安装的 Codex 应用".to_string(),
         ));
     }
     if !path.is_dir() {
-        return Err(AppError::Internal("所选位置必须是 Codex.app".to_string()));
-    }
-    if path.file_name().and_then(|name| name.to_str()) != Some("Codex.app") {
         return Err(AppError::Internal(
-            "请选择 Codex.app，而不是它的上级文件夹".to_string(),
+            "所选位置必须是应用包（.app）".to_string(),
+        ));
+    }
+    // Identity, not name: after the upstream ChatGPT-brand merge the Codex
+    // bundle may be named ChatGPT.app, while /Applications/ChatGPT.app can just
+    // as well be ChatGPT Classic. Only CFBundleIdentifier can tell them apart.
+    if path.extension().and_then(|ext| ext.to_str()) != Some("app") {
+        return Err(AppError::Internal(
+            "请选择 Codex 应用本体（.app），而不是它的上级文件夹".to_string(),
         ));
     }
     let raw = path.to_string_lossy();
+    match sys::read_bundle_identifier(&raw).as_deref() {
+        Some(sys::CODEX_BUNDLE_ID) => {}
+        Some("com.openai.chat") => {
+            return Err(AppError::Internal(
+                "所选应用是 ChatGPT Classic（com.openai.chat），不是 Codex；本工具只管理 Codex"
+                    .to_string(),
+            ));
+        }
+        Some(other) => {
+            return Err(AppError::Internal(format!(
+                "所选应用不是 Codex（CFBundleIdentifier 为 {other}，期望 {}）",
+                sys::CODEX_BUNDLE_ID
+            )));
+        }
+        None => {
+            return Err(AppError::Internal(
+                "无法读取所选应用的 CFBundleIdentifier，请选择已安装的 Codex 应用".to_string(),
+            ));
+        }
+    }
     let (detected_path, build) = sys::installed_codex_build_at_path(&raw)
-        .ok_or_else(|| AppError::Internal("无法读取所选 Codex.app 的版本信息".to_string()))?;
+        .ok_or_else(|| AppError::Internal("无法读取所选 Codex 应用的版本信息".to_string()))?;
     Ok(installed_from_path_build(detected_path, build))
 }
 
@@ -642,6 +667,9 @@ fn unpack_app_zip(zip: &Path, work: &Path, out_app: &Path) -> Result<(), AppErro
         )));
     }
 
+    // The upstream archive may ship the bundle under either name (Codex.app
+    // pre-merge, ChatGPT.app post-merge); identity is checked, and the rename
+    // below normalizes whatever we accepted to the caller's canonical out_app.
     let found = require_single_codex_app(&extract)?;
     if out_app.exists() {
         let _ = std::fs::remove_dir_all(out_app);
@@ -663,7 +691,7 @@ fn require_single_codex_app(dir: &Path) -> Result<PathBuf, AppError> {
     }
     if apps.is_empty() {
         return Err(AppError::Engine(
-            "full-update zip did not contain Codex.app".to_string(),
+            "full-update zip did not contain an .app bundle".to_string(),
         ));
     }
     if apps.len() > 1 {
@@ -672,16 +700,17 @@ fn require_single_codex_app(dir: &Path) -> Result<PathBuf, AppError> {
         ));
     }
     let app = apps.remove(0);
-    if app
-        .file_name()
-        .map(|name| name == "Codex.app")
-        .unwrap_or(false)
-    {
-        Ok(app)
-    } else {
-        Err(AppError::Engine(
-            "full-update zip contained a non-Codex .app bundle".to_string(),
-        ))
+    // Accept any top-level bundle name but require the Codex product identity —
+    // the codesign gate re-asserts this against the sealed plist right after.
+    match sys::read_bundle_identifier(&app.to_string_lossy()).as_deref() {
+        Some(sys::CODEX_BUNDLE_ID) => Ok(app),
+        Some(other) => Err(AppError::Engine(format!(
+            "full-update zip contained a non-Codex .app bundle (CFBundleIdentifier {other}, expected {})",
+            sys::CODEX_BUNDLE_ID
+        ))),
+        None => Err(AppError::Engine(
+            "full-update zip's .app bundle had no readable CFBundleIdentifier".to_string(),
+        )),
     }
 }
 
@@ -1050,6 +1079,12 @@ pub struct MacInstallStatus {
     pub installed: Option<InstalledCodex>,
     /// "managed" | "external" | "none"
     pub status: String,
+    /// All Codex-lineage installs when more than one exists (e.g. an old
+    /// `Codex.app` plus a hand-dragged post-rebrand `ChatGPT.app`). The UI
+    /// should surface this and have the user adopt one explicitly; destructive
+    /// operations stay safe regardless (they re-verify path + build + identity).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ambiguous_paths: Option<Vec<String>>,
 }
 
 /// Classify the installed Codex against our provenance store.
@@ -1064,7 +1099,20 @@ pub fn mac_install_status() -> MacInstallStatus {
         Some(_) => "external",
     }
     .to_string();
-    MacInstallStatus { installed, status }
+    // Report ambient ambiguity (multiple lineage installs) unless provenance
+    // already pins which install the user manages.
+    let ambiguous_paths = match &installed {
+        Some(codex) if !store.is_managed_build(&codex.path, codex.build) => {
+            let candidates = sys::installed_codex_candidates();
+            (candidates.len() > 1).then(|| candidates.into_iter().map(|(path, _)| path).collect())
+        }
+        _ => None,
+    };
+    MacInstallStatus {
+        installed,
+        status,
+        ambiguous_paths,
+    }
 }
 
 /// Adopt the detected install — record provenance after explicit user consent.
@@ -1490,17 +1538,38 @@ mod tests {
         assert!(status.success(), "ditto {args:?} failed");
     }
 
+    fn write_bundle_plist(app: &Path, bundle_id: &str) {
+        std::fs::create_dir_all(app.join("Contents")).unwrap();
+        std::fs::write(
+            app.join("Contents/Info.plist"),
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_id}</string>
+</dict>
+</plist>
+"#
+            ),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn unpack_app_zip_surfaces_bundle() {
         let root = std::env::temp_dir().join(format!("codex-unpack-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
 
-        // A synthetic Codex.app, zipped the way Sparkle ships a macOS full update
-        // (`ditto -c -k --keepParent` → the `.app` is the top-level entry).
-        let src_app = root.join("Codex.app");
-        std::fs::create_dir_all(src_app.join("Contents")).unwrap();
-        std::fs::write(src_app.join("Contents/marker"), "3575").unwrap();
+        // A synthetic post-rebrand bundle (named ChatGPT.app, Codex identity),
+        // zipped the way Sparkle ships a macOS full update (`ditto -c -k
+        // --keepParent` → the `.app` is the top-level entry). unpack must accept
+        // it by identity and normalize it to the caller's out_app name.
+        let src_app = root.join("ChatGPT.app");
+        write_bundle_plist(&src_app, sys::CODEX_BUNDLE_ID);
+        std::fs::write(src_app.join("Contents/marker"), "5059").unwrap();
         let zip = root.join("Codex.zip");
         ditto(&[
             "-c",
@@ -1518,7 +1587,7 @@ mod tests {
         assert!(out_app.join("Contents/marker").exists(), "bundle surfaced");
         assert_eq!(
             std::fs::read_to_string(out_app.join("Contents/marker")).unwrap(),
-            "3575"
+            "5059"
         );
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -1532,6 +1601,26 @@ mod tests {
 
         let err = require_single_codex_app(&root).unwrap_err();
         assert!(err.to_string().contains("multiple .app"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn require_single_codex_app_gates_on_bundle_identity() {
+        let root = std::env::temp_dir().join(format!("codex-identity-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+
+        // ChatGPT Classic in the archive: right name shape, wrong product.
+        let classic = root.join("classic");
+        write_bundle_plist(&classic.join("ChatGPT.app"), "com.openai.chat");
+        let err = require_single_codex_app(&classic).unwrap_err();
+        assert!(err.to_string().contains("com.openai.chat"));
+
+        // Rebranded Codex: accepted regardless of the bundle's file name.
+        let rebranded = root.join("rebranded");
+        write_bundle_plist(&rebranded.join("ChatGPT.app"), sys::CODEX_BUNDLE_ID);
+        let found = require_single_codex_app(&rebranded).unwrap();
+        assert!(found.ends_with("ChatGPT.app"));
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -1204,7 +1204,10 @@ pub fn detect_existing_windows_install_at_path(
         ));
     }
     let installed = detect_portable_install(path).ok_or_else(|| {
-        AppError::Internal("未在所选位置找到 Codex.exe，请选择 Codex 安装文件夹".to_string())
+        AppError::Internal(
+            "未在所选位置找到应用入口（ChatGPT.exe / Codex.exe），请选择 Codex 安装文件夹"
+                .to_string(),
+        )
     })?;
     if installed.version.trim().is_empty() || installed.version == "0.0.0.0" {
         return Err(AppError::Internal(

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -1205,7 +1205,8 @@ pub fn detect_existing_windows_install_at_path(
     }
     let installed = detect_portable_install(path).ok_or_else(|| {
         AppError::Internal(
-            "未在所选位置找到应用入口（ChatGPT.exe / Codex.exe），请选择 Codex 安装文件夹"
+            "未在所选位置识别到 Codex 安装：需要 ChatGPT.exe / Codex.exe 入口，且 AppxManifest.xml \
+             声明的包身份必须是 OpenAI.Codex（其他产品如 ChatGPT Classic 不受本工具管理）"
                 .to_string(),
         )
     })?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -418,7 +418,8 @@ fn is_protected_install_root(path: &Path) -> bool {
 }
 
 fn is_existing_codex_portable_root(path: &Path) -> bool {
-    path.join("Codex.exe").is_file() && path.join("AppxManifest.xml").is_file()
+    codex_win_engine::portable::installed_app_exe(path).is_some()
+        && path.join("AppxManifest.xml").is_file()
 }
 
 fn directory_is_empty(path: &Path) -> Result<bool, AppError> {
@@ -642,7 +643,9 @@ pub fn mac_adopt(state: State<'_, ManagerState>) -> Result<MacInstallStatus, Com
     crate::app::mac_update::mac_adopt().map_err(Into::into)
 }
 
-/// macOS-only: let the user pick an existing Codex.app and validate it.
+/// macOS-only: let the user pick an existing Codex install and validate it.
+/// The bundle may be named Codex.app or (post-rebrand) ChatGPT.app — validation
+/// is by CFBundleIdentifier, so ChatGPT Classic is rejected with a clear error.
 #[tauri::command]
 pub async fn mac_pick_existing_install(
     app: tauri::AppHandle,
@@ -655,7 +658,7 @@ pub async fn mac_pick_existing_install(
     let selected = tauri::async_runtime::spawn_blocking(move || {
         app.dialog()
             .file()
-            .set_title("选择 Codex.app")
+            .set_title("选择 Codex 应用（Codex.app 或 ChatGPT.app）")
             .set_directory(start_dir)
             .blocking_pick_file()
             .map(|path| {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -418,8 +418,10 @@ fn is_protected_install_root(path: &Path) -> bool {
 }
 
 fn is_existing_codex_portable_root(path: &Path) -> bool {
-    codex_win_engine::portable::installed_app_exe(path).is_some()
-        && path.join("AppxManifest.xml").is_file()
+    // Identity-gated (entry exe + AppxManifest Identity == OpenAI.Codex): a
+    // directory that merely contains a ChatGPT.exe (e.g. an unpacked ChatGPT
+    // Classic) must not be treated as a replaceable Codex install.
+    codex_win_engine::detect_portable_install(path).is_some()
 }
 
 fn directory_is_empty(path: &Path) -> Result<bool, AppError> {
@@ -1625,16 +1627,47 @@ mod tests {
         let _ = fs::remove_dir_all(root);
     }
 
+    fn write_portable_manifest(root: &std::path::Path, identity_name: &str) {
+        fs::write(
+            root.join("AppxManifest.xml"),
+            format!(
+                r#"<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="{identity_name}" Publisher="CN=OpenAI OpCo, LLC" Version="26.707.3748.0" ProcessorArchitecture="x64" />
+</Package>"#
+            ),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn accepts_existing_codex_portable_install_root() {
         let root = temp_path("codex-manager-existing-portable-root");
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&root).unwrap();
         fs::write(root.join("Codex.exe"), b"codex").unwrap();
-        fs::write(root.join("AppxManifest.xml"), b"<Package />").unwrap();
+        write_portable_manifest(&root, "OpenAI.Codex");
 
         let validated = validate_install_root_path(&root.to_string_lossy()).unwrap();
         assert_eq!(validated, root.to_string_lossy());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rejects_portable_root_with_foreign_identity() {
+        // An unpacked non-Codex payload (e.g. ChatGPT Classic) also carries a
+        // root-level ChatGPT.exe + AppxManifest.xml. Its identity fails the
+        // gate, so the non-empty directory must NOT be treated as replaceable.
+        let root = temp_path("codex-manager-foreign-portable-root");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("ChatGPT.exe"), b"classic").unwrap();
+        write_portable_manifest(&root, "OpenAI.ChatGPT");
+
+        let err = validate_install_root_path(&root.to_string_lossy()).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("安装位置必须是空文件夹，或已有的 Codex 免安装版目录"));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -816,7 +816,10 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
           ) : null}
         </div>
 
-        {!rechecking && kind === "none" ? (
+        {/* Also offered on "external": with several coexisting lineage installs
+            ambient adoption refuses to pick one (see mac_adopt), and this is
+            the explicit path-picking flow that resolves the ambiguity. */}
+        {!rechecking && (kind === "none" || kind === "external") ? (
           <div className="manual-existing-entry">
             <button
               className="linkbtn subtle"

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -43,6 +43,9 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   const { t, lang } = useI18n();
   const [report, setReport] = useState<MacUpdateReport | null>(null);
   const [status, setStatus] = useState<MacInstallStatus | null>(null);
+  // Several coexisting Codex-lineage installs: ambient adoption refuses, the
+  // explicit picker becomes the primary action (see the external button row).
+  const ambiguousInstall = (status?.ambiguousPaths?.length ?? 0) > 1;
   const [perform, setPerform] = useState<MacPerformReport | null>(null);
   // Human-facing version pair captured at perform time, so the outcome strip can
   // read "26.602.40724 → 26.602.71036" instead of raw build numbers.
@@ -653,6 +656,10 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
                 {t("prov.external")}
               </div>
               <div className="desc">{t("home.external.desc")}</div>
+              {/* Paths are technical content, shown verbatim in every locale. */}
+              {ambiguousInstall && status?.ambiguousPaths ? (
+                <div className="desc mono">{status.ambiguousPaths.join(" · ")}</div>
+              ) : null}
             </>
           ) : (
             <>
@@ -765,10 +772,24 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
           ) : null}
           {!rechecking && kind === "external" ? (
             <>
-              <button className="btn primary big" onClick={adopt} disabled={busy !== null}>
-                <Icon name="shield" />
-                {t("home.external.cta")}
-              </button>
+              {/* With several coexisting Codex installs, ambient adoption
+                  would refuse (and must not silently pick one) — make the
+                  explicit picker the primary action instead. */}
+              {ambiguousInstall ? (
+                <button
+                  className="btn primary big"
+                  onClick={openManualExisting}
+                  disabled={busy !== null || manualExistingBusy !== null}
+                >
+                  <Icon name="folder" />
+                  {t("home.manualExisting.title")}
+                </button>
+              ) : (
+                <button className="btn primary big" onClick={adopt} disabled={busy !== null}>
+                  <Icon name="shield" />
+                  {t("home.external.cta")}
+                </button>
+              )}
               <button className="btn ghost" onClick={onLaunch} disabled={busy !== null}>
                 <CodexGlyph />
                 {t("home.launch")}
@@ -816,10 +837,9 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
           ) : null}
         </div>
 
-        {/* Also offered on "external": with several coexisting lineage installs
-            ambient adoption refuses to pick one (see mac_adopt), and this is
-            the explicit path-picking flow that resolves the ambiguity. */}
-        {!rechecking && (kind === "none" || kind === "external") ? (
+        {/* Also offered on non-ambiguous "external" (on ambiguity the picker
+            IS the primary action above, so the secondary link would repeat). */}
+        {!rechecking && (kind === "none" || (kind === "external" && !ambiguousInstall)) ? (
           <div className="manual-existing-entry">
             <button
               className="linkbtn subtle"

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -92,6 +92,10 @@ export type InstallClass = "managed" | "external" | "none";
 export interface MacInstallStatus {
   installed: InstalledCodex | null;
   status: InstallClass;
+  /** Present when several Codex-lineage installs coexist (e.g. an old
+   *  Codex.app plus a hand-dragged post-rebrand ChatGPT.app); the user should
+   *  adopt one explicitly. Absent when unambiguous. */
+  ambiguousPaths?: string[];
 }
 
 export type UpdateSourceKind = "auto" | "mirror" | "official" | "custom";


### PR DESCRIPTION
[FABLE]

Manager 侧对上游 ChatGPT 品牌合并的兼容修复——实现 Wangnov/codex-app-mirror#37 收敛契约中 Manager 的配套部分（镜像切换顺序的前置项 2）。

## 背景

上游把 Codex 桌面应用原地并入 ChatGPT 品牌：macOS bundle 变为 `ChatGPT.app`（`CFBundleExecutable = ChatGPT`），MSIX 清单入口切到 `app/ChatGPT.exe`（遗留 `Codex.exe` 仍随包分发但不再是入口）；产品身份不变（`com.openai.codex` / `OpenAI.Codex`）。同时 ChatGPT Classic（`com.openai.chat`）与新 Codex 在磁盘上共用 `ChatGPT.app` 名字。**文件名从此不能标识产品**，本 PR 把检测、门禁、生命周期全部切到身份寻址。

## 变更

### macOS
- **检测**：候选扫 `Codex.app` 与 `ChatGPT.app`（`/Applications` + `~/Applications`），只接受 `CFBundleIdentifier == com.openai.codex`——Classic 永不匹配；多个血统安装并存时规范路径优先并通过 `MacInstallStatus.ambiguousPaths`（新可选字段）上报歧义，破坏性操作不受影响（原有 consent 机制会重验 path + build + 身份）。
- **codesign 闸**：`gate_reconstructed` 新增 bundle ID 断言（在 `codesign --verify` 之后读取，plist 受签名封印）——Team ID 相同的 Classic 无法过闸，错误消息明确指出 Classic。
- **全量安装 / 接管**：接受任意顶层 `.app` 名（按身份校验），验证后规范化安装到 `Codex.app`（与官方自更新保留本地目录名的行为一致）；手动选择器同步放开文件名限制，Classic 给出专属错误提示。
- **进程控制**：`codex_running` / `quit_codex` 从 `pgrep -x Codex` 改为 AppleScript `application id "com.openai.codex"` 寻址——既不漏掉改名后的进程（`ChatGPT`），也不误伤同进程名的 Classic。

### Windows
- **portable 入口**：从 `AppxManifest.xml` 的 `Application@Executable` 解析入口（新增 `parse_appx_application_executable`），按"清单相对路径 → basename 递归 → ChatGPT.exe / Codex.exe 回退"三级解析；安装、检测（`detect_portable_install`）、启动、快捷方式、健康检查、报告统一走 `installed_app_exe`，旧布局（仅 `Codex.exe`）继续可用。
- **graceful close**：进程枚举扩展为 `Get-Process -Name Codex, ChatGPT`，且 **root 路径过滤改为必选**——删除了无过滤的 `close_codex_gracefully` 全局变体（无调用方），从类型上杜绝按名字误关 Classic 的可能。
- MSIX 检测 / 身份校验 / AUMID 启动路径不变（身份未变，本就兼容）。

## 测试

- 三个 crate 全绿：src-tauri 66 + mac-engine 12 + win-engine 46（含新增：身份门禁正反用例、改名 bundle 的 unpack 规范化、Classic 拒绝、rebrand 布局 MSIX 的 portable 安装、`installed_app_exe` 三级解析、`Application@Executable` 解析）。
- 前端 `tsc --noEmit` / `eslint --max-warnings=0` / vitest 70 passed。
- clippy：无新增警告（`codesign.rs` 两条 pre-existing `unnecessary_cast` 为本地新版 clippy 所报，CI toolchain 不报，未动）。
- `codex review --uncommitted` 无法执行：本机 Codex CLI v0.132.0 与其配置的 `gpt-5.6-sol` 模型不兼容（"requires a newer version of Codex"）+ MCP token 过期——已用等效的结构化自审替代（正确性/边界/误伤面逐条过），请评审时留意这道门是缺失的。

## 需真机验证（macOS 上无法验证的部分）

- [ ] Windows：rebrand MSIX 的真实升级链路（运行中 → 关闭 → 安装 → 健康检查 → 重启）——`Get-Process -Name Codex, ChatGPT` + 路径过滤的行为
- [ ] Windows：portable 从 26.707.x MSIX 安装后以 `ChatGPT.exe` 启动
- [ ] macOS：对真实 26.707.x 全量 zip 的 unpack → 身份闸 → 规范化安装；delta 路径此前已实测可用
- [ ] macOS：装有 ChatGPT Classic 的机器上确认检测/关闭均不触碰 Classic

## 明确不做（后续跟进）

- i18n 文案的品牌跟进（数百处 "Codex" 显示文案）与 `ambiguousPaths` 的 UI 消费——功能层已就绪，UI 增强另行 PR
- Beta 通道（`OpenAI.CodexBeta` / `com.openai.codex.beta`）支持——按 mirror#37 §六为独立 enhancement

Ref: Wangnov/codex-app-mirror#37
