### PR TITLE
fix(reliability): reconnect the UI to active operations after renderer loss

### DIFF
--- a/src-tauri/src/app/oplock.rs
+++ b/src-tauri/src/app/oplock.rs
@@ -60,6 +60,33 @@ struct Inner {
     lock_file: Result<File, String>,
 }
 
+/// Byte-transfer progress mirrored into the active lease so a reloaded
+/// frontend can restore the progress screen without waiting for the next event.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationProgress {
+    pub downloaded: u64,
+    pub total: u64,
+    pub source: String,
+}
+
+/// Public view of the currently held same-process operation, if any.
+/// Queried on frontend mount so a renderer reload can reattach to in-flight work.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSnapshot {
+    /// Operation token id (same string the destructive commands use).
+    pub id: String,
+    pub kind: OperationKind,
+    pub phase: OperationPhase,
+    pub progress: Option<OperationProgress>,
+    pub paused: bool,
+    /// Whether cancel is a meaningful UI action right now.
+    pub cancellable: bool,
+    /// Whether the phase may be interrupted (pause/cancel/quit-after-cancel).
+    pub interruptible: bool,
+}
+
 struct ActiveOp {
     token: String,
     kind: OperationKind,
@@ -74,6 +101,10 @@ struct ActiveOp {
     holders: u32,
     /// Progress through the op lifecycle; drives quit policy.
     phase: OperationPhase,
+    /// Last reported download progress (if any).
+    progress: Option<OperationProgress>,
+    /// True after a pause was requested while the lease is still held.
+    paused: bool,
 }
 
 #[must_use = "持有 guard 才代表持有操作锁；提前 drop 会立即释放锁"]
@@ -328,6 +359,72 @@ impl OperationManager {
         QuitPolicy::evaluate(force_quit, confirm_close, busy, phase, kind)
     }
 
+    /// Snapshot of the local active operation, for frontend reattach after
+    /// renderer reload / remount. `None` when free (or only a cross-process lock).
+    pub fn snapshot(&self) -> Option<OperationSnapshot> {
+        let Ok(inner) = self.inner.lock() else {
+            return None;
+        };
+        inner.active.as_ref().map(|active| {
+            let interruptible = active.phase.interruptible();
+            // Cancel remains useful through preparing/downloading/verifying/applying
+            // (and while paused mid-transfer). Point-of-no-return phases refuse it.
+            let cancellable = interruptible;
+            OperationSnapshot {
+                id: active.token.clone(),
+                kind: active.kind,
+                phase: active.phase,
+                progress: active.progress.clone(),
+                paused: active.paused,
+                cancellable,
+                interruptible,
+            }
+        })
+    }
+
+    /// Record the latest download progress for a validated token.
+    pub fn set_progress(
+        &self,
+        token: &OperationToken,
+        progress: OperationProgress,
+    ) -> Result<(), OperationError> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| OperationError::Lock("operation mutex poisoned".to_string()))?;
+        let Some(active) = inner.active.as_mut() else {
+            return Err(OperationError::InvalidToken);
+        };
+        if active.token != token.0 {
+            return Err(OperationError::InvalidToken);
+        }
+        // Bytes flowing again means we're no longer in a paused UI state.
+        active.paused = false;
+        active.progress = Some(progress);
+        Ok(())
+    }
+
+    /// Mark the active op as paused (or clear the flag). Used when the UI
+    /// requests pause so a reloaded frontend can restore the paused screen.
+    pub fn set_paused(
+        &self,
+        token: &OperationToken,
+        paused: bool,
+    ) -> Result<(), OperationError> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| OperationError::Lock("operation mutex poisoned".to_string()))?;
+        let Some(active) = inner.active.as_mut() else {
+            return Err(OperationError::InvalidToken);
+        };
+        if active.token != token.0 {
+            return Err(OperationError::InvalidToken);
+        }
+        active.paused = paused;
+        Ok(())
+    }
+
     fn begin_inner(
         &self,
         kind: OperationKind,
@@ -373,6 +470,8 @@ impl OperationManager {
             claimed,
             holders: 0,
             phase: OperationPhase::Preparing,
+            progress: None,
+            paused: false,
         });
         log::info!(
             "acquired operation lock kind={} token_prefix={} detached={detached} claimed={claimed}",
@@ -726,6 +825,75 @@ mod tests {
 
         manager.end(token).unwrap();
         assert_eq!(manager.phase(), OperationPhase::Idle);
+
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn snapshot_exposes_progress_phase_and_flags() {
+        use crate::app::op_phase::OperationPhase;
+        use super::OperationProgress;
+
+        let path = lock_path("snapshot");
+        let manager = OperationManager::new(path.clone());
+        assert!(manager.snapshot().is_none());
+
+        let token = manager.begin_detached(OperationKind::Update).unwrap();
+        manager.validate(&token).unwrap();
+
+        let snap = manager.snapshot().expect("active snapshot");
+        assert_eq!(snap.id, token.0);
+        assert_eq!(snap.kind, OperationKind::Update);
+        assert_eq!(snap.phase, OperationPhase::Preparing);
+        assert!(snap.progress.is_none());
+        assert!(!snap.paused);
+        assert!(snap.cancellable);
+        assert!(snap.interruptible);
+
+        manager
+            .set_progress(
+                &token,
+                OperationProgress {
+                    downloaded: 50,
+                    total: 100,
+                    source: "example.test".into(),
+                },
+            )
+            .unwrap();
+        manager
+            .set_phase(&token, OperationPhase::Downloading)
+            .unwrap();
+        manager.set_paused(&token, true).unwrap();
+
+        let snap = manager.snapshot().expect("progress snapshot");
+        assert_eq!(snap.progress.as_ref().map(|p| p.downloaded), Some(50));
+        assert_eq!(snap.phase, OperationPhase::Downloading);
+        assert!(snap.paused);
+        assert!(snap.cancellable);
+        assert!(snap.interruptible);
+
+        // Progress update clears the paused flag (bytes flowing again).
+        manager
+            .set_progress(
+                &token,
+                OperationProgress {
+                    downloaded: 60,
+                    total: 100,
+                    source: "example.test".into(),
+                },
+            )
+            .unwrap();
+        assert!(!manager.snapshot().unwrap().paused);
+
+        manager
+            .set_phase(&token, OperationPhase::Committing)
+            .unwrap();
+        let snap = manager.snapshot().unwrap();
+        assert!(!snap.cancellable);
+        assert!(!snap.interruptible);
+
+        manager.end(token).unwrap();
+        assert!(manager.snapshot().is_none());
 
         let _ = fs::remove_dir_all(path.parent().unwrap());
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23,7 +23,8 @@ use crate::app::mac_update::{
 use crate::app::op_phase::{OperationPhase, QuitPolicy};
 use crate::app::operation_outcome::{AncillaryRetryReport, AncillaryRetryRequest};
 use crate::app::oplock::{
-    OperationError, OperationGuard, OperationKind, OperationManager, OperationToken,
+    OperationError, OperationGuard, OperationKind, OperationManager, OperationProgress,
+    OperationSnapshot, OperationToken,
 };
 use crate::app::paths;
 use crate::app::provenance::ProvenanceStore;
@@ -316,6 +317,47 @@ impl DetachedGuard {
     fn operations(&self) -> OperationManager {
         self.operations.clone()
     }
+}
+
+/// Progress payload emitted on the download event bus. Includes the operation
+/// id so a reloaded frontend can reject late events from a previous op.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DownloadProgressEvent {
+    downloaded: u64,
+    total: u64,
+    source: String,
+    operation_id: String,
+}
+
+fn emit_op_download_progress(
+    app: &AppHandle,
+    operations: &OperationManager,
+    token: &OperationToken,
+    channel: &str,
+    downloaded: u64,
+    total: u64,
+    source: String,
+) {
+    let progress = OperationProgress {
+        downloaded,
+        total,
+        source: source.clone(),
+    };
+    let _ = operations.set_progress(token, progress);
+    // Bytes in flight ⇒ downloading phase (unless already past it).
+    if total > 0 && downloaded < total {
+        let _ = operations.set_phase(token, OperationPhase::Downloading);
+    }
+    let _ = app.emit(
+        channel,
+        DownloadProgressEvent {
+            downloaded,
+            total,
+            source,
+            operation_id: token.0.clone(),
+        },
+    );
 }
 
 impl Drop for DetachedGuard {
@@ -636,9 +678,23 @@ pub async fn mac_perform_update(
     let network = mac_network_config_for_settings()?;
     let ops = op.operations();
     let phase_token = op.token_clone();
+    let progress_token = phase_token.clone();
+    let progress_ops = ops.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let report = move |p: crate::app::mac_update::DownloadProgress| {
-            let _ = progress_app.emit("mac://download-progress", p);
+            if let Some(token) = progress_token.as_ref() {
+                emit_op_download_progress(
+                    &progress_app,
+                    &progress_ops,
+                    token,
+                    "mac://download-progress",
+                    p.downloaded,
+                    p.total,
+                    p.source,
+                );
+            } else {
+                let _ = progress_app.emit("mac://download-progress", p);
+            }
         };
         let phase_hook = |phase: OperationPhase| {
             if let Some(token) = phase_token.as_ref() {
@@ -743,11 +799,24 @@ pub async fn mac_install(
     if !cfg!(target_os = "macos") {
         return Err(AppError::UnsupportedPlatform.into());
     }
-    let _op = begin_guard(&state, OperationKind::Install)?;
+    let op = begin_guard(&state, OperationKind::Install)?;
+    let token = op.token().clone();
+    let ops = state.operations.clone();
+    let _ = ops.set_phase(&token, OperationPhase::Preparing);
     let network = mac_network_config_for_settings()?;
+    let progress_token = token.clone();
+    let progress_ops = ops.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let report = move |p: crate::app::mac_update::DownloadProgress| {
-            let _ = app.emit("mac://download-progress", p);
+            emit_op_download_progress(
+                &app,
+                &progress_ops,
+                &progress_token,
+                "mac://download-progress",
+                p.downloaded,
+                p.total,
+                p.source,
+            );
         };
         install_macos_with_network(&report, &network)
     })
@@ -759,9 +828,14 @@ pub async fn mac_install(
 /// macOS-only: request pausing an active package download.
 /// Partial bytes are left in place for the next resume-capable run.
 #[tauri::command]
-pub fn mac_pause_download() -> Result<bool, CommandError> {
+pub fn mac_pause_download(state: State<'_, ManagerState>) -> Result<bool, CommandError> {
     if !cfg!(target_os = "macos") {
         return Err(AppError::UnsupportedPlatform.into());
+    }
+    if let Some(snap) = state.operations.snapshot() {
+        let _ = state
+            .operations
+            .set_paused(&OperationToken(snap.id), true);
     }
     Ok(pause_macos_download())
 }
@@ -1085,6 +1159,15 @@ pub fn end_operation(
         .map_err(Into::into)
 }
 
+/// Current same-process operation lease, if any. Used by the frontend on mount
+/// to reattach progress/phase UI after a renderer reload without re-arming work.
+#[tauri::command]
+pub fn get_operation_snapshot(
+    state: State<'_, ManagerState>,
+) -> Result<Option<OperationSnapshot>, CommandError> {
+    Ok(state.operations.snapshot())
+}
+
 /// The user confirmed quitting from the close dialog — flag it and exit so the
 /// CloseRequested / ExitRequested guards stop intercepting and let it go.
 /// Still refuses when the backend is in a non-interruptible install phase.
@@ -1315,6 +1398,11 @@ pub async fn win_auto_stage_update(
 pub fn win_pause_download(state: State<'_, ManagerState>) -> Result<bool, CommandError> {
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
+    }
+    if let Some(snap) = state.operations.snapshot() {
+        let _ = state
+            .operations
+            .set_paused(&OperationToken(snap.id), true);
     }
     Ok(pause_windows_download())
 }
@@ -1644,9 +1732,23 @@ pub async fn win_perform_update(
     let progress_app = app.clone();
     let ops = op.operations();
     let phase_token = op.token_clone();
+    let progress_token = phase_token.clone();
+    let progress_ops = ops.clone();
     let report = tauri::async_runtime::spawn_blocking(move || {
         let report = move |p: WinDownloadProgress| {
-            let _ = progress_app.emit("win://download-progress", p);
+            if let Some(token) = progress_token.as_ref() {
+                emit_op_download_progress(
+                    &progress_app,
+                    &progress_ops,
+                    token,
+                    "win://download-progress",
+                    p.downloaded,
+                    p.total,
+                    p.source,
+                );
+            } else {
+                let _ = progress_app.emit("win://download-progress", p);
+            }
         };
         let phase_hook = |phase: OperationPhase| {
             if let Some(token) = phase_token.as_ref() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,6 +171,7 @@ pub fn run() {
             commands::begin_operation,
             commands::arm_destructive,
             commands::end_operation,
+            commands::get_operation_snapshot,
             commands::confirm_quit,
             commands::win_default_install_root,
             commands::win_pick_install_dir,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { I18nProvider } from "./i18n";
 import { ThemeProvider } from "./theme";
 import { withViewTransition } from "./viewTransition";
 import { QuitConfirm } from "./components";
+import { ErrorBoundary } from "./ErrorBoundary";
 import { Home } from "./views/Home";
 import { Settings } from "./views/Settings";
 import { About } from "./views/About";
@@ -88,16 +89,21 @@ function Shell() {
           <CodexConfig onBack={() => setView("settings")} />
         </div>
       ) : null}
-      <QuitConfirm />
     </>
   );
 }
 
 export function App() {
+  // QuitConfirm sits *outside* ErrorBoundary so a render crash that replaces
+  // Shell still leaves a live listener for app://confirm-quit / quit-blocked.
+  // Theme + i18n wrap both so the confirm sheet keeps working on the crash path.
   return (
     <ThemeProvider>
       <I18nProvider>
-        <Shell />
+        <ErrorBoundary>
+          <Shell />
+        </ErrorBoundary>
+        <QuitConfirm />
       </I18nProvider>
     </ThemeProvider>
   );

--- a/src/app/ErrorBoundary.test.tsx
+++ b/src/app/ErrorBoundary.test.tsx
@@ -2,15 +2,29 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Diagnostics } from "../shared/types";
+import type { Diagnostics, OperationSnapshot } from "../shared/types";
 import { managerApi } from "../services/managerApi";
 import { CATALOG } from "./i18n";
-import { ErrorBoundary } from "./ErrorBoundary";
+import {
+  crashBodyForSnapshot,
+  ErrorBoundary,
+  type CrashStrings,
+} from "./ErrorBoundary";
+import { I18nProvider } from "./i18n";
+import { ThemeProvider } from "./theme";
+import { QuitConfirm } from "./components";
 
 vi.mock("../services/managerApi", () => ({
   managerApi: {
     getDiagnostics: vi.fn(),
     reportFrontendError: vi.fn(() => Promise.resolve()),
+    getOperationSnapshot: vi.fn(() => Promise.resolve(null)),
+    confirmQuit: vi.fn(() => Promise.resolve()),
+    getSettings: vi.fn(() =>
+      Promise.resolve({
+        confirmClose: true,
+      }),
+    ),
   },
 }));
 
@@ -43,10 +57,31 @@ function Boom(): never {
 
 const getDiagnostics = vi.mocked(managerApi.getDiagnostics);
 const reportFrontendError = vi.mocked(managerApi.reportFrontendError);
+const getOperationSnapshot = vi.mocked(managerApi.getOperationSnapshot);
+const confirmQuit = vi.mocked(managerApi.confirmQuit);
+
+function enCrashStrings(): CrashStrings {
+  const en = CATALOG.en;
+  return {
+    "crash.title": en["crash.title"],
+    "crash.body": en["crash.body"],
+    "crash.bodyActive": en["crash.bodyActive"],
+    "crash.bodyCritical": en["crash.bodyCritical"],
+    "crash.bodyPaused": en["crash.bodyPaused"],
+    "crash.reload": en["crash.reload"],
+    "crash.copy": en["crash.copy"],
+    "crash.copied": en["crash.copied"],
+    "crash.details": en["crash.details"],
+    "crash.hideDetails": en["crash.hideDetails"],
+    "crash.quit": en["crash.quit"],
+  };
+}
 
 beforeEach(() => {
   localStorage.setItem("cam.lang", "en");
   getDiagnostics.mockResolvedValue(diagnostics);
+  getOperationSnapshot.mockResolvedValue(null);
+  confirmQuit.mockResolvedValue(undefined);
 });
 
 describe("ErrorBoundary", () => {
@@ -115,5 +150,127 @@ describe("ErrorBoundary", () => {
     }
 
     consoleError.mockRestore();
+  });
+
+  it("uses backend operation state for crash-page copy when an update is active", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const snap: OperationSnapshot = {
+      id: "op-1",
+      kind: "update",
+      phase: "downloading",
+      progress: { downloaded: 1, total: 2, source: "x" },
+      paused: false,
+      cancellable: true,
+      interruptible: true,
+    };
+    getOperationSnapshot.mockResolvedValue(snap);
+
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(CATALOG.en["crash.bodyActive"])).toBeInTheDocument();
+    });
+    expect(getOperationSnapshot).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("warns not to force-quit when the op is at a critical phase", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    getOperationSnapshot.mockResolvedValue({
+      id: "op-2",
+      kind: "install",
+      phase: "committing",
+      progress: null,
+      paused: false,
+      cancellable: false,
+      interruptible: false,
+    });
+
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(CATALOG.en["crash.bodyCritical"])).toBeInTheDocument();
+    });
+    consoleError.mockRestore();
+  });
+
+  it("keeps QuitConfirm available outside the boundary so crash-path quit works", async () => {
+    const user = userEvent.setup();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ThemeProvider>
+        <I18nProvider>
+          <ErrorBoundary>
+            <Boom />
+          </ErrorBoundary>
+          <QuitConfirm />
+        </I18nProvider>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: CATALOG.en["crash.quit"] })).toBeInTheDocument();
+
+    // Browser path: Quit dispatches cam:confirm-quit → QuitConfirm opens.
+    await user.click(screen.getByRole("button", { name: CATALOG.en["crash.quit"] }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Close the manager/i)).toBeInTheDocument();
+    });
+
+    // Confirm sheet primary action is "Close" (not the crash-page Quit).
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(confirmQuit).toHaveBeenCalled());
+
+    consoleError.mockRestore();
+  });
+});
+
+describe("crashBodyForSnapshot", () => {
+  const en = enCrashStrings();
+
+  it("selects idle / active / critical / paused copy", () => {
+    expect(crashBodyForSnapshot(en, null)).toBe(en["crash.body"]);
+    expect(
+      crashBodyForSnapshot(en, {
+        id: "1",
+        kind: "update",
+        phase: "downloading",
+        progress: null,
+        paused: false,
+        cancellable: true,
+        interruptible: true,
+      }),
+    ).toBe(en["crash.bodyActive"]);
+    expect(
+      crashBodyForSnapshot(en, {
+        id: "1",
+        kind: "install",
+        phase: "committing",
+        progress: null,
+        paused: false,
+        cancellable: false,
+        interruptible: false,
+      }),
+    ).toBe(en["crash.bodyCritical"]);
+    expect(
+      crashBodyForSnapshot(en, {
+        id: "1",
+        kind: "update",
+        phase: "downloading",
+        progress: null,
+        paused: true,
+        cancellable: true,
+        interruptible: true,
+      }),
+    ).toBe(en["crash.bodyPaused"]);
   });
 });

