### PR TITLE
fix(win): retry Schannel revocation-offline update fetches

### DIFF
--- a/crates/codex-win-engine/src/download.rs
+++ b/crates/codex-win-engine/src/download.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use sha2::{Digest, Sha256};
 
 use crate::limits::MAX_PACKAGE_BYTES;
-use crate::network::NetworkConfig;
+use crate::network::{is_schannel_revocation_offline, NetworkConfig, SchannelRevocationCheck};
 use crate::process::{curl_exe, hidden_command};
 use crate::EngineError;
 
@@ -137,7 +137,26 @@ fn curl_failure_message(url: &str, exit_code: Option<i32>, stderr: &str) -> Stri
 fn is_connectivity_exit(exit_code: Option<i32>) -> bool {
     matches!(
         exit_code,
-        Some(5 | 6 | 7 | 28 | 35 | 52 | 53 | 54 | 55 | 56 | 58 | 59 | 60 | 67 | 77 | 80 | 82 | 83 | 91)
+        Some(
+            5 | 6
+                | 7
+                | 28
+                | 35
+                | 52
+                | 53
+                | 54
+                | 55
+                | 56
+                | 58
+                | 59
+                | 60
+                | 67
+                | 77
+                | 80
+                | 82
+                | 83
+                | 91
+        )
     )
 }
 
