### PR TITLE
fix(ui): disable browser context menus in production WebViews

### DIFF
--- a/docs/webview-context-menu.md
+++ b/docs/webview-context-menu.md
@@ -1,0 +1,26 @@
+# WebView context-menu policy
+
+## Production (release builds)
+
+| Surface | Expected behavior |
+| --- | --- |
+| Non-editable chrome (home, settings, sheets) | No browser default menu (no Print / Reload / Inspect) |
+| Text fields (`input`, `textarea`, `contenteditable`, `role=textbox`) | Copy / cut / paste remain available via keyboard; OS may still show a native edit menu |
+| Keyboard menu key / Shift+F10 / trackpad secondary click | Same policy as mouse right-click |
+
+Implementation: `src/app/contextMenuPolicy.ts` (installed from `src/main.tsx` when `import.meta.env.DEV` is false). Capture-phase `contextmenu` + `preventDefault` on non-editable targets. No global disable of accessibility or keyboard shortcuts.
+
+## Development builds
+
+Default browser/WebView context menu stays enabled so Reload and DevTools remain available. The production policy is not installed.
+
+## Manual dual-platform checklist
+
+Run a **release** build (`npm run tauri:build` or CI artifact) on each OS:
+
+1. Right-click empty home chrome → no browser menu.
+2. Right-click a settings text field (e.g. custom URL when visible) → edit actions still work; paste with Ctrl/Cmd+V works.
+3. Shift+F10 on chrome → no browser menu.
+4. Dev build (`npm run tauri:dev`) → context menu still appears for debugging.
+
+Automated coverage: `src/app/contextMenuPolicy.test.ts`.