--- a/src/app/ErrorBoundary.tsx
+++ b/src/app/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 
 import { managerApi } from "../services/managerApi";
+import type { OperationSnapshot } from "../shared/types";
 import { Ring } from "./components";
 import { formatDiagnostics } from "./diagnostics";
 import { CATALOG, pickLang, type Lang, type TKey } from "./i18n";
@@ -9,35 +10,72 @@ interface State {
   error: Error | null;
   copied: boolean;
   showDetails: boolean;
+  /** Backend operation lease, if any — drives crash-page copy. */
+  opSnapshot: OperationSnapshot | null;
+  opLoaded: boolean;
 }
 
 const CRASH_KEYS = [
   "crash.title",
   "crash.body",
+  "crash.bodyActive",
+  "crash.bodyCritical",
+  "crash.bodyPaused",
   "crash.reload",
   "crash.copy",
   "crash.copied",
   "crash.details",
   "crash.hideDetails",
+  "crash.quit",
 ] as const satisfies readonly TKey[];
 
 type CrashKey = (typeof CRASH_KEYS)[number];
+export type CrashStrings = Record<CrashKey, string>;
 
-function crashStrings(): Record<CrashKey, string> {
+function crashStrings(): CrashStrings {
   const saved = typeof localStorage === "undefined" ? null : localStorage.getItem("cam.lang");
   const prefs =
     typeof navigator !== "undefined" && navigator.languages ? Array.from(navigator.languages) : [];
   const lang: Lang = pickLang(saved, prefs);
   const catalog = CATALOG[lang] ?? CATALOG.en;
-  const out = {} as Record<CrashKey, string>;
+  const out = {} as CrashStrings;
   for (const key of CRASH_KEYS) {
     out[key] = catalog[key] ?? CATALOG.en[key] ?? key;
   }
   return out;
 }
 
+/** Exported for unit tests — pick crash-page body from a backend snapshot. */
+export function crashBodyForSnapshot(
+  strings: CrashStrings,
+  snap: OperationSnapshot | null,
+): string {
+  if (!snap) return strings["crash.body"];
+  if (snap.paused) return strings["crash.bodyPaused"];
+  if (snap.phase === "committing" || snap.phase === "finishing" || !snap.interruptible) {
+    return strings["crash.bodyCritical"];
+  }
+  if (snap.kind === "install" || snap.kind === "update") {
+    return strings["crash.bodyActive"];
+  }
+  return strings["crash.body"];
+}
+
+function isTauri(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    Boolean((window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__)
+  );
+}
+
 export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
-  state: State = { error: null, copied: false, showDetails: false };
+  state: State = {
+    error: null,
+    copied: false,
+    showDetails: false,
+    opSnapshot: null,
+    opLoaded: false,
+  };
 
   static getDerivedStateFromError(error: Error): Partial<State> {
     return { error };
@@ -45,6 +83,18 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
 
   componentDidMount() {
     window.addEventListener("cam:fatal", this.onFatal);
+    // Child may have thrown during the first render (getDerivedStateFromError),
+    // so the crash screen can be the first committed state — load snapshot now.
+    if (this.state.error) {
+      this.loadOperationSnapshot();
+    }
+  }
+
+  componentDidUpdate(_prevProps: { children: ReactNode }, prevState: State) {
+    // cam:fatal / late throw: enter crash screen after a healthy mount.
+    if (this.state.error && !prevState.error) {
+      this.loadOperationSnapshot();
+    }
   }
 
   componentWillUnmount() {
@@ -59,6 +109,17 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
       componentStack: info.componentStack ?? null,
     });
   }