@@ -148,8 +167,9 @@ fn curl_args(
     max_bytes: &str,
     progress_mode: ProgressMode,
     network: &NetworkConfig,
+    revocation_check: SchannelRevocationCheck,
 ) -> Vec<String> {
-    let mut args = network.curl_args();
+    let mut args = network.curl_args_with_schannel_revocation(revocation_check);
     args.extend([
         "-fL".to_string(),
         "--proto".to_string(),
@@ -231,6 +251,60 @@ fn run_curl_once(
     Ok(())
 }
 
+struct CurlRun<'a> {
+    url: &'a str,
+    dest: &'a str,
+    resume: bool,
+    max_bytes: &'a str,
+    network: &'a NetworkConfig,
+    on_progress: &'a dyn Fn(u64),
+}
+
+impl CurlRun<'_> {
+    fn source(&self) -> &str {
+        url_host(self.url)
+    }
+}
+
+fn run_curl_with_mode(
+    run: &CurlRun<'_>,
+    progress_mode: ProgressMode,
+    revocation_check: SchannelRevocationCheck,
+) -> Result<(), CurlAttemptError> {
+    let args = curl_args(
+        run.url,
+        run.dest,
+        run.resume,
+        run.max_bytes,
+        progress_mode,
+        run.network,
+        revocation_check,
+    );
+    run_curl_once(run.source(), run.dest, args, run.on_progress)
+}
+
+fn retry_with_schannel_no_revoke(
+    err: CurlAttemptError,
+    run: &CurlRun<'_>,
+    progress_mode: ProgressMode,
+) -> Result<(), CurlAttemptError> {
+    let should_retry = match &err {
+        CurlAttemptError::Curl { exit_code, stderr } => {
+            is_schannel_revocation_offline(*exit_code, stderr)
+        }
+        _ => false,
+    };
+    if !should_retry {
+        return Err(err);
+    }
+
+    let source = run.source();
+    log::warn!(
+        "Windows curl Schannel revocation check failed; retrying with --ssl-no-revoke source={source}"
+    );
+    run_curl_with_mode(run, progress_mode, SchannelRevocationCheck::Disabled)
+}
+
 fn run_curl(
     url: &str,
     dest: &Path,
@@ -242,34 +316,39 @@ fn run_curl(
     let source = url_host(url);
     let dest = dest.to_string_lossy().into_owned();
     let max_bytes = max_bytes.to_string();
-
-    let modern_args = curl_args(
+    let run = CurlRun {
         url,
-        &dest,
+        dest: &dest,
         resume,
-        &max_bytes,
-        ProgressMode::NoProgressMeter,
+        max_bytes: &max_bytes,
         network,
-    );
-    if let Err(first_err) = run_curl_once(source, &dest, modern_args, on_progress) {
+        on_progress,
+    };
+
+    if let Err(first_err) = run_curl_with_mode(
+        &run,
+        ProgressMode::NoProgressMeter,
+        SchannelRevocationCheck::Strict,
+    ) {
         if let CurlAttemptError::Curl { exit_code, stderr } = &first_err {
             if is_no_progress_meter_unsupported(*exit_code, stderr) {
                 log::warn!(
                     "Windows curl does not support --no-progress-meter; retrying with -sS source={source}"
                 );
-                let compat_args = curl_args(
-                    url,
-                    &dest,
-                    resume,
-                    &max_bytes,
+                let compat_result = run_curl_with_mode(
+                    &run,
                     ProgressMode::SilentWithErrors,
-                    network,
+                    SchannelRevocationCheck::Strict,
                 );
-                return run_curl_once(source, &dest, compat_args, on_progress)
+                return compat_result
+                    .or_else(|err| {
+                        retry_with_schannel_no_revoke(err, &run, ProgressMode::SilentWithErrors)
+                    })
                     .map_err(|err| err.into_message(url));
             }
         }
-        return Err(first_err.into_message(url));
+        return retry_with_schannel_no_revoke(first_err, &run, ProgressMode::NoProgressMeter)
+            .map_err(|err| err.into_message(url));
     }
     Ok(())
 }
@@ -449,6 +528,7 @@ mod tests {
             "123",
             ProgressMode::NoProgressMeter,
             &NetworkConfig::system(),
+            SchannelRevocationCheck::Strict,
         );
 
         assert!(args.contains(&"--no-progress-meter".to_string()));
@@ -464,6 +544,7 @@ mod tests {
             "123",
             ProgressMode::SilentWithErrors,
             &NetworkConfig::system(),
+            SchannelRevocationCheck::Strict,
         );
 
         assert!(args.contains(&"-sS".to_string()));
@@ -480,6 +561,7 @@ mod tests {
             "123",
             ProgressMode::NoProgressMeter,
             &NetworkConfig::custom("socks5h://127.0.0.1:7890"),
+            SchannelRevocationCheck::Strict,
         );
 
         assert_eq!(args.first().map(String::as_str), Some("--proxy"));

--- a/crates/codex-win-engine/src/network.rs
+++ b/crates/codex-win-engine/src/network.rs
@@ -1,5 +1,11 @@
 use std::process::Command;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchannelRevocationCheck {
+    Strict,
+    Disabled,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProxyMode {
     System,
@@ -49,8 +55,23 @@ impl NetworkConfig {
         }
     }
 
-    pub(crate) fn apply_to_command(&self, command: &mut Command) {
-        let args = self.curl_args();
+    pub(crate) fn curl_args_with_schannel_revocation(
+        &self,
+        revocation_check: SchannelRevocationCheck,
+    ) -> Vec<String> {
+        let mut args = self.curl_args();
+        if revocation_check == SchannelRevocationCheck::Disabled {
+            push_schannel_no_revoke(&mut args);
+        }
+        args
+    }
+
+    pub(crate) fn apply_to_command_with_schannel_revocation(
+        &self,
+        command: &mut Command,
+        revocation_check: SchannelRevocationCheck,
+    ) {
+        let args = self.curl_args_with_schannel_revocation(revocation_check);
         if !args.is_empty() {
             command.args(args);
         }
@@ -63,9 +84,24 @@ impl Default for NetworkConfig {
     }
 }
 
+pub(crate) fn is_schannel_revocation_offline(exit_code: Option<i32>, stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    exit_code == Some(35)
+        && lower.contains("schannel")
+        && (stderr.contains("CRYPT_E_REVOCATION_OFFLINE") || lower.contains("0x80092013"))
+}
+
+#[cfg(windows)]
+fn push_schannel_no_revoke(args: &mut Vec<String>) {
+    args.push("--ssl-no-revoke".to_string());
+}
+
+#[cfg(not(windows))]
+fn push_schannel_no_revoke(_args: &mut Vec<String>) {}
+
 #[cfg(test)]
 mod tests {
-    use super::NetworkConfig;
+    use super::{is_schannel_revocation_offline, NetworkConfig, SchannelRevocationCheck};
 
     #[test]
     fn direct_proxy_mode_disables_curl_proxy_resolution() {
@@ -80,6 +116,34 @@ mod tests {
         assert_eq!(
             NetworkConfig::custom("socks5h://127.0.0.1:7890").curl_args(),
             vec!["--proxy", "socks5h://127.0.0.1:7890", "--noproxy", ""]
+        );
+    }
+
+    #[test]
+    fn detects_schannel_revocation_offline_failure() {
+        let stderr = "curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_REVOCATION_OFFLINE (0x80092013)";
+
+        assert!(is_schannel_revocation_offline(Some(35), stderr));
+        assert!(!is_schannel_revocation_offline(Some(6), stderr));
+        assert!(!is_schannel_revocation_offline(
+            Some(35),
+            "curl: (35) OpenSSL SSL_connect: connection reset"
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn disabled_schannel_revocation_adds_windows_curl_flag_after_proxy_args() {
+        assert_eq!(
+            NetworkConfig::custom("http://127.0.0.1:7890")
+                .curl_args_with_schannel_revocation(SchannelRevocationCheck::Disabled),
+            vec![
+                "--proxy",
+                "http://127.0.0.1:7890",
+                "--noproxy",
+                "",
+                "--ssl-no-revoke"
+            ]
         );
     }
 }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -10,7 +10,7 @@ use crate::capability::WinCapabilityReport;
 use crate::capability::{CapabilityCheck, CapabilityState};
 use crate::limits::MAX_TEXT_BYTES;
 use crate::msix::parse_appx_manifest_xml;
-use crate::network::NetworkConfig;
+use crate::network::{is_schannel_revocation_offline, NetworkConfig, SchannelRevocationCheck};
 use crate::process::{curl_exe, hidden_command};
 use crate::EngineError;
 
@@ -140,13 +140,15 @@ pub fn fetch_text(url: &str) -> Result<String, EngineError> {
     fetch_text_with_network(url, &NetworkConfig::system())
 }
 
-pub fn fetch_text_with_network(url: &str, network: &NetworkConfig) -> Result<String, EngineError> {
-    let source = url_host(url);
-    log::debug!("fetch Windows text source={source}");
+fn fetch_text_output(
+    url: &str,
+    network: &NetworkConfig,
+    revocation_check: SchannelRevocationCheck,
+) -> Result<std::process::Output, EngineError> {
     let max_text = MAX_TEXT_BYTES.to_string();
     let mut command = hidden_command(curl_exe());
-    network.apply_to_command(&mut command);
-    let output = command
+    network.apply_to_command_with_schannel_revocation(&mut command, revocation_check);
+    command
         .args([
             "-fsSL",
             "--proto",
@@ -162,7 +164,24 @@ pub fn fetch_text_with_network(url: &str, network: &NetworkConfig) -> Result<Str
             url,
         ])
         .output()
-        .map_err(|e| EngineError::Io(format!("spawn curl: {e}")))?;
+        .map_err(|e| EngineError::Io(format!("spawn curl: {e}")))
+}
+
+pub fn fetch_text_with_network(url: &str, network: &NetworkConfig) -> Result<String, EngineError> {
+    let source = url_host(url);
+    log::debug!("fetch Windows text source={source}");
+    let mut output = fetch_text_output(url, network, SchannelRevocationCheck::Strict)?;
+    let should_retry_without_revocation = {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        !output.status.success()
+            && is_schannel_revocation_offline(output.status.code(), stderr.as_ref())
+    };
+    if should_retry_without_revocation {
+        log::warn!(
+            "Windows curl Schannel revocation check failed; retrying with --ssl-no-revoke source={source}"
+        );
+        output = fetch_text_output(url, network, SchannelRevocationCheck::Disabled)?;
+    }
 
     if !output.status.success() {
         let err = EngineError::Io(curl_failure_message(
@@ -207,7 +226,26 @@ fn curl_failure_message(url: &str, exit_code: Option<i32>, stderr: &str) -> Stri
 fn is_connectivity_exit(exit_code: Option<i32>) -> bool {
     matches!(
         exit_code,
-        Some(5 | 6 | 7 | 28 | 35 | 52 | 53 | 54 | 55 | 56 | 58 | 59 | 60 | 67 | 77 | 80 | 82 | 83 | 91)
+        Some(
+            5 | 6
+                | 7
+                | 28
+                | 35
+                | 52
+                | 53
+                | 54
+                | 55
+                | 56
+                | 58
+                | 59
+                | 60
+                | 67
+                | 77
+                | 80
+                | 82
+                | 83
+                | 91
+        )
     )
 }
 


### PR DESCRIPTION
## Summary

- Retry Windows update metadata fetches once with `--ssl-no-revoke` when system curl fails with Schannel `CRYPT_E_REVOCATION_OFFLINE`.
- Apply the same targeted retry to Windows package downloads while preserving the existing old-curl `--no-progress-meter` fallback.
- Keep strict TLS as the default path; the relaxed revocation check only runs after the exact Schannel revocation-offline failure.

## Validation

- `rustfmt --edition 2021 --check crates\codex-win-engine\src\network.rs crates\codex-win-engine\src\sys.rs crates\codex-win-engine\src\download.rs`
- `git diff --check`
- `cargo test --manifest-path crates\codex-win-engine\Cargo.toml`
- `cargo clippy --manifest-path crates\codex-win-engine\Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri\Cargo.toml --lib`
- Reproduced local failure with plain `curl.exe` and confirmed `curl.exe --ssl-no-revoke` can fetch `https://codexapp.agentsmirror.com/latest/manifest`.