### PR TITLE
fix(windows): bound external probes and verify post-install launchability

### DIFF
--- a/crates/codex-win-engine/src/authenticode.rs
+++ b/crates/codex-win-engine/src/authenticode.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 #[cfg(windows)]
-use crate::process::hidden_command;
+use crate::process::{hidden_command, run_capturing, RunLimits};
 use crate::EngineError;
 
 // The mirror currently serves Store-re-signed MSIX packages; add a separate
@@ -127,10 +127,11 @@ $sig = Get-AuthenticodeSignature -LiteralPath {path}
         path = ps_quote(&path.to_string_lossy())
     );
 
-    let output = hidden_command(powershell_exe())
-        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
-        .output()
-        .map_err(|e| EngineError::Authenticode(format!("spawn powershell: {e}")))?;
+    let mut command = hidden_command(powershell_exe());
+    command.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+    let output = run_capturing(command, RunLimits::probe(), None).map_err(|e| {
+        EngineError::Authenticode(format!("Get-AuthenticodeSignature: {}", e.message()))
+    })?;
 
     if !output.status.success() {
         let err = EngineError::Authenticode(format!(

--- a/crates/codex-win-engine/src/download.rs
+++ b/crates/codex-win-engine/src/download.rs
@@ -1,15 +1,14 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread;
-use std::time::Duration;
 
 use sha2::{Digest, Sha256};
 
 use crate::limits::MAX_PACKAGE_BYTES;
 use crate::network::{is_schannel_revocation_offline, NetworkConfig, SchannelRevocationCheck};
-use crate::process::{curl_exe, hidden_command};
+use crate::process::{
+    curl_exe, hidden_command, run_with_progress, RunError, RunLimits, TimeoutKind,
+};
 use crate::EngineError;
 
 static DOWNLOAD_ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -208,36 +207,50 @@ fn run_curl_once(
     args: Vec<String>,
     on_progress: &dyn Fn(u64),
 ) -> Result<(), CurlAttemptError> {
-    let mut child = hidden_command(curl_exe())
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| CurlAttemptError::Other(format!("spawn curl: {e}")))?;
+    let dest_path = PathBuf::from(dest);
+    let mut command = hidden_command(curl_exe());
+    command.args(args);
 
-    loop {
-        if DOWNLOAD_CANCELLED.load(Ordering::SeqCst) {
-            let _ = child.kill();
-            let _ = child.wait();
+    // Stall on no byte growth; total bound stops an endlessly crawling transfer.
+    // Cancel is cooperative via DOWNLOAD_CANCELLED — the runner kills the tree.
+    let output = match run_with_progress(
+        command,
+        RunLimits::download(),
+        Some(&DOWNLOAD_CANCELLED),
+        &|| std::fs::metadata(&dest_path).map(|m| m.len()).unwrap_or(0),
+        on_progress,
+    ) {
+        Ok(output) => output,
+        Err(RunError::Cancelled) => {
             let downloaded = std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
             log::info!("Windows download cancelled source={source} downloaded={downloaded}");
             return Err(CurlAttemptError::Cancelled);
         }
-        let downloaded = std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
-        on_progress(downloaded);
-        match child.try_wait() {
-            Ok(Some(_)) => break,
-            Ok(None) => thread::sleep(Duration::from_millis(200)),
-            Err(err) => {
-                let _ = child.kill();
-                return Err(CurlAttemptError::Other(format!("wait for curl: {err}")));
-            }
+        Err(RunError::Timeout { kind, .. }) => {
+            let downloaded = std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
+            return match kind {
+                TimeoutKind::Stall => {
+                    log::warn!(
+                        "Windows download stalled source={source} downloaded={downloaded}"
+                    );
+                    Err(CurlAttemptError::Other(format!(
+                        "curl download stalled (no progress) source={source} downloaded={downloaded}"
+                    )))
+                }
+                TimeoutKind::Total => {
+                    log::warn!(
+                        "Windows download exceeded total deadline source={source} downloaded={downloaded}"
+                    );
+                    Err(CurlAttemptError::Other(format!(
+                        "curl download exceeded total deadline source={source} downloaded={downloaded}"
+                    )))
+                }
+            };
         }
-    }
-
-    let output = child
-        .wait_with_output()
-        .map_err(|err| CurlAttemptError::Other(format!("collect curl output: {err}")))?;
+        Err(err) => {
+            return Err(CurlAttemptError::Other(format!("curl: {}", err.message())));
+        }
+    };
 
     if !output.status.success() {
         return Err(CurlAttemptError::Curl {

--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -54,9 +54,9 @@ pub use portable::{
     purge_codex_user_data, uninstall_portable, PortableInstallReport, PortableUninstallReport,
 };
 pub use sys::{
-    detect_installed_codex, detect_portable_install, fetch_text, fetch_text_with_network,
-    launch_codex, launch_codex_with_options, probe_capabilities, remove_msix_package,
-    InstalledWindowsCodex, LaunchOptions, MsixRemoveReport,
+    close_msix_codex_processes, detect_installed_codex, detect_portable_install, fetch_text,
+    fetch_text_with_network, launch_codex, launch_codex_with_options, probe_capabilities,
+    remove_msix_package, InstalledWindowsCodex, LaunchOptions, MsixRemoveReport,
 };
 pub use sys::{
     install_msix_sideload, precheck_msix_dependencies, verify_msix_health, MsixDependencyPrecheck,

--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -62,6 +62,8 @@ pub use sys::{
     install_msix_sideload, precheck_msix_dependencies, verify_msix_health, MsixDependencyPrecheck,
     MsixHealthReport, MsixSideloadReport,
 };
+// Failure-kind constants for structured MSIX health outcomes.
+pub use sys::msix_failure;
 pub use version::{compare_versions, version_key};
 
 pub const OPENAI_PACKAGE_IDENTITY: &str = "OpenAI.Codex";

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -271,6 +271,10 @@ fn run_powershell_with_limits(
 // alone: post-merge the Codex entry process is `ChatGPT`, which is also the
 // process name of ChatGPT Classic — an unrooted name match would close the
 // wrong product. That is why there is no unfiltered close variant.
+//
+// Path resolution falls through Get-Process.Path → MainModule.FileName →
+// Win32_Process.ExecutablePath: AppX / protected processes often leave `.Path`
+// empty even when the process is clearly ours under InstallLocation.
 #[cfg(windows)]
 fn request_codex_close_filtered(timeout_secs: u64, root: &Path) -> Result<(), EngineError> {
     let root_filter = ps_quote(&root.to_string_lossy());
@@ -279,18 +283,38 @@ fn request_codex_close_filtered(timeout_secs: u64, root: &Path) -> Result<(), En
         r#"
 $RootFilter = {root_filter}
 try {{ $RootFilter = [System.IO.Path]::GetFullPath($RootFilter).TrimEnd('\') }} catch {{}}
+function Get-ProcessExePath($p) {{
+  try {{
+    $path = [string]$p.Path
+    if (-not [string]::IsNullOrWhiteSpace($path)) {{ return $path }}
+  }} catch {{}}
+  try {{
+    $path = [string]$p.MainModule.FileName
+    if (-not [string]::IsNullOrWhiteSpace($path)) {{ return $path }}
+  }} catch {{}}
+  try {{
+    $cim = Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId=" + $p.Id) -ErrorAction SilentlyContinue
+    if ($null -ne $cim -and -not [string]::IsNullOrWhiteSpace([string]$cim.ExecutablePath)) {{
+      return [string]$cim.ExecutablePath
+    }}
+  }} catch {{}}
+  return $null
+}}
+function Test-UnderRoot($p) {{
+  $path = Get-ProcessExePath $p
+  if ([string]::IsNullOrWhiteSpace($path) -or [string]::IsNullOrWhiteSpace($RootFilter)) {{ return $false }}
+  try {{
+    $full = [System.IO.Path]::GetFullPath($path)
+    return ($full.Equals($RootFilter, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $full.StartsWith($RootFilter + '\', [System.StringComparison]::OrdinalIgnoreCase))
+  }} catch {{
+    return $false
+  }}
+}}
 function Get-TargetCodexProcess {{
   $all = Get-Process -Name Codex, ChatGPT -ErrorAction SilentlyContinue
   foreach ($p in $all) {{
-    try {{
-      $path = [string]$p.Path
-      if (-not $path) {{ continue }}
-      $full = [System.IO.Path]::GetFullPath($path)
-      if ($full.Equals($RootFilter, [System.StringComparison]::OrdinalIgnoreCase) -or
-          $full.StartsWith($RootFilter + '\', [System.StringComparison]::OrdinalIgnoreCase)) {{
-        $p
-      }}
-    }} catch {{}}
+    if (Test-UnderRoot $p) {{ $p }}
   }}
 }}
 $deadline = (Get-Date).AddSeconds({timeout})

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::app_version::read_codex_app_version_from_install_root;
 use crate::msix::{parse_appx_manifest_xml, MsixIdentity};
-use crate::process::hidden_command;
+use crate::process::{
+    hidden_command, run_capturing, spawn_and_require_liveness, LivenessResult, RunLimits,
+    PORTABLE_LIVENESS_WINDOW,
+};
 use crate::EngineError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -241,10 +244,20 @@ fn powershell_exe() -> PathBuf {
 
 #[cfg(windows)]
 fn run_powershell(script: &str) -> Result<String, EngineError> {
-    let output = hidden_command(powershell_exe())
-        .args(["-NoProfile", "-NonInteractive", "-Command", script])
-        .output()
-        .map_err(|e| EngineError::Install(format!("spawn powershell: {e}")))?;
+    // Close/shortcut/uninstall scripts can wait on processes; use the install
+    // budget so a stuck AppX/policy machine cannot hang forever.
+    run_powershell_with_limits(script, RunLimits::install())
+}
+
+#[cfg(windows)]
+fn run_powershell_with_limits(
+    script: &str,
+    limits: RunLimits,
+) -> Result<String, EngineError> {
+    let mut command = hidden_command(powershell_exe());
+    command.args(["-NoProfile", "-NonInteractive", "-Command", script]);
+    let output = run_capturing(command, limits, None)
+        .map_err(|e| EngineError::Install(format!("powershell: {}", e.message())))?;
     if !output.status.success() {
         return Err(EngineError::Install(format!(
             "powershell failed: {}",
@@ -550,10 +563,26 @@ fn health_check_portable_install(install_root: &Path, launch: bool) -> Result<bo
     if !launch {
         return Ok(false);
     }
-    hidden_command(&exe)
-        .spawn()
-        .map(|_| true)
-        .map_err(|e| io_err("portable health check launch", e))
+    // Spawn alone is not enough: a broken payload can exit immediately after
+    // CreateProcess succeeds. Require a short liveness window, then leave the
+    // process running (this path is the post-install relaunch).
+    match spawn_and_require_liveness(hidden_command(&exe), PORTABLE_LIVENESS_WINDOW) {
+        Ok(LivenessResult::Survived { child }) => {
+            // Intentionally leak the Child handle so the relaunched app keeps
+            // running after the manager drops the wait loop.
+            std::mem::forget(child);
+            Ok(true)
+        }
+        Ok(LivenessResult::ExitedEarly { code }) => Err(EngineError::Install(format!(
+            "portable health check failed: entry executable exited immediately after launch (exit={})",
+            code.map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string())
+        ))),
+        Err(err) => Err(EngineError::Install(format!(
+            "portable health check launch failed: {}",
+            err.message()
+        ))),
+    }
 }
 
 pub fn install_portable_from_msix(
@@ -978,6 +1007,43 @@ mod tests {
             .starts_with("Codex.rollback")));
         assert!(!install_root.join("old-marker.txt").exists());
         assert!(install_root.join("resources/app.asar").exists());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn health_check_detects_immediate_exit_entry() {
+        // whoami.exe exits instantly — models a broken payload that CreateProcess
+        // accepts then immediately dies. The health check must fail closed.
+        let root = std::env::temp_dir().join(format!(
+            "codex-portable-liveness-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let windir = std::env::var_os("WINDIR").unwrap_or_else(|| "C:\\Windows".into());
+        let whoami = PathBuf::from(windir).join("System32").join("whoami.exe");
+        if !whoami.is_file() {
+            let _ = fs::remove_dir_all(&root);
+            return;
+        }
+        fs::copy(&whoami, root.join("ChatGPT.exe")).unwrap();
+        fs::write(
+            root.join("AppxManifest.xml"),
+            br#"<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.Codex" Publisher="CN=X" Version="1.0.0.0" ProcessorArchitecture="x64" />
+  <Applications><Application Id="App" Executable="app\ChatGPT.exe" /></Applications>
+</Package>"#,
+        )
+        .unwrap();
+
+        let err = health_check_portable_install(&root, true).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exited immediately"),
+            "unexpected error: {msg}"
+        );
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/codex-win-engine/src/process.rs
+++ b/crates/codex-win-engine/src/process.rs
@@ -25,8 +25,13 @@ pub const DEFAULT_STALL_TIMEOUT: Duration = Duration::from_secs(120);
 pub const DEFAULT_DOWNLOAD_TOTAL_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
 /// Minimum survival window after spawning a portable binary for "launchable".
 pub const PORTABLE_LIVENESS_WINDOW: Duration = Duration::from_secs(3);
-/// Budget to observe MSIX activation after shell start.
-pub const MSIX_ACTIVATION_WINDOW_SECS: u64 = 10;
+/// Continuous survival required after MSIX shell activation — aligned with the
+/// portable liveness window so both routes reject the same class of crash-loops.
+pub const MSIX_LIVENESS_WINDOW_SECS: u64 = PORTABLE_LIVENESS_WINDOW.as_secs();
+/// Outer budget to wait for a cold-started MSIX process to *appear* after
+/// `Start-Process shell:AppsFolder\…`. Cold machines / AppX service warm-up can
+/// take well over 10s; too short a window causes false portable fallbacks.
+pub const MSIX_ACTIVATION_WINDOW_SECS: u64 = 30;
 
 /// Poll interval while waiting on a child.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);

--- a/crates/codex-win-engine/src/process.rs
+++ b/crates/codex-win-engine/src/process.rs
@@ -1,9 +1,111 @@
+//! Child-process helpers for the Windows engine.
+//!
+//! Every external probe (PowerShell, curl, portable launch checks) goes through
+//! a shared deadline + optional stall timeout + cleanup path so hung AppX /
+//! enterprise-policy machines cannot freeze the manager indefinitely.
+
 use std::ffi::OsStr;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Default wall-clock budget for a short PowerShell / curl-text probe.
+pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(45);
+/// Longer budget for Add-AppxPackage / Remove-AppxPackage.
+pub const INSTALL_TIMEOUT: Duration = Duration::from_secs(180);
+/// Default no-progress budget for streaming package downloads.
+pub const DEFAULT_STALL_TIMEOUT: Duration = Duration::from_secs(120);
+/// Absolute upper bound for a package download (2 hours). Stall timeout is the
+/// primary hang defense; this only stops an endlessly crawling transfer.
+pub const DEFAULT_DOWNLOAD_TOTAL_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
+/// Minimum survival window after spawning a portable binary for "launchable".
+pub const PORTABLE_LIVENESS_WINDOW: Duration = Duration::from_secs(3);
+/// Budget to observe MSIX activation after shell start.
+pub const MSIX_ACTIVATION_WINDOW_SECS: u64 = 10;
+
+/// Poll interval while waiting on a child.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, Copy)]
+pub struct RunLimits {
+    /// Hard wall-clock deadline from spawn.
+    pub total: Duration,
+    /// Optional: kill when a progress signal has not advanced for this long.
+    pub stall: Option<Duration>,
+}
+
+impl RunLimits {
+    pub fn total(total: Duration) -> Self {
+        Self { total, stall: None }
+    }
+
+    pub fn with_stall(total: Duration, stall: Duration) -> Self {
+        Self {
+            total,
+            stall: Some(stall),
+        }
+    }
+
+    pub fn probe() -> Self {
+        Self::total(DEFAULT_PROBE_TIMEOUT)
+    }
+
+    pub fn install() -> Self {
+        Self::total(INSTALL_TIMEOUT)
+    }
+
+    pub fn download() -> Self {
+        Self::with_stall(DEFAULT_DOWNLOAD_TOTAL_TIMEOUT, DEFAULT_STALL_TIMEOUT)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeoutKind {
+    Total,
+    Stall,
+}
+
+#[derive(Debug)]
+pub enum RunError {
+    Spawn(String),
+    Timeout {
+        kind: TimeoutKind,
+        /// Best-effort stderr collected before kill (often empty).
+        #[allow(dead_code)]
+        partial_stderr: String,
+    },
+    Cancelled,
+    Wait(String),
+}
+
+impl RunError {
+    #[allow(dead_code)] // used by unit tests and available to callers
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, Self::Timeout { .. })
+    }
+
+    #[allow(dead_code)] // used by unit tests and available to callers
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled)
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            Self::Spawn(msg) => format!("spawn failed: {msg}"),
+            Self::Timeout { kind, .. } => match kind {
+                TimeoutKind::Total => "process exceeded total deadline".to_string(),
+                TimeoutKind::Stall => "process made no progress within stall timeout".to_string(),
+            },
+            Self::Cancelled => "process cancelled".to_string(),
+            Self::Wait(msg) => format!("wait failed: {msg}"),
+        }
+    }
+}
 
 pub(crate) fn hidden_command(program: impl AsRef<OsStr>) -> Command {
     #[cfg(windows)]
@@ -27,4 +129,375 @@ pub(crate) fn curl_exe() -> PathBuf {
         .map(|root| root.join("System32").join("curl.exe"))
         .filter(|path| path.exists())
         .unwrap_or_else(|| PathBuf::from("curl"))
+}
+
+/// Terminate a child and, on Windows, its process tree (PowerShell nests work).
+fn terminate_tree(child: &mut Child) {
+    let pid = child.id();
+    let _ = child.kill();
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // Best-effort: kill may race with natural exit. `/T` covers grandchildren
+        // that PowerShell or curl may have spawned under the same tree.
+        let _ = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .creation_flags(CREATE_NO_WINDOW)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+    let _ = child.wait();
+}
+
+fn cancelled(flag: Option<&AtomicBool>) -> bool {
+    flag.map(|f| f.load(Ordering::SeqCst)).unwrap_or(false)
+}
+
+/// Run `command` to completion with a total deadline (and optional cancel flag).
+/// Captures stdout/stderr. Does not interpret exit codes — callers do.
+pub fn run_capturing(
+    mut command: Command,
+    limits: RunLimits,
+    cancel: Option<&AtomicBool>,
+) -> Result<Output, RunError> {
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|e| RunError::Spawn(e.to_string()))?;
+    wait_child(
+        &mut child,
+        limits,
+        cancel,
+        /*progress*/ None,
+        /*on_progress*/ None,
+    )?;
+    child
+        .wait_with_output()
+        .map_err(|e| RunError::Wait(e.to_string()))
+}
+
+/// Like [`run_capturing`], but tracks a progress signal for stall detection.
+/// `progress` is polled each loop; `on_progress` is notified when the value grows.
+pub fn run_with_progress(
+    mut command: Command,
+    limits: RunLimits,
+    cancel: Option<&AtomicBool>,
+    progress: &dyn Fn() -> u64,
+    on_progress: &dyn Fn(u64),
+) -> Result<Output, RunError> {
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|e| RunError::Spawn(e.to_string()))?;
+    wait_child(
+        &mut child,
+        limits,
+        cancel,
+        Some(progress),
+        Some(on_progress),
+    )?;
+    child
+        .wait_with_output()
+        .map_err(|e| RunError::Wait(e.to_string()))
+}
+
+fn wait_child(
+    child: &mut Child,
+    limits: RunLimits,
+    cancel: Option<&AtomicBool>,
+    progress: Option<&dyn Fn() -> u64>,
+    on_progress: Option<&dyn Fn(u64)>,
+) -> Result<(), RunError> {
+    let started = Instant::now();
+    let mut last_progress = progress.map(|p| p()).unwrap_or(0);
+    let mut last_progress_at = Instant::now();
+    if let (Some(p), Some(cb)) = (progress, on_progress) {
+        cb(p());
+    }
+
+    loop {
+        if cancelled(cancel) {
+            terminate_tree(child);
+            return Err(RunError::Cancelled);
+        }
+
+        match child.try_wait() {
+            Ok(Some(_)) => return Ok(()),
+            Ok(None) => {
+                if started.elapsed() >= limits.total {
+                    terminate_tree(child);
+                    return Err(RunError::Timeout {
+                        kind: TimeoutKind::Total,
+                        partial_stderr: String::new(),
+                    });
+                }
+                if let Some(p) = progress {
+                    let current = p();
+                    if current > last_progress {
+                        last_progress = current;
+                        last_progress_at = Instant::now();
+                        if let Some(cb) = on_progress {
+                            cb(current);
+                        }
+                    } else if let Some(stall) = limits.stall {
+                        if last_progress_at.elapsed() >= stall {
+                            terminate_tree(child);
+                            return Err(RunError::Timeout {
+                                kind: TimeoutKind::Stall,
+                                partial_stderr: String::new(),
+                            });
+                        }
+                    }
+                }
+                thread::sleep(POLL_INTERVAL);
+            }
+            Err(err) => {
+                terminate_tree(child);
+                return Err(RunError::Wait(err.to_string()));
+            }
+        }
+    }
+}
+
+/// Outcome of a liveness probe on a freshly spawned process.
+#[derive(Debug)]
+pub enum LivenessResult {
+    /// Still running after the survival window. Caller owns the child handle
+    /// (keep it for relaunch, or drop/kill when only verifying).
+    Survived { child: Child },
+    /// Exited before the window elapsed.
+    ExitedEarly { code: Option<i32> },
+}
+
+/// Spawn `command` and require it to stay alive for `window`.
+///
+/// Used by portable post-install health checks: spawn success alone does not
+/// mean the binary is launchable — an immediate crash must fail the install.
+pub fn spawn_and_require_liveness(
+    mut command: Command,
+    window: Duration,
+) -> Result<LivenessResult, RunError> {
+    // Detach stdio so a chatty broken payload cannot fill pipes and block, and
+    // so unit tests that use console tools (e.g. whoami) do not pollute output.
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|e| RunError::Spawn(e.to_string()))?;
+    let deadline = Instant::now() + window;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Ok(LivenessResult::ExitedEarly {
+                    code: status.code(),
+                });
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return Ok(LivenessResult::Survived { child });
+                }
+                thread::sleep(POLL_INTERVAL);
+            }
+            Err(err) => {
+                terminate_tree(&mut child);
+                return Err(RunError::Wait(err.to_string()));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn sleep_command(secs: u64) -> Command {
+        #[cfg(windows)]
+        {
+            let mut cmd = hidden_command("powershell.exe");
+            cmd.args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!("Start-Sleep -Seconds {secs}"),
+            ]);
+            cmd
+        }
+        #[cfg(not(windows))]
+        {
+            let mut cmd = Command::new("sleep");
+            cmd.arg(secs.to_string());
+            cmd
+        }
+    }
+
+    fn immediate_exit_command(code: i32) -> Command {
+        #[cfg(windows)]
+        {
+            let mut cmd = hidden_command("cmd.exe");
+            cmd.args(["/C", &format!("exit {code}")]);
+            cmd
+        }
+        #[cfg(not(windows))]
+        {
+            let mut cmd = Command::new("sh");
+            cmd.args(["-c", &format!("exit {code}")]);
+            cmd
+        }
+    }
+
+    fn slow_echo_command(delay_secs: u64, message: &str) -> Command {
+        #[cfg(windows)]
+        {
+            let mut cmd = hidden_command("powershell.exe");
+            cmd.args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!("Start-Sleep -Seconds {delay_secs}; Write-Output '{message}'"),
+            ]);
+            cmd
+        }
+        #[cfg(not(windows))]
+        {
+            let mut cmd = Command::new("sh");
+            cmd.args([
+                "-c",
+                &format!("sleep {delay_secs}; printf '%s' '{message}'"),
+            ]);
+            cmd
+        }
+    }
+
+    #[test]
+    fn total_timeout_kills_hung_child() {
+        let err = run_capturing(
+            sleep_command(60),
+            RunLimits::total(Duration::from_millis(400)),
+            None,
+        )
+        .expect_err("hung child must time out");
+        match err {
+            RunError::Timeout {
+                kind: TimeoutKind::Total,
+                ..
+            } => {}
+            other => panic!("expected total timeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slow_child_within_deadline_succeeds() {
+        let output = run_capturing(
+            slow_echo_command(1, "alive"),
+            RunLimits::total(Duration::from_secs(15)),
+            None,
+        )
+        .expect("slow child within deadline");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("alive"), "stdout={stdout}");
+    }
+
+    #[test]
+    fn stall_timeout_when_progress_frozen() {
+        let err = run_with_progress(
+            sleep_command(60),
+            RunLimits::with_stall(Duration::from_secs(30), Duration::from_millis(300)),
+            None,
+            &|| 0u64,
+            &|_| {},
+        )
+        .expect_err("frozen progress must stall-timeout");
+        match err {
+            RunError::Timeout {
+                kind: TimeoutKind::Stall,
+                ..
+            } => {}
+            other => panic!("expected stall timeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn progress_growth_resets_stall_clock() {
+        // A short sleep finishes well under total; monotonically growing progress
+        // keeps the stall clock from firing.
+        let counter = std::sync::atomic::AtomicU64::new(0);
+        let output = run_with_progress(
+            sleep_command(1),
+            RunLimits::with_stall(Duration::from_secs(15), Duration::from_millis(400)),
+            None,
+            &|| counter.fetch_add(1, Ordering::SeqCst),
+            &|_| {},
+        )
+        .expect("progressing child should finish");
+        assert!(output.status.success());
+    }
+
+    #[test]
+    fn cancellation_kills_child() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let cancel = Arc::clone(&flag);
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(200));
+            cancel.store(true, Ordering::SeqCst);
+        });
+        let err = run_capturing(
+            sleep_command(60),
+            RunLimits::total(Duration::from_secs(30)),
+            Some(&flag),
+        )
+        .expect_err("cancel must abort child");
+        assert!(err.is_cancelled(), "got {err:?}");
+        assert!(!err.is_timeout());
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn timeout_error_reports_kind_helpers() {
+        let err = run_capturing(
+            sleep_command(60),
+            RunLimits::total(Duration::from_millis(200)),
+            None,
+        )
+        .expect_err("must timeout");
+        assert!(err.is_timeout());
+        assert!(!err.is_cancelled());
+        assert!(err.message().contains("deadline"));
+    }
+
+    #[test]
+    fn immediate_exit_liveness_detected() {
+        let result = spawn_and_require_liveness(
+            immediate_exit_command(7),
+            Duration::from_secs(2),
+        )
+        .expect("spawn");
+        match result {
+            LivenessResult::ExitedEarly { code } => {
+                assert_eq!(code, Some(7));
+            }
+            LivenessResult::Survived { mut child } => {
+                let _ = child.kill();
+                panic!("immediate-exit binary must not be reported as survived");
+            }
+        }
+    }
+
+    #[test]
+    fn surviving_child_reported_alive() {
+        let result =
+            spawn_and_require_liveness(sleep_command(30), Duration::from_millis(400)).expect("spawn");
+        match result {
+            LivenessResult::Survived { mut child } => {
+                terminate_tree(&mut child);
+            }
+            LivenessResult::ExitedEarly { code } => {
+                panic!("sleep should still be running, exit={code:?}");
+            }
+        }
+    }
 }

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -11,7 +11,10 @@ use crate::capability::{CapabilityCheck, CapabilityState};
 use crate::limits::MAX_TEXT_BYTES;
 use crate::msix::parse_appx_manifest_xml;
 use crate::network::{is_schannel_revocation_offline, NetworkConfig, SchannelRevocationCheck};
-use crate::process::{curl_exe, hidden_command};
+use crate::process::{
+    curl_exe, hidden_command, run_capturing, spawn_and_require_liveness, LivenessResult,
+    RunLimits, MSIX_ACTIVATION_WINDOW_SECS, PORTABLE_LIVENESS_WINDOW,
+};
 use crate::EngineError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,18 +82,17 @@ pub struct MsixRemoveReport {
 /// success only means the cmdlet did not throw — on a stripped Windows (no
 /// Store / App Installer, missing framework packages) the package can register
 /// yet fail to launch, which is exactly the failure users hit. We verify the
-/// package is registered, its Status is Ok, the app entry (AUMID) resolves, and
-/// every declared framework dependency is actually present; when any of these
+/// package is registered, its Status is Ok, the app entry (AUMID) resolves,
+/// every declared framework dependency is present, **and** a real shell
+/// activation leaves a process under the install location. When any of these
 /// fail the caller removes the package and falls back to the portable build.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MsixHealthReport {
     pub healthy: bool,
     /// Whether the health probe actually ran and the `healthy` verdict reflects
-    /// real checks. `false` means the probe could not run and `healthy` is a
-    /// conservative "keep the MSIX" default, not a clean bill of health that was
-    /// observed. Callers/UI/notes use this to tell "verified healthy" apart from
-    /// "kept because unverifiable".
+    /// real checks. `false` means the probe could not run (e.g. PowerShell
+    /// missing) — not a clean bill of health that was observed.
     pub verified: bool,
     pub package_registered: bool,
     /// Raw `Get-AppxPackage` Status string (e.g. "Ok", "Modified").
@@ -101,8 +103,31 @@ pub struct MsixHealthReport {
     /// Declared framework dependencies that are NOT installed on this machine —
     /// the usual reason an MSIX installs but won't launch on a stripped Windows.
     pub missing_dependencies: Vec<String>,
+    /// Shell activation succeeded and a process under the package install
+    /// location stayed alive for the liveness window.
+    #[serde(default)]
+    pub activation_ok: bool,
+    /// Machine-stable failure class for UI / fallback routing. Empty when healthy.
+    /// Values: `not-registered` | `status-bad` | `aumid-unresolved` |
+    /// `missing-dependencies` | `activation-failed` | `immediate-exit` |
+    /// `timeout` | `probe-failed` | `policy`.
+    #[serde(default)]
+    pub failure_kind: String,
     /// Human-facing reason when unhealthy; empty when healthy.
     pub reason: String,
+}
+
+/// Stable failure-kind strings shared with the frontend and notes.
+pub mod msix_failure {
+    pub const NOT_REGISTERED: &str = "not-registered";
+    pub const STATUS_BAD: &str = "status-bad";
+    pub const AUMID_UNRESOLVED: &str = "aumid-unresolved";
+    pub const MISSING_DEPENDENCIES: &str = "missing-dependencies";
+    pub const ACTIVATION_FAILED: &str = "activation-failed";
+    pub const IMMEDIATE_EXIT: &str = "immediate-exit";
+    pub const TIMEOUT: &str = "timeout";
+    pub const PROBE_FAILED: &str = "probe-failed";
+    pub const POLICY: &str = "policy";
 }
 
 /// Result of the framework-dependency PRE-check run BEFORE attempting an MSIX
@@ -148,23 +173,24 @@ fn fetch_text_output(
     let max_text = MAX_TEXT_BYTES.to_string();
     let mut command = hidden_command(curl_exe());
     network.apply_to_command_with_schannel_revocation(&mut command, revocation_check);
-    command
-        .args([
-            "-fsSL",
-            "--proto",
-            "=https",
-            "--proto-redir",
-            "=https",
-            "--connect-timeout",
-            "20",
-            "--max-time",
-            "60",
-            "--max-filesize",
-            &max_text,
-            url,
-        ])
-        .output()
-        .map_err(|e| EngineError::Io(format!("spawn curl: {e}")))
+    command.args([
+        "-fsSL",
+        "--proto",
+        "=https",
+        "--proto-redir",
+        "=https",
+        "--connect-timeout",
+        "20",
+        "--max-time",
+        "60",
+        "--max-filesize",
+        &max_text,
+        url,
+    ]);
+    // curl's own --max-time is the primary budget; the outer deadline is a
+    // backstop that also kills a hung curl that ignored max-time.
+    run_capturing(command, RunLimits::total(std::time::Duration::from_secs(75)), None)
+        .map_err(|e| EngineError::Io(format!("curl: {}", e.message())))
 }
 
 pub fn fetch_text_with_network(url: &str, network: &NetworkConfig) -> Result<String, EngineError> {
@@ -304,10 +330,18 @@ fn powershell_exe() -> PathBuf {
 
 #[cfg(windows)]
 fn run_powershell_json(script: &str) -> Result<String, EngineError> {
-    let output = hidden_command(powershell_exe())
-        .args(["-NoProfile", "-NonInteractive", "-Command", script])
-        .output()
-        .map_err(|e| EngineError::Capability(format!("spawn powershell: {e}")))?;
+    run_powershell_json_with_limits(script, RunLimits::probe())
+}
+
+#[cfg(windows)]
+fn run_powershell_json_with_limits(
+    script: &str,
+    limits: RunLimits,
+) -> Result<String, EngineError> {
+    let mut command = hidden_command(powershell_exe());
+    command.args(["-NoProfile", "-NonInteractive", "-Command", script]);
+    let output = run_capturing(command, limits, None)
+        .map_err(|e| EngineError::Capability(format!("powershell: {}", e.message())))?;
     if !output.status.success() {
         return Err(EngineError::Capability(format!(
             "powershell failed: {}",
@@ -367,7 +401,7 @@ try {{
         path = ps_quote(&path.to_string_lossy()),
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
     );
-    let json = run_powershell_json(&script)
+    let json = run_powershell_json_with_limits(&script, RunLimits::install())
         .map_err(|e| EngineError::Install(format!("run Add-AppxPackage: {e}")))?;
     let mut report: MsixSideloadReport = serde_json::from_str(&json)
         .map_err(|e| EngineError::Install(format!("parse Add-AppxPackage result: {e}")))?;
@@ -635,7 +669,7 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
 "#,
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
     );
-    let json = run_powershell_json(&script)
+    let json = run_powershell_json_with_limits(&script, RunLimits::install())
         .map_err(|e| EngineError::Install(format!("run Remove-AppxPackage: {e}")))?;
     let report: MsixRemoveReport = serde_json::from_str(&json)
         .map_err(|e| EngineError::Install(format!("parse Remove-AppxPackage result: {e}")))?;
@@ -665,9 +699,14 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
 #[cfg(windows)]
 pub fn verify_msix_health() -> MsixHealthReport {
     log::info!("MSIX health check start");
+    // Activation is the expensive step — budget probe + activation window + slack.
+    let limits = RunLimits::total(std::time::Duration::from_secs(
+        60 + MSIX_ACTIVATION_WINDOW_SECS + 15,
+    ));
     let script = format!(
         r#"
 $ErrorActionPreference = 'SilentlyContinue'
+$activationWindowSecs = {activation_window}
 $pkg = Get-AppxPackage -Name {name} |
   Sort-Object -Property Version -Descending |
   Select-Object -First 1
@@ -678,6 +717,9 @@ if ($null -eq $pkg) {{
     status = 'not-registered'
     aumidResolved = $false
     missingDependencies = ''
+    activationOk = $false
+    failureKind = 'not-registered'
+    activationDetail = ''
   }} | ConvertTo-Json -Compress
   exit 0
 }}
@@ -685,6 +727,10 @@ $statusStr = [string]$pkg.Status
 $statusOk = ([string]::IsNullOrEmpty($statusStr) -or $statusStr -eq 'Ok')
 $aumidResolved = $false
 $missing = @()
+$activationOk = $false
+$failureKind = ''
+$activationDetail = ''
+$appId = ''
 function Convert-ToVersion($value) {{
   try {{
     $text = [string]$value
@@ -742,20 +788,110 @@ try {{
     }}
   }}
 }} catch {{}}
+
+# Real activation: shell-start the AUMID and require a process under InstallLocation
+# for the liveness window. Registration alone is not enough on stripped Windows.
+if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
+  if ([string]::IsNullOrEmpty($appId)) {{ $appId = 'App' }}
+  $aumid = [string]$pkg.PackageFamilyName + '!' + $appId
+  $installLoc = [string]$pkg.InstallLocation
+  try {{ $installLoc = [System.IO.Path]::GetFullPath($installLoc).TrimEnd('\') }} catch {{}}
+  try {{
+    Start-Process ("shell:AppsFolder\" + $aumid) -ErrorAction Stop | Out-Null
+    $deadline = (Get-Date).AddSeconds($activationWindowSecs)
+    $sawProcess = $false
+    $stillAlive = $false
+    $targetIds = @()
+    while ((Get-Date) -lt $deadline) {{
+      Start-Sleep -Milliseconds 300
+      $found = @()
+      foreach ($p in @(Get-Process -Name Codex,ChatGPT -ErrorAction SilentlyContinue)) {{
+        try {{
+          $path = [string]$p.Path
+          if (-not $path) {{ continue }}
+          $full = [System.IO.Path]::GetFullPath($path)
+          if ($installLoc -and (
+              $full.Equals($installLoc, [System.StringComparison]::OrdinalIgnoreCase) -or
+              $full.StartsWith($installLoc + '\', [System.StringComparison]::OrdinalIgnoreCase)
+            )) {{
+            $found += $p
+          }}
+        }} catch {{}}
+      }}
+      if ($found.Count -gt 0) {{
+        $sawProcess = $true
+        $targetIds = @($found | ForEach-Object {{ $_.Id }})
+        # Require a short survival stretch so immediate crash-on-launch fails.
+        Start-Sleep -Milliseconds 800
+        $alive = @()
+        foreach ($id in $targetIds) {{
+          $p = Get-Process -Id $id -ErrorAction SilentlyContinue
+          if ($null -ne $p) {{ $alive += $p }}
+        }}
+        if ($alive.Count -gt 0) {{
+          $stillAlive = $true
+          break
+        }}
+      }}
+    }}
+    if ($stillAlive) {{
+      $activationOk = $true
+    }} elseif ($sawProcess) {{
+      $failureKind = 'immediate-exit'
+      $activationDetail = 'package process started then exited during the liveness window'
+    }} else {{
+      $failureKind = 'activation-failed'
+      $activationDetail = 'no process under install location after shell activation'
+    }}
+  }} catch {{
+    $msg = [string]$_.Exception.Message
+    $activationDetail = $msg
+    if ($msg -match '0x80073|policy|denied|Access is denied|0x80070005|blocked') {{
+      $failureKind = 'policy'
+    }} else {{
+      $failureKind = 'activation-failed'
+    }}
+  }}
+}}
+
 [pscustomobject]@{{
   packageRegistered = $true
   statusOk = $statusOk
   status = $statusStr
   aumidResolved = $aumidResolved
   missingDependencies = ($missing -join ', ')
+  activationOk = $activationOk
+  failureKind = $failureKind
+  activationDetail = $activationDetail
 }} | ConvertTo-Json -Compress
 "#,
-        name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
+        name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY),
+        activation_window = MSIX_ACTIVATION_WINDOW_SECS
     );
 
-    let parsed = run_powershell_json(&script)
-        .ok()
-        .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok());
+    let run_result = run_powershell_json_with_limits(&script, limits);
+    let parsed = match &run_result {
+        Ok(json) => serde_json::from_str::<serde_json::Value>(json).ok(),
+        Err(err) => {
+            let msg = err.to_string();
+            if msg.contains("exceeded total deadline") || msg.contains("no progress") {
+                log::info!("MSIX health check result healthy=false status=timeout");
+                return MsixHealthReport {
+                    healthy: false,
+                    verified: true,
+                    package_registered: true,
+                    status: "timeout".to_string(),
+                    status_ok: false,
+                    aumid_resolved: false,
+                    missing_dependencies: vec![],
+                    activation_ok: false,
+                    failure_kind: msix_failure::TIMEOUT.to_string(),
+                    reason: "health probe timed out; routed to portable fallback".to_string(),
+                };
+            }
+            None
+        }
+    };
 
     let Some(value) = parsed else {
         // The health probe itself could not run. On managed/stripped Windows this
@@ -771,6 +907,8 @@ try {{
             status_ok: false,
             aumid_resolved: false,
             missing_dependencies: vec![],
+            activation_ok: false,
+            failure_kind: msix_failure::PROBE_FAILED.to_string(),
             reason: "health probe could not run; routed to portable fallback".to_string(),
         };
     };
@@ -801,22 +939,62 @@ try {{
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect();
+    let activation_ok = value
+        .get("activationOk")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let activation_detail = value
+        .get("activationDetail")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let reported_kind = value
+        .get("failureKind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
 
-    let healthy =
-        package_registered && status_ok && aumid_resolved && missing_dependencies.is_empty();
-    let reason = if healthy {
-        String::new()
-    } else if !package_registered {
-        "the package is not registered after install".to_string()
-    } else if !status_ok {
-        format!("package status is {status}")
-    } else if !aumid_resolved {
-        "could not resolve the app entry (AUMID)".to_string()
-    } else {
-        format!(
-            "missing framework dependencies: {}",
-            missing_dependencies.join(", ")
+    let (healthy, failure_kind, reason) = if !package_registered {
+        (
+            false,
+            msix_failure::NOT_REGISTERED.to_string(),
+            "the package is not registered after install".to_string(),
         )
+    } else if !status_ok {
+        (
+            false,
+            msix_failure::STATUS_BAD.to_string(),
+            format!("package status is {status}"),
+        )
+    } else if !aumid_resolved {
+        (
+            false,
+            msix_failure::AUMID_UNRESOLVED.to_string(),
+            "could not resolve the app entry (AUMID)".to_string(),
+        )
+    } else if !missing_dependencies.is_empty() {
+        (
+            false,
+            msix_failure::MISSING_DEPENDENCIES.to_string(),
+            format!(
+                "missing framework dependencies: {}",
+                missing_dependencies.join(", ")
+            ),
+        )
+    } else if !activation_ok {
+        let kind = if reported_kind.is_empty() {
+            msix_failure::ACTIVATION_FAILED.to_string()
+        } else {
+            reported_kind
+        };
+        let reason = if activation_detail.is_empty() {
+            "package failed real activation / liveness check".to_string()
+        } else {
+            format!("package activation failed: {activation_detail}")
+        };
+        (false, kind, reason)
+    } else {
+        (true, String::new(), String::new())
     };
 
     let report = MsixHealthReport {
@@ -828,11 +1006,14 @@ try {{
         status_ok,
         aumid_resolved,
         missing_dependencies,
+        activation_ok,
+        failure_kind,
         reason,
     };
     let healthy = report.healthy;
     let status = &report.status;
-    log::info!("MSIX health check result healthy={healthy} status={status}");
+    let kind = &report.failure_kind;
+    log::info!("MSIX health check result healthy={healthy} status={status} failure_kind={kind}");
     report
 }
 
@@ -851,6 +1032,8 @@ pub fn verify_msix_health() -> MsixHealthReport {
         status_ok: true,
         aumid_resolved: true,
         missing_dependencies: vec![],
+        activation_ok: true,
+        failure_kind: String::new(),
         reason: "MSIX health checks are only meaningful on Windows".to_string(),
     }
 }
@@ -977,14 +1160,27 @@ pub fn launch_codex_with_options(
                 ))
             })?;
         // CREATE_NO_WINDOW only suppresses a console flash; the GUI still shows.
+        // Require a short liveness window so an immediate crash is reported as a
+        // launch failure instead of a silent no-op.
         let mut command = hidden_command(exe);
         if options.disable_codex_self_updates {
             command.env(CODEX_SELF_UPDATE_ENV_KEY, CODEX_SELF_UPDATE_ENV_DISABLED);
         }
-        command
-            .spawn()
-            .map(|_| ())
-            .map_err(|e| EngineError::Io(format!("launch Codex: {e}")))
+        match spawn_and_require_liveness(command, PORTABLE_LIVENESS_WINDOW) {
+            Ok(LivenessResult::Survived { child }) => {
+                std::mem::forget(child);
+                Ok(())
+            }
+            Ok(LivenessResult::ExitedEarly { code }) => Err(EngineError::Io(format!(
+                "Codex exited immediately after launch (exit={})",
+                code.map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string())
+            ))),
+            Err(err) => Err(EngineError::Io(format!(
+                "launch Codex: {}",
+                err.message()
+            ))),
+        }
     } else {
         if options.disable_codex_self_updates {
             log::debug!(
@@ -1012,7 +1208,8 @@ Start-Process ("shell:AppsFolder\" + $pkg.PackageFamilyName + "!" + $id)
 "#,
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
     );
-    run_powershell_json(&script).map(|_| ())
+    // Activation is fire-and-forget from the shell; bound the AUMID resolve + Start-Process.
+    run_powershell_json_with_limits(&script, RunLimits::probe()).map(|_| ())
 }
 
 #[cfg(not(windows))]
@@ -1305,6 +1502,35 @@ mod tests {
             report.msix_deployment.state,
             crate::capability::CapabilityState::Unavailable
         );
+    }
+
+    #[test]
+    fn msix_health_failure_kinds_are_stable_strings() {
+        // Keep these stable: frontend / notes may switch on them.
+        assert_eq!(super::msix_failure::NOT_REGISTERED, "not-registered");
+        assert_eq!(super::msix_failure::ACTIVATION_FAILED, "activation-failed");
+        assert_eq!(super::msix_failure::IMMEDIATE_EXIT, "immediate-exit");
+        assert_eq!(super::msix_failure::TIMEOUT, "timeout");
+        assert_eq!(super::msix_failure::POLICY, "policy");
+    }
+
+    #[test]
+    fn msix_health_report_defaults_new_fields_on_deserialize() {
+        // Older fixtures without activationOk / failureKind still parse.
+        let report: super::MsixHealthReport = serde_json::from_value(serde_json::json!({
+            "healthy": true,
+            "verified": true,
+            "packageRegistered": true,
+            "status": "Ok",
+            "statusOk": true,
+            "aumidResolved": true,
+            "missingDependencies": [],
+            "reason": ""
+        }))
+        .unwrap();
+        assert!(report.healthy);
+        assert!(!report.activation_ok); // default false when absent
+        assert!(report.failure_kind.is_empty());
     }
 
     // Pure routing logic for the framework pre-check — verified on every host so

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -13,7 +13,8 @@ use crate::msix::parse_appx_manifest_xml;
 use crate::network::{is_schannel_revocation_offline, NetworkConfig, SchannelRevocationCheck};
 use crate::process::{
     curl_exe, hidden_command, run_capturing, spawn_and_require_liveness, LivenessResult,
-    RunLimits, MSIX_ACTIVATION_WINDOW_SECS, PORTABLE_LIVENESS_WINDOW,
+    RunError, RunLimits, TimeoutKind, MSIX_ACTIVATION_WINDOW_SECS, MSIX_LIVENESS_WINDOW_SECS,
+    PORTABLE_LIVENESS_WINDOW,
 };
 use crate::EngineError;
 
@@ -328,22 +329,56 @@ fn powershell_exe() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("powershell.exe"))
 }
 
+/// Typed PowerShell runner failure so callers can branch on timeout without
+/// string-matching human messages.
+#[cfg(windows)]
+#[derive(Debug)]
+enum PowerShellRunError {
+    Timeout(TimeoutKind),
+    Other(String),
+}
+
+#[cfg(windows)]
+impl PowerShellRunError {
+    fn message(&self) -> String {
+        match self {
+            Self::Timeout(TimeoutKind::Total) => {
+                "powershell: process exceeded total deadline".to_string()
+            }
+            Self::Timeout(TimeoutKind::Stall) => {
+                "powershell: process made no progress within stall timeout".to_string()
+            }
+            Self::Other(msg) => msg.clone(),
+        }
+    }
+
+    fn into_capability(self) -> EngineError {
+        EngineError::Capability(self.message())
+    }
+
+    fn into_install(self) -> EngineError {
+        EngineError::Install(self.message())
+    }
+}
+
 #[cfg(windows)]
 fn run_powershell_json(script: &str) -> Result<String, EngineError> {
-    run_powershell_json_with_limits(script, RunLimits::probe())
+    run_powershell_json_with_limits(script, RunLimits::probe()).map_err(|e| e.into_capability())
 }
 
 #[cfg(windows)]
 fn run_powershell_json_with_limits(
     script: &str,
     limits: RunLimits,
-) -> Result<String, EngineError> {
+) -> Result<String, PowerShellRunError> {
     let mut command = hidden_command(powershell_exe());
     command.args(["-NoProfile", "-NonInteractive", "-Command", script]);
-    let output = run_capturing(command, limits, None)
-        .map_err(|e| EngineError::Capability(format!("powershell: {}", e.message())))?;
+    let output = run_capturing(command, limits, None).map_err(|e| match e {
+        RunError::Timeout { kind, .. } => PowerShellRunError::Timeout(kind),
+        other => PowerShellRunError::Other(format!("powershell: {}", other.message())),
+    })?;
     if !output.status.success() {
-        return Err(EngineError::Capability(format!(
+        return Err(PowerShellRunError::Other(format!(
             "powershell failed: {}",
             String::from_utf8_lossy(&output.stderr).trim()
         )));
@@ -402,7 +437,7 @@ try {{
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
     );
     let json = run_powershell_json_with_limits(&script, RunLimits::install())
-        .map_err(|e| EngineError::Install(format!("run Add-AppxPackage: {e}")))?;
+        .map_err(|e| EngineError::Install(format!("run Add-AppxPackage: {}", e.message())))?;
     let mut report: MsixSideloadReport = serde_json::from_str(&json)
         .map_err(|e| EngineError::Install(format!("parse Add-AppxPackage result: {e}")))?;
     if let Some(installed) = report.installed.take() {
@@ -670,7 +705,7 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
     );
     let json = run_powershell_json_with_limits(&script, RunLimits::install())
-        .map_err(|e| EngineError::Install(format!("run Remove-AppxPackage: {e}")))?;
+        .map_err(|e| EngineError::Install(format!("run Remove-AppxPackage: {}", e.message())))?;
     let report: MsixRemoveReport = serde_json::from_str(&json)
         .map_err(|e| EngineError::Install(format!("parse Remove-AppxPackage result: {e}")))?;
     if report.success {
@@ -696,17 +731,70 @@ pub fn remove_msix_package() -> Result<MsixRemoveReport, EngineError> {
     })
 }
 
+/// Best-effort: close Codex processes belonging to the registered OpenAI.Codex
+/// MSIX package (by InstallLocation). Used after an activation probe that may
+/// have started the app, and before portable fallback / Remove-AppxPackage.
+/// Failures are logged and swallowed — cleanup must not block fallback.
+#[cfg(windows)]
+pub fn close_msix_codex_processes(timeout_secs: u64) -> Result<(), EngineError> {
+    let script = format!(
+        r#"
+$ErrorActionPreference = 'SilentlyContinue'
+$pkg = Get-AppxPackage -Name {name} |
+  Sort-Object -Property Version -Descending |
+  Select-Object -First 1
+if ($null -eq $pkg) {{ 'no-package'; exit 0 }}
+$loc = [string]$pkg.InstallLocation
+if ([string]::IsNullOrWhiteSpace($loc)) {{ 'no-location'; exit 0 }}
+try {{ $loc = [System.IO.Path]::GetFullPath($loc).TrimEnd('\') }} catch {{}}
+Write-Output $loc
+"#,
+        name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
+    );
+    let loc = match run_powershell_json_with_limits(&script, RunLimits::probe()) {
+        Ok(s) => s.trim().to_string(),
+        Err(err) => {
+            log::warn!(
+                "close MSIX Codex processes: could not resolve install location error={}",
+                err.message()
+            );
+            return Ok(());
+        }
+    };
+    if loc.is_empty() || loc == "no-package" || loc == "no-location" {
+        return Ok(());
+    }
+    crate::portable::close_codex_gracefully_for_root(timeout_secs, Path::new(&loc))
+}
+
+#[cfg(not(windows))]
+pub fn close_msix_codex_processes(_timeout_secs: u64) -> Result<(), EngineError> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn best_effort_close_msix_after_probe() {
+    // Start-Process detaches from the PowerShell tree, so killing the probe on
+    // timeout leaves Codex running. Always try to reap it before the caller
+    // falls back / removes the package.
+    if let Err(err) = close_msix_codex_processes(15) {
+        log::warn!("best-effort MSIX process cleanup after probe failed error={err}");
+    }
+}
+
 #[cfg(windows)]
 pub fn verify_msix_health() -> MsixHealthReport {
     log::info!("MSIX health check start");
-    // Activation is the expensive step — budget probe + activation window + slack.
+    // Activation is the expensive step — budget deps probe + cold-start window +
+    // continuous liveness + cleanup + slack.
     let limits = RunLimits::total(std::time::Duration::from_secs(
-        60 + MSIX_ACTIVATION_WINDOW_SECS + 15,
+        60 + MSIX_ACTIVATION_WINDOW_SECS + MSIX_LIVENESS_WINDOW_SECS + 30,
     ));
     let script = format!(
         r#"
 $ErrorActionPreference = 'SilentlyContinue'
 $activationWindowSecs = {activation_window}
+$livenessWindowSecs = {liveness_window}
 $pkg = Get-AppxPackage -Name {name} |
   Sort-Object -Property Version -Descending |
   Select-Object -First 1
@@ -731,6 +819,9 @@ $activationOk = $false
 $failureKind = ''
 $activationDetail = ''
 $appId = ''
+$installLoc = ''
+$targetIds = @()
+$activationAttempted = $false
 function Convert-ToVersion($value) {{
   try {{
     $text = [string]$value
@@ -748,6 +839,52 @@ function Same-Architecture($package, [string]$required) {{
   if ([string]::IsNullOrWhiteSpace($required) -or $required -eq 'neutral') {{ return $true }}
   $arch = [string]$package.Architecture
   return [string]::IsNullOrWhiteSpace($arch) -or $arch -eq 'Neutral' -or $arch -eq $required
+}}
+# AppX / protected processes often leave Get-Process.Path empty. Fall through
+# MainModule and CIM so a live Codex is not treated as activation-failed.
+function Get-ProcessExePath($p) {{
+  try {{
+    $path = [string]$p.Path
+    if (-not [string]::IsNullOrWhiteSpace($path)) {{ return $path }}
+  }} catch {{}}
+  try {{
+    $path = [string]$p.MainModule.FileName
+    if (-not [string]::IsNullOrWhiteSpace($path)) {{ return $path }}
+  }} catch {{}}
+  try {{
+    $cim = Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId=" + $p.Id) -ErrorAction SilentlyContinue
+    if ($null -ne $cim -and -not [string]::IsNullOrWhiteSpace([string]$cim.ExecutablePath)) {{
+      return [string]$cim.ExecutablePath
+    }}
+  }} catch {{}}
+  return $null
+}}
+function Test-UnderInstall($p, [string]$root) {{
+  if ([string]::IsNullOrWhiteSpace($root)) {{ return $false }}
+  $path = Get-ProcessExePath $p
+  if ([string]::IsNullOrWhiteSpace($path)) {{ return $false }}
+  try {{
+    $full = [System.IO.Path]::GetFullPath($path)
+    return ($full.Equals($root, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $full.StartsWith($root + '\', [System.StringComparison]::OrdinalIgnoreCase))
+  }} catch {{
+    return $false
+  }}
+}}
+function Get-PackageProcesses([string]$root) {{
+  $found = @()
+  foreach ($p in @(Get-Process -Name Codex,ChatGPT -ErrorAction SilentlyContinue)) {{
+    if (Test-UnderInstall $p $root) {{ $found += $p }}
+  }}
+  return $found
+}}
+function Stop-PackageProcesses([string]$root, $ids) {{
+  foreach ($id in @($ids)) {{
+    try {{ Stop-Process -Id $id -Force -ErrorAction SilentlyContinue }} catch {{}}
+  }}
+  foreach ($p in @(Get-PackageProcesses $root)) {{
+    try {{ Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }} catch {{}}
+  }}
 }}
 try {{
   $manifest = Get-AppxPackageManifest $pkg -ErrorAction Stop
@@ -790,48 +927,48 @@ try {{
 }} catch {{}}
 
 # Real activation: shell-start the AUMID and require a process under InstallLocation
-# for the liveness window. Registration alone is not enough on stripped Windows.
+# for a continuous liveness window aligned with portable. Registration alone is
+# not enough on stripped Windows.
 if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
   if ([string]::IsNullOrEmpty($appId)) {{ $appId = 'App' }}
   $aumid = [string]$pkg.PackageFamilyName + '!' + $appId
   $installLoc = [string]$pkg.InstallLocation
   try {{ $installLoc = [System.IO.Path]::GetFullPath($installLoc).TrimEnd('\') }} catch {{}}
+  $activationAttempted = $true
   try {{
     Start-Process ("shell:AppsFolder\" + $aumid) -ErrorAction Stop | Out-Null
     $deadline = (Get-Date).AddSeconds($activationWindowSecs)
     $sawProcess = $false
     $stillAlive = $false
-    $targetIds = @()
     while ((Get-Date) -lt $deadline) {{
       Start-Sleep -Milliseconds 300
-      $found = @()
-      foreach ($p in @(Get-Process -Name Codex,ChatGPT -ErrorAction SilentlyContinue)) {{
-        try {{
-          $path = [string]$p.Path
-          if (-not $path) {{ continue }}
-          $full = [System.IO.Path]::GetFullPath($path)
-          if ($installLoc -and (
-              $full.Equals($installLoc, [System.StringComparison]::OrdinalIgnoreCase) -or
-              $full.StartsWith($installLoc + '\', [System.StringComparison]::OrdinalIgnoreCase)
-            )) {{
-            $found += $p
-          }}
-        }} catch {{}}
-      }}
-      if ($found.Count -gt 0) {{
-        $sawProcess = $true
-        $targetIds = @($found | ForEach-Object {{ $_.Id }})
-        # Require a short survival stretch so immediate crash-on-launch fails.
-        Start-Sleep -Milliseconds 800
+      $found = @(Get-PackageProcesses $installLoc)
+      if ($found.Count -eq 0) {{ continue }}
+      $sawProcess = $true
+      $targetIds = @($found | ForEach-Object {{ $_.Id }} | Select-Object -Unique)
+      # Continuous survival for $livenessWindowSecs (same bar as portable).
+      $liveDeadline = (Get-Date).AddSeconds($livenessWindowSecs)
+      $continuous = $true
+      while ((Get-Date) -lt $liveDeadline) {{
+        Start-Sleep -Milliseconds 250
         $alive = @()
         foreach ($id in $targetIds) {{
           $p = Get-Process -Id $id -ErrorAction SilentlyContinue
           if ($null -ne $p) {{ $alive += $p }}
         }}
-        if ($alive.Count -gt 0) {{
-          $stillAlive = $true
+        # Also accept replacements under install root (Electron restarts).
+        if ($alive.Count -eq 0) {{
+          $alive = @(Get-PackageProcesses $installLoc)
+          $targetIds = @($alive | ForEach-Object {{ $_.Id }} | Select-Object -Unique)
+        }}
+        if ($alive.Count -eq 0) {{
+          $continuous = $false
           break
         }}
+      }}
+      if ($continuous) {{
+        $stillAlive = $true
+        break
       }}
     }}
     if ($stillAlive) {{
@@ -852,6 +989,11 @@ if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
       $failureKind = 'activation-failed'
     }}
   }}
+  # Unhealthy activation must not leave Codex holding package files open for
+  # the subsequent portable fallback / Remove-AppxPackage.
+  if (-not $activationOk -and $activationAttempted) {{
+    Stop-PackageProcesses $installLoc $targetIds
+  }}
 }}
 
 [pscustomobject]@{{
@@ -866,31 +1008,33 @@ if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
 }} | ConvertTo-Json -Compress
 "#,
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY),
-        activation_window = MSIX_ACTIVATION_WINDOW_SECS
+        activation_window = MSIX_ACTIVATION_WINDOW_SECS,
+        liveness_window = MSIX_LIVENESS_WINDOW_SECS
     );
 
     let run_result = run_powershell_json_with_limits(&script, limits);
     let parsed = match &run_result {
         Ok(json) => serde_json::from_str::<serde_json::Value>(json).ok(),
-        Err(err) => {
-            let msg = err.to_string();
-            if msg.contains("exceeded total deadline") || msg.contains("no progress") {
-                log::info!("MSIX health check result healthy=false status=timeout");
-                return MsixHealthReport {
-                    healthy: false,
-                    verified: true,
-                    package_registered: true,
-                    status: "timeout".to_string(),
-                    status_ok: false,
-                    aumid_resolved: false,
-                    missing_dependencies: vec![],
-                    activation_ok: false,
-                    failure_kind: msix_failure::TIMEOUT.to_string(),
-                    reason: "health probe timed out; routed to portable fallback".to_string(),
-                };
-            }
-            None
+        Err(PowerShellRunError::Timeout(kind)) => {
+            log::info!(
+                "MSIX health check result healthy=false status=timeout kind={kind:?}"
+            );
+            // Start-Process detaches; kill any process the timed-out probe left running.
+            best_effort_close_msix_after_probe();
+            return MsixHealthReport {
+                healthy: false,
+                verified: true,
+                package_registered: true,
+                status: "timeout".to_string(),
+                status_ok: false,
+                aumid_resolved: false,
+                missing_dependencies: vec![],
+                activation_ok: false,
+                failure_kind: msix_failure::TIMEOUT.to_string(),
+                reason: "health probe timed out; routed to portable fallback".to_string(),
+            };
         }
+        Err(_) => None,
     };
 
     let Some(value) = parsed else {
@@ -899,6 +1043,7 @@ if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
         // so treat the verdict as degraded and let the caller fall back to the
         // portable build instead of silently keeping an unverifiable package.
         log::info!("MSIX health check result healthy=false status=probe-failed");
+        best_effort_close_msix_after_probe();
         return MsixHealthReport {
             healthy: false,
             verified: false,
@@ -1209,7 +1354,9 @@ Start-Process ("shell:AppsFolder\" + $pkg.PackageFamilyName + "!" + $id)
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY)
     );
     // Activation is fire-and-forget from the shell; bound the AUMID resolve + Start-Process.
-    run_powershell_json_with_limits(&script, RunLimits::probe()).map(|_| ())
+    run_powershell_json_with_limits(&script, RunLimits::probe())
+        .map(|_| ())
+        .map_err(|e| e.into_install())
 }
 
 #[cfg(not(windows))]
@@ -1512,6 +1659,28 @@ mod tests {
         assert_eq!(super::msix_failure::IMMEDIATE_EXIT, "immediate-exit");
         assert_eq!(super::msix_failure::TIMEOUT, "timeout");
         assert_eq!(super::msix_failure::POLICY, "policy");
+    }
+
+    #[test]
+    fn msix_liveness_window_matches_portable() {
+        assert_eq!(
+            crate::process::MSIX_LIVENESS_WINDOW_SECS,
+            crate::process::PORTABLE_LIVENESS_WINDOW.as_secs()
+        );
+        assert!(crate::process::MSIX_ACTIVATION_WINDOW_SECS >= 20);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn powershell_timeout_is_typed_not_string_matched() {
+        let err = super::PowerShellRunError::Timeout(crate::process::TimeoutKind::Total);
+        assert!(matches!(
+            err,
+            super::PowerShellRunError::Timeout(crate::process::TimeoutKind::Total)
+        ));
+        // Callers classify via the enum arm, not by scraping message text.
+        let msg = err.message();
+        assert!(msg.contains("deadline"));
     }
 
     #[test]

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -12,7 +12,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use serde::{Deserialize, Serialize};
 
 use codex_win_engine::{
-    cancel_active_download, close_codex_gracefully_for_root, detect_installed_codex,
+    cancel_active_download, close_codex_gracefully_for_root, close_msix_codex_processes,
+    detect_installed_codex,
     detect_portable_install, download_to_with_progress_bounded_with_network,
     fetch_text_with_network, find_msix_sha256, install_msix_sideload, install_portable_from_msix,
     limits::MAX_PACKAGE_BYTES, parse_manifest, pause_active_download, plan_update,
@@ -995,6 +996,24 @@ pub fn perform_windows_update_with_install_mode_and_network(
         let health = verify_msix_health();
         if !health.healthy {
             log::warn!("Windows route changed to portable fallback from_route=msix-sideload to_route=portable-fallback");
+            // Activation probe may have started Codex (or left a half-started
+            // process). Close it before portable install and Remove-AppxPackage
+            // so package files unlock cleanly. Prefer the sideload install path
+            // when known; always also sweep via the registered package location.
+            if let Some(installed) = sideload.installed.as_ref() {
+                if let Err(err) =
+                    close_codex_gracefully_for_root(20, PathBuf::from(&installed.path).as_path())
+                {
+                    log::warn!(
+                        "close MSIX Codex after unhealthy health check (install path) error={err}"
+                    );
+                }
+            }
+            if let Err(err) = close_msix_codex_processes(20) {
+                log::warn!(
+                    "close MSIX Codex after unhealthy health check (package sweep) error={err}"
+                );
+            }
             let mut report = install_portable_after_stage(
                 settings,
                 stage,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1421,24 +1421,35 @@ mod open_url_tests {
 }
 
 /// Windows-only: classify the installed Codex (managed / external / none).
+///
+/// Async + `spawn_blocking` so AppX / PowerShell status probes cannot freeze the
+/// WebView when enterprise policy or a hung AppX service stalls detection.
 #[tauri::command]
-pub fn win_status(state: State<'_, ManagerState>) -> Result<WinInstallStatus, CommandError> {
+pub async fn win_status(state: State<'_, ManagerState>) -> Result<WinInstallStatus, CommandError> {
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
     }
     let settings = windows_domain_settings_for_persisted(&state);
-    Ok(win_install_status(&settings))
+    tauri::async_runtime::spawn_blocking(move || win_install_status(&settings))
+        .await
+        .map_err(|e| AppError::Internal(format!("join: {e}")))
+        .map_err(Into::into)
 }
 
 /// Windows-only: adopt the detected external install (after explicit consent).
+///
+/// Async + `spawn_blocking` so filesystem / provenance work stays off the UI thread.
 #[tauri::command]
-pub fn win_adopt(state: State<'_, ManagerState>) -> Result<WinInstallStatus, CommandError> {
+pub async fn win_adopt(state: State<'_, ManagerState>) -> Result<WinInstallStatus, CommandError> {
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
     }
     let _op = begin_guard(&state, OperationKind::Adopt)?;
     let settings = windows_domain_settings_for_persisted(&state);
-    adopt_windows_install(&settings).map_err(Into::into)
+    tauri::async_runtime::spawn_blocking(move || adopt_windows_install(&settings))
+        .await
+        .map_err(|e| AppError::Internal(format!("join: {e}")))?
+        .map_err(Into::into)
 }
 
 /// Windows-only: open the installed Codex.

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -336,7 +336,7 @@ const WIN_FALLBACK_PERFORM: WinPerformReport = {
     rawError: null,
   },
   portable: null,
-  msixHealth: { healthy: true, verified: true, packageRegistered: true, status: "Ok", statusOk: true, aumidResolved: true, missingDependencies: [], reason: "" },
+  msixHealth: { healthy: true, verified: true, packageRegistered: true, status: "Ok", statusOk: true, aumidResolved: true, missingDependencies: [], activationOk: true, failureKind: "", reason: "" },
   installed: {
     path: "C:\\Program Files\\WindowsApps\\OpenAI.Codex_26.602.3474.0_x64__2p2nqsd0c76g0",
     version: "26.602.3474.0",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -321,6 +321,18 @@ export interface MsixHealthReport {
   aumidResolved: boolean;
   /** Declared framework dependencies missing on this machine. */
   missingDependencies: string[];
+  /**
+   * Real shell activation left a process under the package install location
+   * for the liveness window. Registration alone is not enough.
+   */
+  activationOk?: boolean;
+  /**
+   * Machine-stable failure class for notes / routing. Empty when healthy.
+   * Values: not-registered | status-bad | aumid-unresolved |
+   * missing-dependencies | activation-failed | immediate-exit | timeout |
+   * probe-failed | policy.
+   */
+  failureKind?: string;
   /** Human-facing reason when unhealthy; empty when healthy. */
   reason: string;
 }


### PR DESCRIPTION
## Summary
Implements #148: bound all Windows external probes and verify post-install launchability instead of registration/spawn success alone.

### Changes
- **Unified process runner** (`process.rs`): total deadline, optional stall (no-progress) timeout, cancel flag, process-tree cleanup via `taskkill /T` on Windows.
- **curl downloads**: stall timeout (120s) + absolute total bound; cancel kills the curl tree.
- **PowerShell probes**: all AppX / Authenticode / shortcut paths run under probe (45s) or install (180s) budgets.
- **MSIX health**: after registration/status/AUMID/deps checks, performs real `shell:AppsFolder` activation and requires a process under `InstallLocation` for a liveness window. Structured `failureKind`: `not-registered` | `status-bad` | `aumid-unresolved` | `missing-dependencies` | `activation-failed` | `immediate-exit` | `timeout` | `probe-failed` | `policy`.
- **Portable health / launch**: spawn + minimum survival window; immediate exit fails the install/launch.
- **UI thread**: `win_status` / `win_adopt` are async + `spawn_blocking` (alongside existing plan/stage/launch/perform paths).

### Tests
```
cd crates/codex-win-engine && cargo test
```
68 passed, including hung/slow/stall/cancel/immediate-exit process tests and portable immediate-exit health check.

`src-tauri` `cargo check` clean against the engine.

### Manual Windows verification (CI cannot fully cover AppX activation)
1. Fresh machine / VM with Store frameworks present: install via MSIX path → package registers, Codex window appears (activation), report `healthy=true` / `activationOk=true`.
2. Stripped / framework-missing host: sideload registers then health fails with `missing-dependencies` or `activation-failed` / `immediate-exit` → portable fallback.
3. Policy-blocked activation: expect `failureKind=policy` and portable fallback.
4. Corrupt portable payload (replace entry with a quick-exit binary): install health fails with "exited immediately".
5. Simulate hung PowerShell (debugger freeze on `Get-AppxPackage`): status/plan returns within probe budget (~45s) without freezing the WebView.
6. Throttle network mid-download with zero byte growth for >120s: download errors with stall message and curl is killed.

## Test plan
- [x] `cargo test` in `crates/codex-win-engine` (68 ok)
- [x] `cargo check` in `src-tauri`
- [ ] Manual steps above on a real Windows host