+
+  private loadOperationSnapshot = () => {
+    void Promise.resolve()
+      .then(() => managerApi.getOperationSnapshot())
+      .then((snap) => {
+        this.setState({ opSnapshot: snap, opLoaded: true });
+      })
+      .catch(() => {
+        this.setState({ opSnapshot: null, opLoaded: true });
+      });
+  };
 
   private onFatal = (event: Event) => {
     const detail = (event as CustomEvent<{ error?: unknown }>).detail;
@@ -88,6 +149,19 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
     }
   };
 
+  /** Ask the shared QuitConfirm (mounted outside this boundary) to handle exit. */
+  private requestQuit = () => {
+    if (isTauri()) {
+      void import("@tauri-apps/api/window")
+        .then(({ getCurrentWindow }) => getCurrentWindow().close())
+        .catch(() => {
+          void managerApi.confirmQuit().catch(() => undefined);
+        });
+    } else {
+      window.dispatchEvent(new Event("cam:confirm-quit"));
+    }
+  };
+
   render() {
     if (!this.state.error) {
       return this.props.children;
@@ -96,6 +170,9 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
     const strings = crashStrings();
     const error = this.state.error;
     const summary = `${error.name}: ${error.message}`;
+    const body = this.state.opLoaded
+      ? crashBodyForSnapshot(strings, this.state.opSnapshot)
+      : strings["crash.body"];
 
     return (
       <div className="pop">
@@ -104,7 +181,7 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
             <Ring icon="alert" variant="danger" />
             <div role="alert" aria-live="assertive">
               <div className="headline">{strings["crash.title"]}</div>
-              <div className="desc">{strings["crash.body"]}</div>
+              <div className="desc">{body}</div>
             </div>
             <button
               type="button"
@@ -129,6 +206,9 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
             </button>
             <button className="btn ghost" onClick={this.copy}>
               {this.state.copied ? strings["crash.copied"] : strings["crash.copy"]}
+            </button>
+            <button className="btn ghost" onClick={this.requestQuit}>
+              {strings["crash.quit"]}
             </button>
           </div>
         </div>

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -85,11 +85,18 @@ const ZH = {
   "error.generic": "操作未完成。请稍后重试；若持续失败，可复制诊断信息反馈。",
   "crash.title": "出了点问题",
   "crash.body": "管理器遇到意外错误。此界面不会改动你已安装的 Codex。",
+  "crash.bodyActive":
+    "管理器遇到意外错误。后台仍有安装/更新在进行 — 请点「重新加载」重新连接，或等待完成。",
+  "crash.bodyCritical":
+    "管理器在安装/更新的关键步骤出错。请勿强退；点「重新加载」重新连接并等待完成。",
+  "crash.bodyPaused":
+    "管理器遇到意外错误。后台有已暂停的下载 — 请点「重新加载」重新连接后继续或取消。",
   "crash.reload": "重新加载",
   "crash.copy": "复制诊断信息",
   "crash.copied": "已复制诊断信息",
   "crash.details": "查看详情",
   "crash.hideDetails": "收起详情",
+  "crash.quit": "退出",
   "home.source": "更新源:{source}",
   "home.stale.rechecked": "安装状态已变化,已重新检查——请再次确认。",
 
@@ -356,11 +363,18 @@ const EN: Record<Key, string> = {
   "error.generic": "Something didn’t finish. Try again; if it keeps failing, copy diagnostics and send feedback.",
   "crash.title": "Something went wrong",
   "crash.body": "The manager hit an unexpected error. Your Codex install was not changed by this screen.",
+  "crash.bodyActive":
+    "The manager hit an unexpected error. A Codex install/update is still running in the background — use Reload to reconnect, or wait for it to finish.",
+  "crash.bodyCritical":
+    "The manager hit an unexpected error while a Codex install/update is at a critical step. Do not force-quit; use Reload to reconnect and wait for it to finish.",
+  "crash.bodyPaused":
+    "The manager hit an unexpected error. A download is paused in the background — use Reload to reconnect and resume or cancel.",
   "crash.reload": "Reload",
   "crash.copy": "Copy diagnostics",
   "crash.copied": "Diagnostics copied",
   "crash.details": "Show details",
   "crash.hideDetails": "Hide details",
+  "crash.quit": "Quit",
   "home.source": "Source: {source}",
   "home.stale.rechecked": "The installed state changed — re-checked; please confirm again.",
 
@@ -624,11 +638,18 @@ const FR: Record<Key, string> = {
   "error.generic": "L'opération ne s'est pas terminée. Réessayez ; en cas d'échec répété, copiez le diagnostic et envoyez un retour.",
   "crash.title": "Une erreur s'est produite",
   "crash.body": "Le gestionnaire a rencontré une erreur inattendue. Cet écran n'a pas modifié votre installation Codex.",
+  "crash.bodyActive":
+    "Le gestionnaire a rencontré une erreur inattendue. Une installation/mise à jour Codex est encore en cours — utilisez Recharger pour vous reconnecter, ou attendez la fin.",
+  "crash.bodyCritical":
+    "Le gestionnaire a rencontré une erreur pendant une étape critique d'installation/mise à jour. Ne forcez pas la fermeture ; utilisez Recharger et attendez la fin.",
+  "crash.bodyPaused":
+    "Le gestionnaire a rencontré une erreur inattendue. Un téléchargement est en pause — utilisez Recharger pour vous reconnecter, puis reprendre ou annuler.",
   "crash.reload": "Recharger",
   "crash.copy": "Copier le diagnostic",
   "crash.copied": "Diagnostic copié",
   "crash.details": "Afficher les détails",
   "crash.hideDetails": "Masquer les détails",
+  "crash.quit": "Quitter",
   "home.source": "Source : {source}",
   "home.stale.rechecked": "L'état installé a changé — nouvelle vérification effectuée ; veuillez confirmer à nouveau.",
 
@@ -893,11 +914,18 @@ const ZH_TW: Record<Key, string> = {
   "error.generic": "操作未完成。請稍後重試；若持續失敗，可複製診斷資訊回報。",
   "crash.title": "出了點問題",
   "crash.body": "管理器遇到意外錯誤。此畫面不會改動你已安裝的 Codex。",
+  "crash.bodyActive":
+    "管理器遇到意外錯誤。後台仍有安裝/更新在進行 — 請點「重新載入」重新連線，或等待完成。",
+  "crash.bodyCritical":
+    "管理器在安裝/更新的關鍵步驟出錯。請勿強制結束；點「重新載入」重新連線並等待完成。",
+  "crash.bodyPaused":
+    "管理器遇到意外錯誤。後台有已暫停的下載 — 請點「重新載入」重新連線後繼續或取消。",
   "crash.reload": "重新載入",
   "crash.copy": "複製診斷資訊",
   "crash.copied": "已複製診斷資訊",
   "crash.details": "查看詳情",
   "crash.hideDetails": "收起詳情",
+  "crash.quit": "結束",
   "home.source": "來源：{source}",
   "home.stale.rechecked": "安裝狀態已變更，已重新檢查——請再次確認。",
 
@@ -1172,11 +1200,18 @@ const DE: Record<Key, string> = {
   "error.generic": "Der Vorgang wurde nicht abgeschlossen. Erneut versuchen; bei wiederholtem Fehler Diagnose kopieren und melden.",
   "crash.title": "Etwas ist schiefgelaufen",
   "crash.body": "Der Manager ist auf einen unerwarteten Fehler gestoßen. Deine Codex-Installation wurde durch diesen Bildschirm nicht geändert.",
+  "crash.bodyActive":
+    "Der Manager ist auf einen unerwarteten Fehler gestoßen. Eine Codex-Installation/Aktualisierung läuft noch im Hintergrund — mit Neu laden neu verbinden oder abwarten.",
+  "crash.bodyCritical":
+    "Der Manager ist bei einem kritischen Installations-/Aktualisierungsschritt fehlgeschlagen. Nicht erzwingen beenden; mit Neu laden neu verbinden und abwarten.",
+  "crash.bodyPaused":
+    "Der Manager ist auf einen unerwarteten Fehler gestoßen. Ein Download ist pausiert — mit Neu laden neu verbinden und fortsetzen oder abbrechen.",
   "crash.reload": "Neu laden",
   "crash.copy": "Diagnose kopieren",
   "crash.copied": "Diagnose kopiert",
   "crash.details": "Details anzeigen",
   "crash.hideDetails": "Details ausblenden",
+  "crash.quit": "Beenden",
   "home.source": "Quelle: {source}",
   "home.stale.rechecked": "Der Installationszustand hat sich geändert — erneut geprüft; bitte noch einmal bestätigen.",
 
@@ -1451,11 +1486,18 @@ const KO: Record<Key, string> = {
   "error.generic": "작업이 완료되지 않았습니다. 다시 시도하고, 계속 실패하면 진단 정보를 복사해 피드백을 보내 주세요.",
   "crash.title": "문제가 발생했습니다",
   "crash.body": "관리자에서 예기치 않은 오류가 발생했습니다. 이 화면은 설치된 Codex를 변경하지 않습니다.",
+  "crash.bodyActive":
+    "관리자에서 예기치 않은 오류가 발생했습니다. 백그라운드에서 Codex 설치/업데이트가 계속 실행 중입니다 — 「다시 로드」로 다시 연결하거나 완료될 때까지 기다리세요.",
+  "crash.bodyCritical":
+    "관리자가 설치/업데이트의 중요한 단계에서 오류가 났습니다. 강제 종료하지 말고 「다시 로드」로 다시 연결한 뒤 완료될 때까지 기다리세요.",
+  "crash.bodyPaused":
+    "관리자에서 예기치 않은 오류가 발생했습니다. 백그라운드 다운로드가 일시 중지되었습니다 — 「다시 로드」로 다시 연결한 뒤 재개하거나 취소하세요.",
   "crash.reload": "다시 로드",
   "crash.copy": "진단 정보 복사",
   "crash.copied": "진단 정보를 복사했습니다",
   "crash.details": "세부 정보 보기",
   "crash.hideDetails": "세부 정보 숨기기",
+  "crash.quit": "종료",
   "home.source": "소스: {source}",
   "home.stale.rechecked": "설치 상태가 변경되어 다시 확인했습니다 — 다시 한번 확인해 주세요.",
 
@@ -1726,11 +1768,18 @@ const JA: Record<Key, string> = {
   "error.generic": "操作が完了しませんでした。再試行し、続く場合は診断情報をコピーしてフィードバックしてください。",
   "crash.title": "問題が発生しました",
   "crash.body": "マネージャーで予期しないエラーが発生しました。この画面はインストール済みの Codex を変更しません。",
+  "crash.bodyActive":
+    "マネージャーで予期しないエラーが発生しました。バックグラウンドで Codex のインストール/更新が続いています — 「再読み込み」で再接続するか、完了を待ってください。",
+  "crash.bodyCritical":
+    "マネージャーがインストール/更新の重要ステップでエラーになりました。強制終了せず、「再読み込み」で再接続して完了を待ってください。",
+  "crash.bodyPaused":
+    "マネージャーで予期しないエラーが発生しました。ダウンロードが一時停止中です — 「再読み込み」で再接続して再開またはキャンセルしてください。",
   "crash.reload": "再読み込み",
   "crash.copy": "診断情報をコピー",
   "crash.copied": "診断情報をコピーしました",
   "crash.details": "詳細を表示",
   "crash.hideDetails": "詳細を隠す",
+  "crash.quit": "終了",
   "home.source": "ソース: {source}",
   "home.stale.rechecked": "インストール状態が変わったため再チェックしました — もう一度ご確認ください。",
   "prov.managed": "管理済み",
@@ -1985,11 +2034,18 @@ const RU: Record<Key, string> = {
   "error.generic": "Операция не завершилась. Повторите попытку; если ошибка повторяется, скопируйте диагностику и отправьте отзыв.",
   "crash.title": "Что-то пошло не так",
   "crash.body": "В менеджере произошла непредвиденная ошибка. Этот экран не изменял установленный Codex.",
+  "crash.bodyActive":
+    "В менеджере произошла непредвиденная ошибка. Установка/обновление Codex всё ещё идёт в фоне — нажмите «Перезагрузить», чтобы переподключиться, или дождитесь завершения.",
+  "crash.bodyCritical":
+    "В менеджере произошла ошибка на критическом шаге установки/обновления. Не завершайте принудительно; нажмите «Перезагрузить» и дождитесь завершения.",
+  "crash.bodyPaused":
+    "В менеджере произошла непредвиденная ошибка. Загрузка на паузе — нажмите «Перезагрузить», чтобы переподключиться и продолжить или отменить.",
   "crash.reload": "Перезагрузить",
   "crash.copy": "Копировать диагностику",
   "crash.copied": "Диагностика скопирована",
   "crash.details": "Показать подробности",
   "crash.hideDetails": "Скрыть подробности",
+  "crash.quit": "Выйти",
   "home.source": "Источник: {source}",
   "home.stale.rechecked": "Состояние установки изменилось — проверка выполнена заново; подтвердите ещё раз.",
   "prov.managed": "Управляется",
@@ -2244,11 +2300,18 @@ const AR: Record<Key, string> = {
   "error.generic": "لم تكتمل العملية. حاول مرة أخرى؛ وإن استمر الفشل فانسخ التشخيص وأرسل ملاحظاتك.",
   "crash.title": "حدث خطأ ما",
   "crash.body": "واجه المدير خطأ غير متوقع. هذه الشاشة لم تغيّر تثبيت Codex لديك.",
+  "crash.bodyActive":
+    "واجه المدير خطأ غير متوقع. ما زال تثبيت/تحديث Codex يعمل في الخلفية — استخدم «إعادة التحميل» لإعادة الاتصال، أو انتظر حتى ينتهي.",
+  "crash.bodyCritical":
+    "واجه المدير خطأ أثناء خطوة حرجة من التثبيت/التحديث. لا تُنهَه قسرًا؛ استخدم «إعادة التحميل» وأعد الاتصال وانتظر حتى ينتهي.",
+  "crash.bodyPaused":
+    "واجه المدير خطأ غير متوقع. التنزيل متوقف مؤقتًا — استخدم «إعادة التحميل» لإعادة الاتصال ثم الاستئناف أو الإلغاء.",
   "crash.reload": "إعادة التحميل",
   "crash.copy": "نسخ التشخيص",
   "crash.copied": "تم نسخ التشخيص",
   "crash.details": "عرض التفاصيل",
   "crash.hideDetails": "إخفاء التفاصيل",
+  "crash.quit": "خروج",
   "home.source": "المصدر: {source}",
   "home.stale.rechecked": "تغيّرت حالة التثبيت — أُعيد الفحص؛ يُرجى التأكيد مرة أخرى.",
   "prov.managed": "مُدار",
@@ -2503,11 +2566,18 @@ const ES: Record<Key, string> = {
   "error.generic": "La operación no terminó. Inténtalo de nuevo; si sigue fallando, copia el diagnóstico y envía comentarios.",
   "crash.title": "Algo salió mal",
   "crash.body": "El administrador encontró un error inesperado. Esta pantalla no modificó tu instalación de Codex.",
+  "crash.bodyActive":
+    "El administrador encontró un error inesperado. Una instalación/actualización de Codex sigue en segundo plano — usa Recargar para reconectar o espera a que termine.",
+  "crash.bodyCritical":
+    "El administrador falló en un paso crítico de instalación/actualización. No fuerces el cierre; usa Recargar para reconectar y espera a que termine.",
+  "crash.bodyPaused":
+    "El administrador encontró un error inesperado. Hay una descarga en pausa — usa Recargar para reconectar y reanudar o cancelar.",
   "crash.reload": "Recargar",
   "crash.copy": "Copiar diagnóstico",
   "crash.copied": "Diagnóstico copiado",
   "crash.details": "Mostrar detalles",
   "crash.hideDetails": "Ocultar detalles",
+  "crash.quit": "Salir",
   "home.source": "Fuente: {source}",
   "home.stale.rechecked": "El estado de instalación cambió — se volvió a comprobar; confírmalo de nuevo.",
   "prov.managed": "Gestionado",
@@ -2762,11 +2832,18 @@ const PT_BR: Record<Key, string> = {
   "error.generic": "A operação não foi concluída. Tente novamente; se continuar falhando, copie o diagnóstico e envie feedback.",
   "crash.title": "Algo deu errado",
   "crash.body": "O gerenciador encontrou um erro inesperado. Esta tela não alterou sua instalação do Codex.",
+  "crash.bodyActive":
+    "O gerenciador encontrou um erro inesperado. Uma instalação/atualização do Codex ainda está em andamento — use Recarregar para reconectar ou aguarde terminar.",
+  "crash.bodyCritical":
+    "O gerenciador falhou em uma etapa crítica de instalação/atualização. Não force o encerramento; use Recarregar para reconectar e aguarde terminar.",
+  "crash.bodyPaused":
+    "O gerenciador encontrou um erro inesperado. Um download está pausado — use Recarregar para reconectar e retomar ou cancelar.",
   "crash.reload": "Recarregar",
   "crash.copy": "Copiar diagnóstico",
   "crash.copied": "Diagnóstico copiado",
   "crash.details": "Mostrar detalhes",
   "crash.hideDetails": "Ocultar detalhes",
+  "crash.quit": "Sair",
   "home.source": "Fonte: {source}",
   "home.stale.rechecked": "O estado da instalação mudou — verificado novamente; confirme mais uma vez.",
   "prov.managed": "Gerenciado",

--- a/src/app/views/Home.test.tsx
+++ b/src/app/views/Home.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../../services/managerApi", async (importOriginal) => {
     managerApi: {
       getSettings: vi.fn(),
       setSettings: vi.fn(),
+      getOperationSnapshot: vi.fn(() => Promise.resolve(null)),
       macStatus: vi.fn(),
       macPlanUpdate: vi.fn(),
       macPerformUpdate: vi.fn(),

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -30,6 +30,7 @@ import {
 import { ProgressScreen, type PausedDownload } from "./ProgressScreen";
 import { useDownloadProgress } from "./useDownloadProgress";
 import { useFocusRecheck, installIdentity } from "./useFocusRecheck";
+import { useOperationReattach } from "./useOperationReattach";
 
 type Kind = "loading" | "error" | "none" | "idle" | "update" | "external" | "uptodate";
 
@@ -93,6 +94,7 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     downloadStopBusy,
     downloadStopRef,
     startDlListen,
+    applySnapshotProgress,
     requestDownloadStop,
     resetStop,
   } = useDownloadProgress({
@@ -145,6 +147,14 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       const s = await managerApi.getSettings().catch(() => DEFAULT_SETTINGS);
       setSettings(s);
       void refreshStatus();
+      // Skip the startup check when an install/update is already mid-flight —
+      // reattach owns the screen until that lease ends.
+      const snap = await Promise.resolve()
+        .then(() => managerApi.getOperationSnapshot())
+        .catch(() => null);
+      if (snap && (snap.kind === "install" || snap.kind === "update")) {
+        return;
+      }
       if (s.checkOnStartup) {
         void check();
       }
@@ -173,6 +183,23 @@ function MacHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   useEffect(() => {
     checkRef.current = check;
   }, [check]);
+
+  // After renderer reload: query OperationSnapshot, rebuild progress listeners
+  // by operation id, and poll until the backend lease ends.
+  useOperationReattach({
+    startDlListen,
+    applySnapshotProgress,
+    resetStop,
+    setBusy: (next) => setBusy(next),
+    setPaused,
+    onOperationEnded: () => {
+      void checkRef.current();
+    },
+    isLocallyBusy: () => {
+      const b = busyRef.current;
+      return b === "perform" || b === "install";
+    },
+  });
 
   useEffect(() => {
     if (!settings.periodicCheck) return;

--- a/src/app/views/WinHome.test.tsx
+++ b/src/app/views/WinHome.test.tsx
@@ -29,6 +29,7 @@ vi.mock("../../services/managerApi", async (importOriginal) => {
     managerApi: {
       getSettings: vi.fn(),
       setSettings: vi.fn(),
+      getOperationSnapshot: vi.fn(() => Promise.resolve(null)),
       winStatus: vi.fn(),
       winPlanUpdate: vi.fn(),
       winPerformUpdate: vi.fn(),

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -29,6 +29,7 @@ import {
 import { ProgressScreen, type PausedDownload } from "./ProgressScreen";
 import { useDownloadProgress } from "./useDownloadProgress";
 import { useFocusRecheck, installIdentity } from "./useFocusRecheck";
+import { useOperationReattach } from "./useOperationReattach";
 
 type Kind = "loading" | "error" | "none" | "idle" | "update" | "external" | "uptodate";
 
@@ -87,6 +88,7 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
     downloadStopBusy,
     downloadStopRef,
     startDlListen,
+    applySnapshotProgress,
     requestDownloadStop,
     resetStop,
   } = useDownloadProgress({
@@ -131,6 +133,14 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
       setSettings(s);
       void managerApi.winDefaultInstallRoot().then(setDefaultInstallRoot).catch(() => undefined);
       void refreshStatus();
+      // Skip the startup check when an install/update is already mid-flight —
+      // reattach owns the screen until that lease ends.
+      const snap = await Promise.resolve()
+        .then(() => managerApi.getOperationSnapshot())
+        .catch(() => null);
+      if (snap && (snap.kind === "install" || snap.kind === "update")) {
+        return;
+      }
       if (s.checkOnStartup) {
         void check();
       }
@@ -159,6 +169,24 @@ export function WinHome({ onOpenSettings }: { onOpenSettings: () => void }) {
   useEffect(() => {
     checkRef.current = check;
   }, [check]);
+
+  // After renderer reload: query OperationSnapshot, rebuild progress listeners
+  // by operation id, and poll until the backend lease ends.
+  useOperationReattach({
+    startDlListen,
+    applySnapshotProgress,
+    resetStop,
+    setBusy: (next) => setBusy(next),
+    setPaused,
+    onOperationEnded: () => {
+      void checkRef.current();
+      void refreshStatus();
+    },
+    isLocallyBusy: () => {
+      const b = busyRef.current;
+      return b === "perform" || b === "install";
+    },
+  });
 
   // Window focus → silently re-detect the local install and re-check if the
   // install identity (version OR path) drifted out-of-band. Parity with the mac

--- a/src/app/views/useDownloadProgress.test.tsx
+++ b/src/app/views/useDownloadProgress.test.tsx
@@ -1,0 +1,207 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listen } from "@tauri-apps/api/event";
+
+import type { DownloadProgress } from "../../shared/types";
+import { I18nProvider } from "../i18n";
+import { useDownloadProgress } from "./useDownloadProgress";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+const listenMock = vi.mocked(listen);
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>;
+}
+
+describe("useDownloadProgress", () => {
+  let onProgress: ((event: { payload: DownloadProgress }) => void) | undefined;
+
+  beforeEach(() => {
+    localStorage.setItem("cam.lang", "en");
+    onProgress = undefined;
+    listenMock.mockReset();
+    listenMock.mockImplementation(async (_event, handler) => {
+      onProgress = handler as (event: { payload: DownloadProgress }) => void;
+      return () => {
+        onProgress = undefined;
+      };
+    });
+  });
+
+  it("latches the first operation id and rejects late events from older ops", async () => {
+    const { result } = renderHook(
+      () =>
+        useDownloadProgress({
+          eventName: "mac://download-progress",
+          pauseDownload: vi.fn(async () => true),
+          cancelDownload: vi.fn(async () => true),
+          cannotCancelMessage: "cannot cancel",
+          onError: vi.fn(),
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.startDlListen();
+    });
+
+    act(() => {
+      onProgress?.({
+        payload: {
+          downloaded: 10,
+          total: 100,
+          source: "a.test",
+          operationId: "op-new",
+        },
+      });
+    });
+    expect(result.current.dl?.downloaded).toBe(10);
+    expect(result.current.activeOperationIdRef.current).toBe("op-new");
+
+    // Late event from a previous operation must not overwrite live progress.
+    act(() => {
+      onProgress?.({
+        payload: {
+          downloaded: 999,
+          total: 100,
+          source: "old.test",
+          operationId: "op-old",
+        },
+      });
+    });
+    expect(result.current.dl?.downloaded).toBe(10);
+
+    // Same op continues to update.
+    act(() => {
+      onProgress?.({
+        payload: {
+          downloaded: 40,
+          total: 100,
+          source: "a.test",
+          operationId: "op-new",
+        },
+      });
+    });
+    expect(result.current.dl?.downloaded).toBe(40);
+  });
+
+  it("rebuilds a listener bound to a reattached operation id", async () => {
+    const { result } = renderHook(
+      () =>
+        useDownloadProgress({
+          eventName: "win://download-progress",
+          pauseDownload: vi.fn(async () => true),
+          cancelDownload: vi.fn(async () => true),
+          cannotCancelMessage: "cannot cancel",
+          onError: vi.fn(),
+        }),
+      { wrapper },
+    );
+
+    result.current.applySnapshotProgress({
+      downloaded: 25,
+      total: 200,
+      source: "mirror.test",
+      operationId: "reattach-1",
+    });
+
+    await act(async () => {
+      await result.current.startDlListen({
+        operationId: "reattach-1",
+        preserveProgress: true,
+      });
+    });
+
+    expect(result.current.dl?.downloaded).toBe(25);
+    expect(result.current.activeOperationIdRef.current).toBe("reattach-1");
+
+    // Foreign op rejected.
+    act(() => {
+      onProgress?.({
+        payload: {
+          downloaded: 1,
+          total: 200,
+          source: "x",
+          operationId: "other",
+        },
+      });
+    });
+    expect(result.current.dl?.downloaded).toBe(25);
+
+    // Matching op accepted.
+    act(() => {
+      onProgress?.({
+        payload: {
+          downloaded: 80,
+          total: 200,
+          source: "mirror.test",
+          operationId: "reattach-1",
+        },
+      });
+    });
+    expect(result.current.dl?.downloaded).toBe(80);
+
+    // Untagged events rejected while bound to a concrete id.
+    act(() => {
+      onProgress?.({
+        payload: {
+          downloaded: 5,
+          total: 200,
+          source: "x",
+        },
+      });
+    });
+    expect(result.current.dl?.downloaded).toBe(80);
+  });
+
+  it("resetStop clears the active operation id", async () => {
+    const { result } = renderHook(
+      () =>
+        useDownloadProgress({
+          eventName: "mac://download-progress",
+          pauseDownload: vi.fn(async () => true),
+          cancelDownload: vi.fn(async () => true),
+          cannotCancelMessage: "cannot cancel",
+          onError: vi.fn(),
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.startDlListen({ operationId: "x" });
+    });
+    expect(result.current.activeOperationIdRef.current).toBe("x");
+
+    act(() => {
+      result.current.resetStop();
+    });
+    expect(result.current.activeOperationIdRef.current).toBeNull();
+    expect(result.current.dl).toBeNull();
+  });
+
+  it("startDlListen registers the platform event channel", async () => {
+    const { result } = renderHook(
+      () =>
+        useDownloadProgress({
+          eventName: "mac://download-progress",
+          pauseDownload: vi.fn(async () => true),
+          cancelDownload: vi.fn(async () => true),
+          cannotCancelMessage: "cannot cancel",
+          onError: vi.fn(),
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.startDlListen();
+    });
+
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalledWith("mac://download-progress", expect.any(Function));
+    });
+  });
+});

--- a/src/app/views/useDownloadProgress.ts
+++ b/src/app/views/useDownloadProgress.ts
@@ -7,6 +7,13 @@ import { useI18n } from "../i18n";
 import { useCountUp } from "../useCountUp";
 import type { DownloadStopIntent } from "./ProgressScreen";
 
+export type StartDlListenOptions = {
+  /** When reattaching, bind to this operation id and reject foreign events. */
+  operationId?: string | null;
+  /** Keep the last known progress (reattach) instead of clearing to empty. */
+  preserveProgress?: boolean;
+};
+
 /** The live-download state machine shared by the Mac and Windows homes: the
  *  progress bytes + eased readouts, the pause/cancel intent, and the backend
  *  stop request. Platform differences are injected — the event channel name and
@@ -31,6 +38,10 @@ export function useDownloadProgress(opts: {
   // Latest live progress, read at pause time to snapshot the paused figures
   // (the `dl` state is cleared when the perform/install call unwinds).
   const dlRef = useRef<DownloadProgress | null>(null);
+  // Active operation id: latched from the first tagged event, or set on reattach.
+  // Events carrying a *different* id are dropped so a late packet from op A
+  // cannot paint onto op B after a new task started (or after reload).
+  const activeOperationIdRef = useRef<string | null>(null);
 
   // Smoothly roll the live figures instead of snapping on every progress event.
   const dlPctTarget = dl && dl.total > 0 ? Math.min(100, (dl.downloaded / dl.total) * 100) : 0;
@@ -40,6 +51,23 @@ export function useDownloadProgress(opts: {
 
   const onDlProgress = useCallback((event: { payload: DownloadProgress }) => {
     const p = event.payload;
+    const eventOpId = typeof p.operationId === "string" && p.operationId ? p.operationId : null;
+    const activeId = activeOperationIdRef.current;
+
+    if (eventOpId) {
+      if (activeId && eventOpId !== activeId) {
+        // Late event for a previous operation — ignore.
+        return;
+      }
+      if (!activeId) {
+        // First tagged event for this listen session: latch the id.
+        activeOperationIdRef.current = eventOpId;
+      }
+    } else if (activeId) {
+      // We already bound to a concrete op (reattach); untagged events are foreign.
+      return;
+    }
+
     setDl(p);
     dlRef.current = p;
     const now = Date.now();
@@ -52,18 +80,37 @@ export function useDownloadProgress(opts: {
     }
   }, []);
 
-  const startDlListen = useCallback(async () => {
-    setDl(null);
-    dlRef.current = null;
+  const startDlListen = useCallback(
+    async (options?: StartDlListenOptions) => {
+      activeOperationIdRef.current = options?.operationId ?? null;
+      if (!options?.preserveProgress) {
+        setDl(null);
+        dlRef.current = null;
+        setSpeed(0);
+        dlSample.current = null;
+      }
+      try {
+        return await listen<DownloadProgress>(eventName, onDlProgress);
+      } catch {
+        // Non-Tauri (web preview): no event bus — nothing to clean up.
+        return () => {};
+      }
+    },
+    [eventName, onDlProgress],
+  );
+
+  /** Seed progress state from a backend snapshot (reload reattach). */
+  const applySnapshotProgress = useCallback((progress: DownloadProgress | null | undefined) => {
+    if (!progress) return;
+    setDl(progress);
+    dlRef.current = progress;
     setSpeed(0);
-    dlSample.current = null;
-    try {
-      return await listen<DownloadProgress>(eventName, onDlProgress);
-    } catch {
-      // Non-Tauri (web preview): no event bus — nothing to clean up.
-      return () => {};
-    }
-  }, [eventName, onDlProgress]);
+    dlSample.current = { t: Date.now(), bytes: progress.downloaded };
+  }, []);
+
+  const clearActiveOperation = useCallback(() => {
+    activeOperationIdRef.current = null;
+  }, []);
 
   const requestDownloadStop = useCallback(
     async (intent: DownloadStopIntent) => {
@@ -95,6 +142,7 @@ export function useDownloadProgress(opts: {
     setDownloadStop(null);
     setDownloadStopBusy(false);
     downloadStopRef.current = null;
+    activeOperationIdRef.current = null;
   }, []);
 
   return {
@@ -107,7 +155,10 @@ export function useDownloadProgress(opts: {
     downloadStop,
     downloadStopBusy,
     downloadStopRef,
+    activeOperationIdRef,
     startDlListen,
+    applySnapshotProgress,
+    clearActiveOperation,
     requestDownloadStop,
     resetStop,
   };

--- a/src/app/views/useOperationReattach.test.ts
+++ b/src/app/views/useOperationReattach.test.ts
@@ -1,0 +1,162 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { managerApi } from "../../services/managerApi";
+import type { OperationSnapshot } from "../../shared/types";
+import { useOperationReattach } from "./useOperationReattach";
+
+vi.mock("../../services/managerApi", () => ({
+  managerApi: {
+    getOperationSnapshot: vi.fn(),
+  },
+}));
+
+const getSnapshot = vi.mocked(managerApi.getOperationSnapshot);
+
+const ACTIVE: OperationSnapshot = {
+  id: "op-42",
+  kind: "update",
+  phase: "downloading",
+  progress: { downloaded: 512, total: 2048, source: "cdn.test", operationId: "op-42" },
+  paused: false,
+  cancellable: true,
+  interruptible: true,
+};
+
+describe("useOperationReattach", () => {
+  beforeEach(() => {
+    getSnapshot.mockReset();
+  });
+
+  it("restores busy/progress and rebuilds the listener from a backend snapshot", async () => {
+    getSnapshot.mockResolvedValue(ACTIVE);
+    const startDlListen = vi.fn(async () => () => {});
+    const applySnapshotProgress = vi.fn();
+    const resetStop = vi.fn();
+    const setBusy = vi.fn();
+    const setPaused = vi.fn();
+    const onOperationEnded = vi.fn();
+
+    renderHook(() =>
+      useOperationReattach({
+        startDlListen,
+        applySnapshotProgress,
+        resetStop,
+        setBusy,
+        setPaused,
+        onOperationEnded,
+        isLocallyBusy: () => false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(setBusy).toHaveBeenCalledWith("perform");
+    });
+    expect(applySnapshotProgress).toHaveBeenCalledWith(ACTIVE.progress);
+    expect(setPaused).toHaveBeenCalledWith(null);
+    expect(startDlListen).toHaveBeenCalledWith({
+      operationId: "op-42",
+      preserveProgress: true,
+    });
+  });
+
+  it("restores a paused download screen from snapshot", async () => {
+    getSnapshot.mockResolvedValue({
+      ...ACTIVE,
+      kind: "install",
+      paused: true,
+      progress: { downloaded: 10, total: 100, source: "x" },
+    });
+    const setBusy = vi.fn();
+    const setPaused = vi.fn();
+
+    renderHook(() =>
+      useOperationReattach({
+        startDlListen: vi.fn(async () => () => {}),
+        applySnapshotProgress: vi.fn(),
+        resetStop: vi.fn(),
+        setBusy,
+        setPaused,
+        onOperationEnded: vi.fn(),
+        isLocallyBusy: () => false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(setBusy).toHaveBeenCalledWith("install");
+    });
+    expect(setPaused).toHaveBeenCalledWith({
+      kind: "install",
+      dl: { downloaded: 10, total: 100, source: "x" },
+    });
+  });
+
+  it("polls until the lease ends then clears UI and notifies", async () => {
+    getSnapshot
+      .mockResolvedValueOnce(ACTIVE) // mount query
+      .mockResolvedValueOnce(ACTIVE) // first poll still busy
+      .mockResolvedValueOnce(null); // second poll: finished
+
+    const resetStop = vi.fn();
+    const setBusy = vi.fn();
+    const setPaused = vi.fn();
+    const onOperationEnded = vi.fn();
+
+    renderHook(() =>
+      useOperationReattach({
+        startDlListen: vi.fn(async () => () => {}),
+        applySnapshotProgress: vi.fn(),
+        resetStop,
+        setBusy,
+        setPaused,
+        onOperationEnded,
+        isLocallyBusy: () => false,
+      }),
+    );
+
+    await waitFor(() => expect(setBusy).toHaveBeenCalledWith("perform"));
+
+    // First poll tick (800ms).
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 850));
+    });
+    // Second poll tick ends the op.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 850));
+    });
+
+    await waitFor(() => {
+      expect(onOperationEnded).toHaveBeenCalled();
+    });
+    expect(resetStop).toHaveBeenCalled();
+    expect(setBusy).toHaveBeenCalledWith(null);
+    expect(setPaused).toHaveBeenCalledWith(null);
+  });
+
+  it("does not attach when a local perform/install already owns the UI", async () => {
+    getSnapshot.mockResolvedValue(ACTIVE);
+    const startDlListen = vi.fn(async () => () => {});
+    const setBusy = vi.fn();
+
+    renderHook(() =>
+      useOperationReattach({
+        startDlListen,
+        applySnapshotProgress: vi.fn(),
+        resetStop: vi.fn(),
+        setBusy,
+        setPaused: vi.fn(),
+        onOperationEnded: vi.fn(),
+        isLocallyBusy: () => true,
+      }),
+    );
+
+    // Give the async mount path a chance to run.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(startDlListen).not.toHaveBeenCalled();
+    expect(setBusy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/views/useOperationReattach.ts
+++ b/src/app/views/useOperationReattach.ts
@@ -1,0 +1,164 @@
+import { useEffect, useRef } from "react";
+
+import { managerApi } from "../../services/managerApi";
+import type { DownloadProgress, OperationKind, OperationSnapshot } from "../../shared/types";
+import type { PausedDownload } from "./ProgressScreen";
+import type { StartDlListenOptions } from "./useDownloadProgress";
+
+export type ReattachBusy = "perform" | "install";
+
+function busyFromKind(kind: OperationKind): ReattachBusy | null {
+  if (kind === "install") return "install";
+  if (kind === "update") return "perform";
+  return null;
+}
+
+function pausedKind(kind: OperationKind): PausedDownload["kind"] | null {
+  if (kind === "install") return "install";
+  if (kind === "update") return "perform";
+  return null;
+}
+
+/**
+ * On mount: query the backend operation snapshot, restore progress/busy UI,
+ * re-subscribe to the download event channel filtered by operation id, and
+ * poll until the lease ends (the original invoke promise is gone after reload).
+ */
+export function useOperationReattach(opts: {
+  startDlListen: (options?: StartDlListenOptions) => Promise<() => void>;
+  applySnapshotProgress: (progress: DownloadProgress | null | undefined) => void;
+  resetStop: () => void;
+  setBusy: (busy: ReattachBusy | null) => void;
+  setPaused: (paused: PausedDownload | null) => void;
+  /** Called once when the reattached op finishes (success or failure). */
+  onOperationEnded: () => void;
+  /** True while a local perform/install is already driving the UI. */
+  isLocallyBusy: () => boolean;
+}) {
+  const {
+    startDlListen,
+    applySnapshotProgress,
+    resetStop,
+    setBusy,
+    setPaused,
+    onOperationEnded,
+    isLocallyBusy,
+  } = opts;
+
+  // Stable refs so the one-shot mount effect does not re-run when callbacks change.
+  const startDlListenRef = useRef(startDlListen);
+  const applySnapshotProgressRef = useRef(applySnapshotProgress);
+  const resetStopRef = useRef(resetStop);
+  const setBusyRef = useRef(setBusy);
+  const setPausedRef = useRef(setPaused);
+  const onOperationEndedRef = useRef(onOperationEnded);
+  const isLocallyBusyRef = useRef(isLocallyBusy);
+  useEffect(() => {
+    startDlListenRef.current = startDlListen;
+    applySnapshotProgressRef.current = applySnapshotProgress;
+    resetStopRef.current = resetStop;
+    setBusyRef.current = setBusy;
+    setPausedRef.current = setPaused;
+    onOperationEndedRef.current = onOperationEnded;
+    isLocallyBusyRef.current = isLocallyBusy;
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+    let attachedId: string | null = null;
+
+    const clearPoll = () => {
+      if (pollTimer != null) {
+        clearTimeout(pollTimer);
+        pollTimer = null;
+      }
+    };
+
+    const finish = () => {
+      clearPoll();
+      if (unlisten) {
+        unlisten();
+        unlisten = null;
+      }
+      attachedId = null;
+      resetStopRef.current();
+      setBusyRef.current(null);
+      setPausedRef.current(null);
+      onOperationEndedRef.current();
+    };
+
+    const applySnap = (snap: OperationSnapshot) => {
+      const busy = busyFromKind(snap.kind);
+      if (!busy) return false;
+      setBusyRef.current(busy);
+      applySnapshotProgressRef.current(snap.progress ?? null);
+      if (snap.paused) {
+        const kind = pausedKind(snap.kind);
+        if (kind) {
+          setPausedRef.current({ kind, dl: snap.progress ?? null });
+        }
+      } else {
+        setPausedRef.current(null);
+      }
+      return true;
+    };
+
+    const poll = () => {
+      clearPoll();
+      pollTimer = setTimeout(() => {
+        void (async () => {
+          if (cancelled || !attachedId) return;
+          const next = await Promise.resolve()
+            .then(() => managerApi.getOperationSnapshot())
+            .catch(() => null);
+          if (cancelled) return;
+          if (!next || next.id !== attachedId) {
+            finish();
+            return;
+          }
+          applySnap(next);
+          poll();
+        })();
+      }, 800);
+    };
+
+    void (async () => {
+      // Local perform/install already owns the UI — don't double-attach.
+      if (isLocallyBusyRef.current()) return;
+
+      const snap = await Promise.resolve()
+        .then(() => managerApi.getOperationSnapshot())
+        .catch(() => null);
+      if (cancelled || !snap) return;
+      if (isLocallyBusyRef.current()) return;
+
+      const busy = busyFromKind(snap.kind);
+      if (!busy) return;
+
+      attachedId = snap.id;
+      if (!applySnap(snap)) {
+        attachedId = null;
+        return;
+      }
+
+      unlisten = await startDlListenRef.current({
+        operationId: snap.id,
+        preserveProgress: true,
+      });
+      if (cancelled) {
+        unlisten();
+        unlisten = null;
+        return;
+      }
+      poll();
+    })();
+
+    return () => {
+      cancelled = true;
+      clearPoll();
+      if (unlisten) unlisten();
+    };
+  }, []);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom/client";
 
 import { App } from "./app/App";
 import { installContextMenuPolicy } from "./app/contextMenuPolicy";
-import { ErrorBoundary } from "./app/ErrorBoundary";
 import { installGlobalErrorHandlers } from "./app/globalErrors";
 import { currentPlatform } from "./app/platform";
 import { resolveInitialTheme } from "./app/theme";
@@ -23,9 +22,7 @@ installGlobalErrorHandlers();
 installContextMenuPolicy();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <ErrorBoundary>
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  </ErrorBoundary>,
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
 );

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -15,6 +15,7 @@ import type {
   MacUninstallReport,
   MacUpdateReport,
   OperationKind,
+  OperationSnapshot,
   OperationToken,
   WinInstallStatus,
   WinPerformReport,
@@ -497,6 +498,13 @@ export const managerApi = {
       return Promise.resolve(`browser-dev-token-${kind}`);
     }
     return invoke<OperationToken>("arm_destructive", { kind });
+  },
+  /** Active install/update lease, or null when idle. Queried on mount to reattach. */
+  getOperationSnapshot(): Promise<OperationSnapshot | null> {
+    if (!hasTauriRuntime()) {
+      return Promise.resolve(null);
+    }
+    return invoke<OperationSnapshot | null>("get_operation_snapshot");
   },
   macPlanUpdate(simulatedBuild?: number): Promise<MacUpdateReport> {
     if (!hasTauriRuntime()) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,6 +2,29 @@ export type OperatingSystem = "windows" | "macos" | "linux" | "unknown";
 export type Architecture = "x64" | "arm64" | "unknown";
 export type OperationKind = "install" | "update" | "uninstall" | "set-install-root" | "adopt";
 export type OperationToken = string;
+/** Lifecycle phase of a backend operation lease (mirrors Rust `OperationPhase`). */
+export type OperationPhase =
+  | "idle"
+  | "preparing"
+  | "downloading"
+  | "verifying"
+  | "applying"
+  | "committing"
+  | "finishing";
+
+/**
+ * Active same-process operation, as reported by `get_operation_snapshot`.
+ * Used to reattach the UI after a renderer reload while work continues.
+ */
+export interface OperationSnapshot {
+  id: string;
+  kind: OperationKind;
+  phase: OperationPhase;
+  progress: DownloadProgress | null;
+  paused: boolean;
+  cancellable: boolean;
+  interruptible: boolean;
+}
 
 /**
  * Serialized error returned by failing Tauri commands. Mirrors the backend
@@ -53,6 +76,11 @@ export interface DownloadProgress {
   total: number;
   /** Host the bytes come from, e.g. codexapp.agentsmirror.com. */
   source: string;
+  /**
+   * Backend operation id that produced this event. Present on live desktop
+   * progress so a reloaded UI can reject late events from a previous op.
+   */
+  operationId?: string;
 }
 
 export interface MacUpdateReport {


### PR DESCRIPTION
Tracks #147

## Summary

After a renderer reload / remount, the UI can reattach to an in-flight install or update instead of losing progress and controls.

- **Backend `OperationSnapshot`**: `id`, `kind`, `phase`, `progress`, `paused`, `cancellable`, `interruptible` via `get_operation_snapshot`
- Progress events carry `operationId`; lease stores last progress / pause flag
- Frontend mount queries snapshot, rebuilds download listeners by operation id, polls until the lease ends
- Late events with a foreign operation id are rejected
- `QuitConfirm` sits outside `ErrorBoundary` so crash-path close still works
- Crash-page body uses real backend lease state (idle / active / critical / paused)

Also includes #146 (phase-aware quit + install recovery) as a base dependency for phase fields.

## Tests

```
npx vitest run
# 90 passed — includes reload reattach, late-event filter, listener rebuild, ErrorBoundary quit

cargo test --lib oplock
# 11 passed — includes snapshot_exposes_progress_phase_and_flags

npm run check && npm run lint
```

## Checklist

- [x] OperationSnapshot backend contract
- [x] Resubscribe by operation id on mount
- [x] Late-event isolation
- [x] Reload restores progress/phase/actions
- [x] ErrorBoundary quit confirm path
- [x] Crash copy from backend state
- [x] Tests for reload, listener rebuild, late events, ErrorBoundary quit

Closes #147