### PR TITLE
fix(reliability): keep claimed operation leases valid for the full task lifetime

### DIFF
--- a/src-tauri/src/app/oplock.rs
+++ b/src-tauri/src/app/oplock.rs
@@ -62,7 +62,10 @@ struct ActiveOp {
     token: String,
     kind: OperationKind,
     started_unix: u64,
+    /// Detached tokens start unclaimed; the first successful `validate` claims them.
+    /// Claimed leases are not subject to wall-clock stale reclaim.
     detached: bool,
+    claimed: bool,
 }
 
 #[must_use = "持有 guard 才代表持有操作锁；提前 drop 会立即释放锁"]
@@ -162,14 +165,27 @@ impl OperationManager {
             .inner
             .lock()
             .map_err(|_| OperationError::Lock("operation mutex poisoned".to_string()))?;
-        self.reclaim_stale_detached(&mut inner)?;
-        match inner.active.as_ref() {
-            Some(active) if active.token == token.0 => Ok(()),
-            _ => {
-                log::warn!("operation token validation failed");
-                Err(OperationError::InvalidToken)
+        // Match+claim before stale reclaim so a live worker presenting a still-active
+        // token is never dropped mid-validate. Abandoned unclaimed tokens are only
+        // reclaimed on begin/is_busy/end (or validate of a non-matching token).
+        if let Some(active) = inner.active.as_mut() {
+            if active.token == token.0 {
+                // First successful validate claims a detached lease so long-running
+                // tasks are no longer reclaimed solely by wall-clock age.
+                if active.detached && !active.claimed {
+                    active.claimed = true;
+                    log::info!(
+                        "claimed detached operation lease kind={} token_prefix={}",
+                        active.kind.as_str(),
+                        token_prefix(&token.0)
+                    );
+                }
+                return Ok(());
             }
         }
+        self.reclaim_stale_detached(&mut inner)?;
+        log::warn!("operation token validation failed");
+        Err(OperationError::InvalidToken)
     }
 
     pub fn is_busy(&self) -> bool {
@@ -229,14 +245,18 @@ impl OperationManager {
             }
             let _ = write_lock_diagnostics(lock_file, kind, &token, started_unix);
         }
+        // Attached guards are claimed immediately; detached tokens stay unclaimed
+        // until the first successful `validate` (DetachedGuard path).
+        let claimed = !detached;
         inner.active = Some(ActiveOp {
             token: token.0.clone(),
             kind,
             started_unix,
             detached,
+            claimed,
         });
         log::info!(
-            "acquired operation lock kind={} token_prefix={} detached={detached}",
+            "acquired operation lock kind={} token_prefix={} detached={detached} claimed={claimed}",
             kind.as_str(),
             token_prefix(&token.0)
         );
@@ -277,10 +297,10 @@ impl OperationManager {
     }
 
     fn reclaim_stale_detached(&self, inner: &mut Inner) -> Result<(), OperationError> {
-        if let Some(active) = self.stale_detached(inner) {
+        if let Some(active) = self.stale_unclaimed_detached(inner) {
             let age_secs = now_unix().saturating_sub(active.started_unix);
             log::info!(
-                "reclaiming stale detached operation kind={} age_secs={age_secs}",
+                "reclaiming stale unclaimed detached operation kind={} age_secs={age_secs}",
                 active.kind.as_str()
             );
             Self::unlock_lock_file(inner)?;
@@ -289,9 +309,12 @@ impl OperationManager {
         Ok(())
     }
 
-    fn stale_detached<'a>(&self, inner: &'a Inner) -> Option<&'a ActiveOp> {
+    /// Only unclaimed detached tokens expire by wall-clock age.
+    /// Claimed leases remain valid for the full task lifetime until `end`/Drop.
+    fn stale_unclaimed_detached<'a>(&self, inner: &'a Inner) -> Option<&'a ActiveOp> {
         inner.active.as_ref().filter(|active| {
             active.detached
+                && !active.claimed
                 && now_unix().saturating_sub(active.started_unix) >= self.stale_after_secs
         })
     }
@@ -401,13 +424,132 @@ mod tests {
     }
 
     #[test]
-    fn detached_token_times_out_and_allows_new_begin() {
-        let path = lock_path("timeout");
+    fn unclaimed_detached_past_stale_can_be_reclaimed() {
+        let path = lock_path("unclaimed-timeout");
         let manager = OperationManager::new_with_stale_after(path.clone(), 0);
-        let _token = manager.begin_detached(OperationKind::Update).unwrap();
+        let token = manager.begin_detached(OperationKind::Update).unwrap();
 
+        // Unclaimed + past stale: reclaim allows a new begin.
         let guard = manager.begin(OperationKind::Install).unwrap();
         assert_eq!(guard.kind(), OperationKind::Install);
+        // Original unclaimed token is gone after reclaim.
+        assert!(matches!(
+            manager.validate(&token),
+            Err(OperationError::InvalidToken)
+        ));
+        assert!(matches!(
+            manager.end(token),
+            Err(OperationError::InvalidToken)
+        ));
+
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn claimed_detached_past_stale_is_not_reclaimed() {
+        let path = lock_path("claimed-no-timeout");
+        let manager = OperationManager::new_with_stale_after(path.clone(), 0);
+        let token = manager.begin_detached(OperationKind::Update).unwrap();
+
+        // Claim via validate before any reclaim path runs with a zero threshold.
+        manager.validate(&token).unwrap();
+
+        // Past wall-clock stale threshold, but claimed → still busy / blocked.
+        assert!(manager.is_busy());
+        assert!(matches!(
+            manager.begin(OperationKind::Install),
+            Err(OperationError::BusySameProcess("update"))
+        ));
+        assert!(matches!(
+            manager.begin_detached(OperationKind::Uninstall),
+            Err(OperationError::BusySameProcess("update"))
+        ));
+        // Lease remains valid under the original token.
+        manager.validate(&token).unwrap();
+
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn validate_claims_detached_and_rejects_wrong_token() {
+        let path = lock_path("claim-validate");
+        // Non-zero stale so a wrong-token validate does not reclaim the unclaimed op.
+        let manager = OperationManager::new_with_stale_after(path.clone(), 60);
+        let token = manager.begin_detached(OperationKind::Adopt).unwrap();
+
+        assert!(matches!(
+            manager.validate(&OperationToken("wrong".to_string())),
+            Err(OperationError::InvalidToken)
+        ));
+        // Wrong token must not claim or clear the unclaimed op.
+        assert!(manager.is_busy());
+
+        manager.validate(&token).unwrap();
+        // Second validate is a no-op success after claim.
+        manager.validate(&token).unwrap();
+
+        assert!(matches!(
+            manager.begin(OperationKind::Install),
+            Err(OperationError::BusySameProcess("adopt"))
+        ));
+
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn end_releases_claimed_detached_lease() {
+        let path = lock_path("end-claimed");
+        let manager = OperationManager::new_with_stale_after(path.clone(), 0);
+        let token = manager.begin_detached(OperationKind::Install).unwrap();
+        manager.validate(&token).unwrap();
+
+        manager.end(token.clone()).unwrap();
+        assert!(!manager.is_busy());
+        assert!(matches!(
+            manager.validate(&token),
+            Err(OperationError::InvalidToken)
+        ));
+        assert!(manager.begin(OperationKind::Update).is_ok());
+
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn drop_path_releases_claimed_detached_via_end() {
+        // Mirrors DetachedGuard: validate claims, Drop ends.
+        let path = lock_path("drop-claimed");
+        let manager = OperationManager::new_with_stale_after(path.clone(), 0);
+        let token = manager.begin_detached(OperationKind::Update).unwrap();
+        manager.validate(&token).unwrap();
+
+        // Simulate DetachedGuard Drop.
+        manager.end(token).unwrap();
+        assert!(!manager.is_busy());
+        let next = manager.begin_detached(OperationKind::Install).unwrap();
+        assert!(manager.validate(&next).is_ok());
+        manager.end(next).unwrap();
+
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn concurrent_begin_while_claimed_is_blocked() {
+        let path = lock_path("concurrent-claimed");
+        let manager = OperationManager::new(path.clone());
+        let token = manager.begin_detached(OperationKind::Update).unwrap();
+        manager.validate(&token).unwrap();
+
+        assert!(matches!(
+            manager.begin(OperationKind::Install),
+            Err(OperationError::BusySameProcess("update"))
+        ));
+        assert!(matches!(
+            manager.begin_detached(OperationKind::Uninstall),
+            Err(OperationError::BusySameProcess("update"))
+        ));
+
+        manager.end(token).unwrap();
+        assert!(manager.begin(OperationKind::Install).is_ok());
 
         let _ = fs::remove_dir_all(path.parent().unwrap());
     }

--- a/src-tauri/src/app/oplock.rs
+++ b/src-tauri/src/app/oplock.rs
@@ -66,6 +66,10 @@ struct ActiveOp {
     /// Claimed leases are not subject to wall-clock stale reclaim.
     detached: bool,
     claimed: bool,
+    /// Number of live `validate` holders (DetachedGuard instances). `end` only
+    /// unlocks when the last holder releases, so concurrent guards cannot free
+    /// the lock while another worker still thinks it owns the lease.
+    holders: u32,
 }
 
 #[must_use = "持有 guard 才代表持有操作锁；提前 drop 会立即释放锁"]
@@ -140,24 +144,37 @@ impl OperationManager {
             .inner
             .lock()
             .map_err(|_| OperationError::Lock("operation mutex poisoned".to_string()))?;
-        self.reclaim_stale_detached(&mut inner)?;
-        let Some(active) = inner.active.as_ref() else {
-            log::warn!("end_operation received invalid token");
-            return Err(OperationError::InvalidToken);
-        };
-        if active.token != token.0 {
-            log::warn!("end_operation received mismatched token");
-            return Err(OperationError::InvalidToken);
+        // Matching token: release a holder (and unlock only on the last one)
+        // BEFORE stale reclaim, so an unclaimed-but-expired correct token still
+        // ends cleanly instead of self-reclaiming into InvalidToken.
+        if let Some(active) = inner.active.as_mut() {
+            if active.token == token.0 {
+                let active_kind = active.kind;
+                if active.holders > 0 {
+                    active.holders -= 1;
+                }
+                if active.holders > 0 {
+                    log::debug!(
+                        "released operation lease holder kind={} remaining={} token_prefix={}",
+                        active_kind.as_str(),
+                        active.holders,
+                        token_prefix(&token.0)
+                    );
+                    return Ok(());
+                }
+                Self::unlock_lock_file(&mut inner)?;
+                log::info!(
+                    "ended operation lock kind={} token_prefix={}",
+                    active_kind.as_str(),
+                    token_prefix(&token.0)
+                );
+                inner.active.take();
+                return Ok(());
+            }
         }
-        let active_kind = active.kind;
-        Self::unlock_lock_file(&mut inner)?;
-        log::info!(
-            "ended operation lock kind={} token_prefix={}",
-            active_kind.as_str(),
-            token_prefix(&token.0)
-        );
-        inner.active.take();
-        Ok(())
+        self.reclaim_stale_detached(&mut inner)?;
+        log::warn!("end_operation received invalid token");
+        Err(OperationError::InvalidToken)
     }
 
     pub fn validate(&self, token: &OperationToken) -> Result<(), OperationError> {
@@ -180,6 +197,7 @@ impl OperationManager {
                         token_prefix(&token.0)
                     );
                 }
+                active.holders = active.holders.saturating_add(1);
                 return Ok(());
             }
         }
@@ -254,6 +272,7 @@ impl OperationManager {
             started_unix,
             detached,
             claimed,
+            holders: 0,
         });
         log::info!(
             "acquired operation lock kind={} token_prefix={} detached={detached} claimed={claimed}",
@@ -485,13 +504,18 @@ mod tests {
         assert!(manager.is_busy());
 
         manager.validate(&token).unwrap();
-        // Second validate is a no-op success after claim.
+        // Second validate adds another holder (concurrent DetachedGuard) — still busy.
         manager.validate(&token).unwrap();
 
         assert!(matches!(
             manager.begin(OperationKind::Install),
             Err(OperationError::BusySameProcess("adopt"))
         ));
+        // First end only drops one holder; lock stays until the last end.
+        manager.end(token.clone()).unwrap();
+        assert!(manager.is_busy());
+        manager.end(token).unwrap();
+        assert!(!manager.is_busy());
 
         let _ = fs::remove_dir_all(path.parent().unwrap());
     }


### PR DESCRIPTION
Tracks #145

## Summary

Long-running detached operations (install/update/download) no longer lose their operation lock after the ~5 minute wall-clock stale timeout once a worker has claimed the token.

### Design

1. **Unclaimed vs claimed leases** — `ActiveOp` now tracks `claimed`.
2. **`begin_detached`** creates an **unclaimed** detached op.
3. **First successful `validate(token)`** (DetachedGuard path) **claims** the lease.
4. **Stale reclaim** (`reclaim_stale_detached`) applies **only to unclaimed** detached tokens.
5. **Claimed leases** stay valid for the full task lifetime until `end` / DetachedGuard Drop (RAII on success/failure/cancel/panic).
6. Lock conflicts still surface as structured `OperationError` variants: `BusySameProcess`, `BusyOtherProcess`, `InvalidToken`.

### Code

- `src-tauri/src/app/oplock.rs` — claim model + expanded unit tests
- DetachedGuard in `commands.rs` already validates then ends on Drop; no command-layer API change required

## Tests

```
cargo test --lib app::oplock
# 9 passed
```

Coverage includes:
- unclaimed detached past stale → reclaim / new begin allowed
- claimed detached past stale → not reclaimed; concurrent begin → BusySameProcess
- claim via validate; wrong token → InvalidToken
- end/Drop releases claimed lease
- concurrent begin while claimed blocked
- existing attached-guard + cross-process lock tests

## Checklist

- [x] token → active lease claim model
- [x] RAII release (end / DetachedGuard Drop)
- [x] claimed leases not wall-clock expired
- [x] stale timeout only for unclaimed detached tokens
- [x] stable structured lock conflict errors
- [x] unit tests for claim / reclaim / concurrent begin

## Validation

- `cargo test --lib app::oplock` — 9 passed