--- a/src/app/contextMenuPolicy.test.ts
+++ b/src/app/contextMenuPolicy.test.ts
@@ -13,22 +13,35 @@ describe("isEditableContextTarget", () => {
   it("accepts text inputs and textareas", () => {
     document.body.innerHTML = `
       <input id="t" type="text" />
+      <input id="n" type="number" />
       <textarea id="a"></textarea>
-      <div id="ce" contenteditable="true"></div>
+      <div id="ce" contenteditable="true">hello</div>
+      <div id="tb" role="textbox">x</div>
     `;
     expect(isEditableContextTarget(document.getElementById("t"))).toBe(true);
+    expect(isEditableContextTarget(document.getElementById("n"))).toBe(true);
     expect(isEditableContextTarget(document.getElementById("a"))).toBe(true);
     expect(isEditableContextTarget(document.getElementById("ce"))).toBe(true);
+    expect(isEditableContextTarget(document.getElementById("tb"))).toBe(true);
   });
 
-  it("rejects non-text inputs and ordinary chrome", () => {
+  it("accepts Text nodes inside contenteditable", () => {
+    document.body.innerHTML = `<div id="ce" contenteditable="true">hello</div>`;
+    const text = document.getElementById("ce")!.firstChild;
+    expect(text).toBeInstanceOf(Text);
+    expect(isEditableContextTarget(text)).toBe(true);
+  });
+
+  it("rejects non-text inputs, select, and ordinary chrome", () => {
     document.body.innerHTML = `
       <input id="cb" type="checkbox" />
       <button id="b">go</button>
+      <select id="s"><option>a</option></select>
       <div id="d">plain</div>
     `;
     expect(isEditableContextTarget(document.getElementById("cb"))).toBe(false);
     expect(isEditableContextTarget(document.getElementById("b"))).toBe(false);
+    expect(isEditableContextTarget(document.getElementById("s"))).toBe(false);
     expect(isEditableContextTarget(document.getElementById("d"))).toBe(false);
     expect(isEditableContextTarget(null)).toBe(false);
   });
@@ -40,13 +53,17 @@ describe("isEditableContextTarget", () => {
 });
 
 describe("installContextMenuPolicy", () => {
+  let dispose: (() => void) | null = null;
+
   afterEach(() => {
+    dispose?.();
+    dispose = null;
     document.body.innerHTML = "";
   });
 
   it("prevents default on non-editable targets when enabled", () => {
     document.body.innerHTML = `<div id="d">x</div><input id="t" type="text" />`;
-    const dispose = installContextMenuPolicy(true);
+    dispose = installContextMenuPolicy(true);
 
     const plain = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     document.getElementById("d")!.dispatchEvent(plain);
@@ -55,23 +72,30 @@ describe("installContextMenuPolicy", () => {
     const edit = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     document.getElementById("t")!.dispatchEvent(edit);
     expect(edit.defaultPrevented).toBe(false);
+  });
 
-    dispose();
+  it("does not prevent default for Text inside contenteditable", () => {
+    document.body.innerHTML = `<div id="ce" contenteditable="true">hello</div>`;
+    dispose = installContextMenuPolicy(true);
+    const text = document.getElementById("ce")!.firstChild!;
+    const edit = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    text.dispatchEvent(edit);
+    expect(edit.defaultPrevented).toBe(false);
   });
 
   it("is a no-op when disabled (dev builds)", () => {
     document.body.innerHTML = `<div id="d">x</div>`;
-    const dispose = installContextMenuPolicy(false);
+    dispose = installContextMenuPolicy(false);
     const plain = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     document.getElementById("d")!.dispatchEvent(plain);
     expect(plain.defaultPrevented).toBe(false);
-    dispose();
   });
 
   it("dispose removes the listener", () => {
     document.body.innerHTML = `<div id="d">x</div>`;
-    const dispose = installContextMenuPolicy(true);
+    dispose = installContextMenuPolicy(true);
     dispose();
+    dispose = null;
     const plain = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     document.getElementById("d")!.dispatchEvent(plain);
     expect(plain.defaultPrevented).toBe(false);

--- a/src/app/contextMenuPolicy.test.ts
+++ b/src/app/contextMenuPolicy.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  installContextMenuPolicy,
+  isEditableContextTarget,
+} from "./contextMenuPolicy";
+
+describe("isEditableContextTarget", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("accepts text inputs and textareas", () => {
+    document.body.innerHTML = `
+      <input id="t" type="text" />
+      <textarea id="a"></textarea>
+      <div id="ce" contenteditable="true"></div>
+    `;
+    expect(isEditableContextTarget(document.getElementById("t"))).toBe(true);
+    expect(isEditableContextTarget(document.getElementById("a"))).toBe(true);
+    expect(isEditableContextTarget(document.getElementById("ce"))).toBe(true);
+  });
+
+  it("rejects non-text inputs and ordinary chrome", () => {
+    document.body.innerHTML = `
+      <input id="cb" type="checkbox" />
+      <button id="b">go</button>
+      <div id="d">plain</div>
+    `;
+    expect(isEditableContextTarget(document.getElementById("cb"))).toBe(false);
+    expect(isEditableContextTarget(document.getElementById("b"))).toBe(false);
+    expect(isEditableContextTarget(document.getElementById("d"))).toBe(false);
+    expect(isEditableContextTarget(null)).toBe(false);
+  });
+
+  it("walks up to an editable ancestor", () => {
+    document.body.innerHTML = `<div contenteditable="true"><span id="s">x</span></div>`;
+    expect(isEditableContextTarget(document.getElementById("s"))).toBe(true);
+  });
+});
+
+describe("installContextMenuPolicy", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("prevents default on non-editable targets when enabled", () => {
+    document.body.innerHTML = `<div id="d">x</div><input id="t" type="text" />`;
+    const dispose = installContextMenuPolicy(true);
+
+    const plain = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.getElementById("d")!.dispatchEvent(plain);
+    expect(plain.defaultPrevented).toBe(true);
+
+    const edit = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.getElementById("t")!.dispatchEvent(edit);
+    expect(edit.defaultPrevented).toBe(false);
+
+    dispose();
+  });
+
+  it("is a no-op when disabled (dev builds)", () => {
+    document.body.innerHTML = `<div id="d">x</div>`;
+    const dispose = installContextMenuPolicy(false);
+    const plain = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.getElementById("d")!.dispatchEvent(plain);
+    expect(plain.defaultPrevented).toBe(false);
+    dispose();
+  });
+
+  it("dispose removes the listener", () => {
+    document.body.innerHTML = `<div id="d">x</div>`;
+    const dispose = installContextMenuPolicy(true);
+    dispose();
+    const plain = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.getElementById("d")!.dispatchEvent(plain);
+    expect(plain.defaultPrevented).toBe(false);
+  });
+});

--- a/src/app/contextMenuPolicy.ts
+++ b/src/app/contextMenuPolicy.ts
@@ -1,0 +1,60 @@
+/**
+ * Production WebView context-menu policy.
+ *
+ * Release builds must not expose browser chrome (Print / Reload / Inspect).
+ * Editable controls keep the platform text-editing affordances so copy/cut/paste
+ * still work via keyboard and, where the engine shows one, a native edit menu.
+ *
+ * Dev builds leave the default menu alone so Reload / DevTools stay available.
+ */
+
+const EDITABLE_SELECTOR = [
+  "input",
+  "textarea",
+  "select",
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+  '[role="textbox"]',
+].join(", ");
+
+/** True when the event target (or an ancestor) is a text-editing control. */
+export function isEditableContextTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const el = target.closest(EDITABLE_SELECTOR);
+  if (!el) return false;
+  if (el instanceof HTMLInputElement) {
+    // Buttons/checkboxes are "input" but not text-editing surfaces.
+    const type = (el.type || "text").toLowerCase();
+    return ![
+      "button",
+      "checkbox",
+      "radio",
+      "submit",
+      "reset",
+      "file",
+      "image",
+      "range",
+      "color",
+      "hidden",
+    ].includes(type);
+  }
+  return true;
+}
+
+/**
+ * Install the production policy. No-op when `enabled` is false (dev builds).
+ * Returns a disposer for tests.
+ */
+export function installContextMenuPolicy(enabled = !import.meta.env.DEV): () => void {
+  if (!enabled || typeof document === "undefined") {
+    return () => {};
+  }
+
+  const onContextMenu = (event: Event) => {
+    if (isEditableContextTarget(event.target)) return;
+    event.preventDefault();
+  };
+
+  document.addEventListener("contextmenu", onContextMenu, true);
+  return () => document.removeEventListener("contextmenu", onContextMenu, true);
+}

--- a/src/app/contextMenuPolicy.ts
+++ b/src/app/contextMenuPolicy.ts
@@ -11,17 +11,32 @@
 const EDITABLE_SELECTOR = [
   "input",
   "textarea",
-  "select",
   '[contenteditable=""]',
   '[contenteditable="true"]',
+  '[contenteditable="plaintext-only"]',
   '[role="textbox"]',
 ].join(", ");
 
+function eventTargetElement(target: EventTarget | null): Element | null {
+  if (target instanceof Text) return target.parentElement;
+  if (target instanceof Element) return target;
+  return null;
+}
+
 /** True when the event target (or an ancestor) is a text-editing control. */
 export function isEditableContextTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) return false;
-  const el = target.closest(EDITABLE_SELECTOR);
-  if (!el) return false;
+  const start = eventTargetElement(target);
+  if (!start) return false;
+  const el = start.closest(EDITABLE_SELECTOR);
+  if (!el) {
+    // Inherited contentEditable is not always reflected as an attribute match.
+    let node: Element | null = start;
+    while (node) {
+      if (node instanceof HTMLElement && node.isContentEditable) return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
   if (el instanceof HTMLInputElement) {
     // Buttons/checkboxes are "input" but not text-editing surfaces.
     const type = (el.type || "text").toLowerCase();
@@ -38,7 +53,13 @@ export function isEditableContextTarget(target: EventTarget | null): boolean {
       "hidden",
     ].includes(type);
   }
-  return true;
+  if (el instanceof HTMLTextAreaElement) return true;
+  if (el.getAttribute("role") === "textbox") return true;
+  // Prefer the live contentEditable flag; also honor the attribute so jsdom
+  // (and similar test envs where isContentEditable stays false) still match.
+  if (el instanceof HTMLElement && el.isContentEditable) return true;
+  const ce = el.getAttribute("contenteditable");
+  return ce === "" || ce === "true" || ce === "plaintext-only";
 }
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./app/App";
+import { installContextMenuPolicy } from "./app/contextMenuPolicy";
 import { ErrorBoundary } from "./app/ErrorBoundary";
 import { installGlobalErrorHandlers } from "./app/globalErrors";
 import { currentPlatform } from "./app/platform";
@@ -17,6 +18,9 @@ document.documentElement.dataset.platform = currentPlatform();
 // user gets one dark frame on every launch.
 document.documentElement.dataset.theme = resolveInitialTheme();
 installGlobalErrorHandlers();
+// Production WebViews: no browser Print/Reload menu; editable fields keep
+// copy/paste. Dev builds leave the default menu for Reload/DevTools.
+installContextMenuPolicy();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <ErrorBoundary>


### PR DESCRIPTION
Closes #144

## Summary

- Production WebViews install a capture-phase `contextmenu` policy that `preventDefault`s on non-editable surfaces (no Print / Reload / Inspect chrome).
- Editable controls (`input` text types, `textarea`, `contenteditable`, `role=textbox`) still allow copy/cut/paste.
- Dev builds leave the default menu enabled for Reload/DevTools.
- Dual-platform checklist: `docs/webview-context-menu.md`
- Unit tests: `src/app/contextMenuPolicy.test.ts`

## Validation

- [x] `npx vitest run src/app/contextMenuPolicy.test.ts`
- [x] `npm run check`
- [ ] Manual release-build checklist on Windows WebView2 + macOS WKWebView (see docs)

## Notes

Uses frontend policy (cross-platform, preserves keyboard shortcuts and AT). Does not globally disable accessibility menus.