### PR TITLE
ci(windows): test engine crates and packaged lifecycle, and prepare Authenticode signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,15 @@ jobs:
         run: npm run build
       - name: Clippy (deny warnings)
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
-      - name: Test
+      - name: Test (src-tauri)
         run: cargo test --manifest-path src-tauri/Cargo.toml --workspace
+      # Path deps are not workspace members, so their unit/integration tests are
+      # not covered by the step above. Run each engine crate explicitly so
+      # mac/win pure-logic regressions fail required CI on every PR.
+      - name: Test codex-mac-engine (standalone)
+        run: cargo test --manifest-path crates/codex-mac-engine/Cargo.toml --all-targets
+      - name: Test codex-win-engine (standalone)
+        run: cargo test --manifest-path crates/codex-win-engine/Cargo.toml --all-targets
 
   audit:
     name: Audit (report)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,20 +143,32 @@ jobs:
 
       # ── Windows: PE architecture diagnostic (especially ARM64 cross-build) ─
       #    windows-latest is x64; aarch64-pc-windows-msvc is cross-compiled.
-      #    Recording the PE machine type proves the *artifact* is ARM64 without
-      #    claiming runtime verification on ARM64 hardware. See
-      #    docs/windows-signing.md § ARM64.
+      #    Hard-assert the main PE machine type (0xAA64 / 0x8664). The NSIS
+      #    outer -setup.exe is an x86/x64 stub that embeds the payload, so we
+      #    assert machine type on the app binary, not the setup wrapper.
+      #    Cross-compilation ≠ runtime verification. See docs/windows-signing.md.
+      #    Invoke scripts in-process (`& .\scripts\…`); nested `pwsh -File` breaks
+      #    array parameter binding for -Path on GitHub-hosted Windows runners.
       - name: Windows PE architecture diagnostic
         if: matrix.os == 'windows'
         shell: pwsh
         run: |
           $target = "${{ matrix.target }}"
           $main = "src-tauri/target/$target/release/codex-app-manager.exe"
-          $setup = Get-ChildItem "src-tauri/target/$target/release/bundle/nsis/*-setup.exe" -ErrorAction SilentlyContinue
-          $paths = @($main) + @($setup | ForEach-Object { $_.FullName })
-          pwsh -File scripts/windows-pe-arch.ps1 -Path $paths
+          $setup = @(Get-ChildItem "src-tauri/target/$target/release/bundle/nsis/*-setup.exe" -ErrorAction SilentlyContinue)
+          if (-not (Test-Path -LiteralPath $main)) {
+            Write-Host "::error::[build] missing main PE: $main"
+            exit 1
+          }
+          $expect = if ($target -like "aarch64-*") { "0xAA64" } else { "0x8664" }
+          # Hard assert on the app binary only (setup is a host stub).
+          & .\scripts\windows-pe-arch.ps1 -Path $main -ExpectMachine $expect
+          if ($setup.Count -gt 0) {
+            # Report-only for the installer wrapper (no ExpectMachine).
+            & .\scripts\windows-pe-arch.ps1 -Path @($setup | ForEach-Object { $_.FullName })
+          }
           if ($target -like "aarch64-*") {
-            Write-Host "::notice::ARM64 target is cross-built on x64 runners — PE machine type is checked above; full install/launch smoke is x64-only until ARM64 runners or trusted virtualization is available."
+            Write-Host "::notice::ARM64 main PE asserted machine=0xAA64 (cross-build on x64). Full install/launch smoke remains x64-only until ARM64 runners or trusted virtualization is available."
           }
 
       # ── Windows: optional Authenticode (OV/EV) on final NSIS installer ────
@@ -174,7 +186,7 @@ jobs:
           WINDOWS_TIMESTAMP_URL: ${{ vars.WINDOWS_TIMESTAMP_URL }}
         run: |
           $setup = Get-ChildItem "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe" -ErrorAction Stop
-          pwsh -File scripts/sign-windows-authenticode.ps1 -Path @($setup.FullName) -Stage "sign"
+          & .\scripts\sign-windows-authenticode.ps1 -Path $setup.FullName -Stage "sign"
 
       - name: Verify Authenticode on Windows installer
         if: matrix.os == 'windows'
@@ -183,8 +195,8 @@ jobs:
           AUTHENTICODE_MODE: ${{ vars.AUTHENTICODE_REQUIRED == 'true' && 'required' || 'optional' }}
         run: |
           $setup = Get-ChildItem "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe" -ErrorAction Stop
-          pwsh -File scripts/verify-windows-authenticode.ps1 `
-            -Path @($setup.FullName) `
+          & .\scripts\verify-windows-authenticode.ps1 `
+            -Path $setup.FullName `
             -Mode $env:AUTHENTICODE_MODE `
             -Stage "sign-verify"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 #   sign + notarize + staple + repackage updater/dmg) → collect → publish a
 #   GitHub Release with the Tauri updater manifest (latest.json).
 #
-# Required repo secrets (Settings ▸ Secrets and variables ▸ Actions):
+# Required repo secrets (Settings ▸ Secrets and variables ▸ Actions / release env):
 #   APPLE_CERTIFICATE            base64 of your "Developer ID Application" .p12
 #   APPLE_CERTIFICATE_PASSWORD   password for that .p12
 #   APPLE_SIGNING_IDENTITY       "Developer ID Application: NAME (TEAMID)"
@@ -15,6 +15,12 @@ name: Release
 #   AC_API_KEY_BASE64            base64 of the AuthKey_XXXX.p8
 #   TAURI_SIGNING_PRIVATE_KEY            updater private key (string)
 #   TAURI_SIGNING_PRIVATE_KEY_PASSWORD   its password (empty if none)
+#
+# Optional Windows Authenticode (non-blocking until configured; see docs/windows-signing.md):
+#   WINDOWS_CERTIFICATE          base64 of OV/EV code-signing .pfx
+#   WINDOWS_CERTIFICATE_PASSWORD password for that .pfx
+#   vars.AUTHENTICODE_REQUIRED   set to "true" to fail release when PE is unsigned
+#   vars.WINDOWS_TIMESTAMP_URL   optional RFC3161 timestamp URL override
 
 on:
   push:
@@ -135,14 +141,63 @@ jobs:
           export AC_API_KEY="$RUNNER_TEMP/AuthKey.p8"
           bash scripts/finalize-macos.sh "${{ matrix.target }}"
 
+      # ── Windows: PE architecture diagnostic (especially ARM64 cross-build) ─
+      #    windows-latest is x64; aarch64-pc-windows-msvc is cross-compiled.
+      #    Recording the PE machine type proves the *artifact* is ARM64 without
+      #    claiming runtime verification on ARM64 hardware. See
+      #    docs/windows-signing.md § ARM64.
+      - name: Windows PE architecture diagnostic
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $target = "${{ matrix.target }}"
+          $main = "src-tauri/target/$target/release/codex-app-manager.exe"
+          $setup = Get-ChildItem "src-tauri/target/$target/release/bundle/nsis/*-setup.exe" -ErrorAction SilentlyContinue
+          $paths = @($main) + @($setup | ForEach-Object { $_.FullName })
+          pwsh -File scripts/windows-pe-arch.ps1 -Path $paths
+          if ($target -like "aarch64-*") {
+            Write-Host "::notice::ARM64 target is cross-built on x64 runners — PE machine type is checked above; full install/launch smoke is x64-only until ARM64 runners or trusted virtualization is available."
+          }
+
+      # ── Windows: optional Authenticode (OV/EV) on final NSIS installer ────
+      #    Non-blocking until WINDOWS_CERTIFICATE is configured in the release
+      #    environment. When present, signs the published -setup.exe. Full
+      #    inside-out signing of main binary + uninstaller should eventually
+      #    move into tauri build via certificateThumbprint (docs/windows-signing.md).
+      #    This is independent of the Tauri updater minisign key below.
+      - name: Authenticode-sign Windows installer (optional)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_TIMESTAMP_URL: ${{ vars.WINDOWS_TIMESTAMP_URL }}
+        run: |
+          $setup = Get-ChildItem "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe" -ErrorAction Stop
+          pwsh -File scripts/sign-windows-authenticode.ps1 -Path @($setup.FullName) -Stage "sign"
+
+      - name: Verify Authenticode on Windows installer
+        if: matrix.os == 'windows'
+        shell: pwsh
+        env:
+          AUTHENTICODE_MODE: ${{ vars.AUTHENTICODE_REQUIRED == 'true' && 'required' || 'optional' }}
+        run: |
+          $setup = Get-ChildItem "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe" -ErrorAction Stop
+          pwsh -File scripts/verify-windows-authenticode.ps1 `
+            -Path @($setup.FullName) `
+            -Mode $env:AUTHENTICODE_MODE `
+            -Stage "sign-verify"
+
       # ── Windows: sign the NSIS installer for the updater ──────────────────
-      #    The build is intentionally unsigned (mirroring macOS), so Tauri emits
-      #    no `.sig`. In Tauri 2 the Windows updater ships the `-setup.exe`
-      #    itself, so signing it here with the updater key — exactly what
-      #    finalize-macos.sh does for the .app.tar.gz — is equivalent to
-      #    `createUpdaterArtifacts` and is what gets windows-x86_64 and
-      #    windows-aarch64 into latest.json. Without it the manifest has macOS
-      #    platforms only and Windows in-app self-update never sees new versions.
+      #    The build is intentionally unsigned for Authenticode (until OV/EV is
+      #    configured), so Tauri emits no updater `.sig` during build. In Tauri 2
+      #    the Windows updater ships the `-setup.exe` itself, so signing it here
+      #    with the updater key — exactly what finalize-macos.sh does for the
+      #    .app.tar.gz — is equivalent to `createUpdaterArtifacts` and is what
+      #    gets windows-x86_64 and windows-aarch64 into latest.json. Without it
+      #    the manifest has macOS platforms only and Windows in-app self-update
+      #    never sees new versions.
+      #    NOTE: updater signature ≠ Authenticode ≠ SmartScreen reputation.
       - name: Sign Windows updater artifact
         if: matrix.os == 'windows'
         shell: bash
@@ -150,6 +205,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
+          echo "::group::[sign] Tauri updater signature (.sig)"
           B="src-tauri/target/${{ matrix.target }}/release/bundle"
           shopt -s nullglob
           signed=0
@@ -158,15 +214,17 @@ jobs:
             signed=$((signed + 1))
           done
           if [ "$signed" -eq 0 ]; then
-            echo "::error::no NSIS -setup.exe found to sign under $B/nsis" >&2
+            echo "::error::[sign] no NSIS -setup.exe found to sign under $B/nsis" >&2
             exit 1
           fi
+          echo "::endgroup::"
 
       # ── Collect artifacts (rename macOS updater tarball with its arch so the
       #    two macOS jobs don't collide when merged) ──────────────────────────
       - name: Collect artifacts
         shell: bash
         run: |
+          echo "::group::[build] collect final publishable artifacts"
           DST="$GITHUB_WORKSPACE/dist-artifacts"; mkdir -p "$DST"
           B="src-tauri/target/${{ matrix.target }}/release/bundle"
           ARCH="${{ matrix.target }}"; ARCH="${ARCH%%-*}"
@@ -188,6 +246,26 @@ jobs:
             done
           fi
           ls -la "$DST"
+          # Gate on final publishable names (not intermediate target/ paths).
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            setup_count=$(ls -1 "$DST"/*-setup.exe 2>/dev/null | wc -l | tr -d ' ')
+            sig_count=$(ls -1 "$DST"/*-setup.exe.sig 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$setup_count" -lt 1 ]; then
+              echo "::error::[build] no final *-setup.exe in dist-artifacts" >&2
+              exit 1
+            fi
+            if [ "$sig_count" -lt 1 ]; then
+              echo "::error::[sign] no final *-setup.exe.sig in dist-artifacts (updater signature missing)" >&2
+              exit 1
+            fi
+          else
+            dmg_count=$(ls -1 "$DST"/*.dmg 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$dmg_count" -lt 1 ]; then
+              echo "::error::[build] no final *.dmg in dist-artifacts" >&2
+              exit 1
+            fi
+          fi
+          echo "::endgroup::"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
@@ -220,6 +298,42 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      # Validate the merged *publishable* tree (renamed final names), not the
+      # per-target intermediate build directories from the matrix jobs.
+      - name: Validate final release artifacts
+        shell: bash
+        run: |
+          echo "::group::[build] validate final publishable artifacts"
+          set -euo pipefail
+          ls -la dist
+          missing=0
+          require() {
+            local pattern="$1"
+            # shellcheck disable=SC2086
+            if ! compgen -G "dist/$pattern" > /dev/null; then
+              echo "::error::[build] missing final artifact matching: $pattern"
+              missing=1
+            else
+              echo "OK $pattern → $(compgen -G "dist/$pattern" | tr '\n' ' ')"
+            fi
+          }
+          require "CodexAppManager_aarch64.dmg"
+          require "CodexAppManager_x86_64.dmg"
+          require "CodexAppManager_aarch64.app.tar.gz"
+          require "CodexAppManager_x86_64.app.tar.gz"
+          require "CodexAppManager_aarch64.app.tar.gz.sig"
+          require "CodexAppManager_x86_64.app.tar.gz.sig"
+          # Windows NSIS names after space-stripping (see Collect artifacts).
+          require "*x64*-setup.exe"
+          require "*arm64*-setup.exe"
+          require "*x64*-setup.exe.sig"
+          require "*arm64*-setup.exe.sig"
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::[build] final artifact validation failed"
+            exit 1
+          fi
+          echo "::endgroup::"
 
       - name: Generate updater manifest (latest.json)
         env:

--- a/.github/workflows/win-installer-check.yml
+++ b/.github/workflows/win-installer-check.yml
@@ -10,6 +10,9 @@ name: Windows installer check
 #
 # ARM64 is NOT smoke-tested here: GitHub-hosted runners are x64, and a
 # cross-built ARM64 PE is not runtime verification. See docs/windows-signing.md.
+#
+# CI shell is already `pwsh` — invoke helper scripts in-process with
+# `& .\scripts\...ps1` (nested `pwsh -File ... -Path @(…)` breaks array binding).
 
 on:
   pull_request:
@@ -64,6 +67,7 @@ jobs:
       # exfiltrate keys. createUpdaterArtifacts is off; Authenticode remains a
       # release-time concern (release.yml) with optional post-build path.
       - name: Build NSIS installer
+        id: build
         shell: bash
         run: |
           echo "::group::[build] tauri nsis x86_64"
@@ -82,9 +86,17 @@ jobs:
             exit 1
           }
           $main = "src-tauri/target/x86_64-pc-windows-msvc/release/codex-app-manager.exe"
+          if (-not (Test-Path -LiteralPath $main)) {
+            Write-Host "::error::[build] missing main PE: $main"
+            exit 1
+          }
           Write-Host "INSTALLER=$($setup.FullName)"
           "installer=$($setup.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          pwsh -File scripts/windows-pe-arch.ps1 -Path @($main, $setup.FullName)
+          # In-process invoke — do not nest `pwsh -File` (array -Path binding breaks).
+          # Hard-assert the app PE only; NSIS -setup.exe is a host stub and may
+          # not match the payload architecture.
+          & .\scripts\windows-pe-arch.ps1 -Path $main -ExpectMachine 0x8664
+          & .\scripts\windows-pe-arch.ps1 -Path $setup.FullName
 
       - name: Authenticode probe (optional / non-blocking)
         shell: pwsh
@@ -92,8 +104,8 @@ jobs:
           # Flip to "required" via repo variable once OV/EV is wired into release.
           AUTHENTICODE_MODE: ${{ vars.AUTHENTICODE_REQUIRED == 'true' && 'required' || 'optional' }}
         run: |
-          pwsh -File scripts/verify-windows-authenticode.ps1 `
-            -Path @("${{ steps.artifact.outputs.installer }}") `
+          & .\scripts\verify-windows-authenticode.ps1 `
+            -Path "${{ steps.artifact.outputs.installer }}" `
             -Mode $env:AUTHENTICODE_MODE `
             -Stage "sign-verify"
 
@@ -102,11 +114,14 @@ jobs:
         env:
           AUTHENTICODE_MODE: ${{ vars.AUTHENTICODE_REQUIRED == 'true' && 'required' || 'optional' }}
         run: |
-          pwsh -File scripts/windows-packaged-smoke.ps1 `
+          & .\scripts\windows-packaged-smoke.ps1 `
             -Installer "${{ steps.artifact.outputs.installer }}" `
             -AuthenticodeMode $env:AUTHENTICODE_MODE
 
+      # Upload even when smoke fails so the built installer can be inspected.
+      # Still requires the build/locate steps to have produced a setup.exe.
       - name: Upload installer
+        if: ${{ always() && steps.artifact.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: nsis-installer

--- a/.github/workflows/win-installer-check.yml
+++ b/.github/workflows/win-installer-check.yml
@@ -2,14 +2,30 @@ name: Windows installer check
 
 # Builds the NSIS installer (the only place the custom template + branding +
 # languages are exercised — the PR `ci.yml` matrix runs clippy/tests but never
-# bundles). Runs when the installer template, brand images, or bundle config
-# change, and uploads the -setup.exe so it can be inspected on a real Windows box.
+# bundles), then runs a packaged lifecycle smoke on Windows x64:
+# install → first launch → upgrade → uninstall.
+#
+# Also probes Authenticode on the installer and installed PE files in
+# non-blocking (optional) mode until OV/EV secrets are configured.
+#
+# ARM64 is NOT smoke-tested here: GitHub-hosted runners are x64, and a
+# cross-built ARM64 PE is not runtime verification. See docs/windows-signing.md.
 
 on:
   pull_request:
     paths:
       - "src-tauri/installer/**"
       - "src-tauri/tauri.conf.json"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
+      - "src-tauri/src/**"
+      - "crates/**"
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/windows-*.ps1"
+      - "scripts/sign-windows-authenticode.ps1"
+      - "scripts/verify-windows-authenticode.ps1"
       - ".github/workflows/win-installer-check.yml"
   workflow_dispatch:
 
@@ -44,12 +60,51 @@ jobs:
       # NSIS only — just needs to compile the template, resolve the brand images,
       # and link all languages. NO signing secrets here on purpose: this is a
       # pull_request trigger running PR-authored code (config/template/hooks), so
-      # exposing TAURI_SIGNING_PRIVATE_KEY would let a PR exfiltrate the updater
-      # signing key. The build doesn't need it (createUpdaterArtifacts is off);
-      # signing the updater artifact is a release-time concern (release.yml).
+      # exposing TAURI_SIGNING_PRIVATE_KEY / WINDOWS_CERTIFICATE would let a PR
+      # exfiltrate keys. createUpdaterArtifacts is off; Authenticode remains a
+      # release-time concern (release.yml) with optional post-build path.
       - name: Build NSIS installer
         shell: bash
-        run: npm run tauri build -- --bundles nsis --target x86_64-pc-windows-msvc
+        run: |
+          echo "::group::[build] tauri nsis x86_64"
+          npm run tauri build -- --bundles nsis --target x86_64-pc-windows-msvc
+          echo "::endgroup::"
+
+      - name: Locate installer + PE arch diagnostic
+        id: artifact
+        shell: pwsh
+        run: |
+          $nsis = "src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"
+          $setup = Get-ChildItem -Path $nsis -Filter "*-setup.exe" -ErrorAction Stop |
+            Select-Object -First 1
+          if (-not $setup) {
+            Write-Host "::error::[build] no *-setup.exe under $nsis"
+            exit 1
+          }
+          $main = "src-tauri/target/x86_64-pc-windows-msvc/release/codex-app-manager.exe"
+          Write-Host "INSTALLER=$($setup.FullName)"
+          "installer=$($setup.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          pwsh -File scripts/windows-pe-arch.ps1 -Path @($main, $setup.FullName)
+
+      - name: Authenticode probe (optional / non-blocking)
+        shell: pwsh
+        env:
+          # Flip to "required" via repo variable once OV/EV is wired into release.
+          AUTHENTICODE_MODE: ${{ vars.AUTHENTICODE_REQUIRED == 'true' && 'required' || 'optional' }}
+        run: |
+          pwsh -File scripts/verify-windows-authenticode.ps1 `
+            -Path @("${{ steps.artifact.outputs.installer }}") `
+            -Mode $env:AUTHENTICODE_MODE `
+            -Stage "sign-verify"
+
+      - name: Packaged lifecycle smoke (install / launch / upgrade / uninstall)
+        shell: pwsh
+        env:
+          AUTHENTICODE_MODE: ${{ vars.AUTHENTICODE_REQUIRED == 'true' && 'required' || 'optional' }}
+        run: |
+          pwsh -File scripts/windows-packaged-smoke.ps1 `
+            -Installer "${{ steps.artifact.outputs.installer }}" `
+            -AuthenticodeMode $env:AUTHENTICODE_MODE
 
       - name: Upload installer
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,7 +45,27 @@ Omit the `AC_API_*` vars to skip notarization for a quick local dev finalize.
 
 Windows has no light/dark adaptive app icon (`.ico` is static) — the single
 Default icon is used. NSIS installer + updater bundle are produced by `tauri
-build`; no extra finalize step.
+build`; no Apple-style finalize step.
+
+Post-build on the Windows matrix (see [`release.yml`](../.github/workflows/release.yml)):
+
+1. **PE arch diagnostic** — `scripts/windows-pe-arch.ps1` records x64 vs ARM64
+   machine types. ARM64 is cross-built on x64 runners; this is **not** runtime
+   verification ([`docs/windows-signing.md`](./windows-signing.md)).
+2. **Optional Authenticode** — `scripts/sign-windows-authenticode.ps1` signs the
+   final `-setup.exe` when `WINDOWS_CERTIFICATE` is present; otherwise skips.
+3. **Authenticode verify** — `scripts/verify-windows-authenticode.ps1` in
+   `optional` mode by default; set `AUTHENTICODE_REQUIRED=true` to gate.
+4. **Tauri updater `.sig`** — `npx tauri signer sign` (always required for
+   Windows in-app update entries in `latest.json`).
+5. **Collect final artifacts** — space-stripped names under `dist-artifacts/`,
+   with an explicit check that both `-setup.exe` and `-setup.exe.sig` exist.
+
+PR-time x64 packaged smoke lives in
+[`win-installer-check.yml`](../.github/workflows/win-installer-check.yml)
+(`scripts/windows-packaged-smoke.ps1`: install → launch → upgrade → uninstall).
+Required CI (`ci.yml`) also runs standalone engine crate tests for
+`codex-mac-engine` and `codex-win-engine`.
 
 ## Required GitHub Actions secrets
 
@@ -61,8 +81,20 @@ build`; no extra finalize step.
 | `TAURI_SIGNING_PRIVATE_KEY` | updater private key |
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | its password (empty if none) |
 
-Export your local .p12 / .p8 to base64 with `base64 -i file -o -`.
+### Optional Windows Authenticode secrets / vars
+
+| Name | What |
+|---|---|
+| `WINDOWS_CERTIFICATE` | base64 of OV/EV code-signing **.pfx** (release env) |
+| `WINDOWS_CERTIFICATE_PASSWORD` | password for that .pfx |
+| `AUTHENTICODE_REQUIRED` (repo **variable**) | `true` → fail release when PE is not `Valid` |
+| `WINDOWS_TIMESTAMP_URL` (repo **variable**) | optional RFC3161 timestamp URL |
+
+Export your local .p12 / .p8 / .pfx to base64 with `base64 -i file -o -`.
 
 > Artifact globs in the workflow's *Collect* step and the matcher regexes in
 > `gen-updater-manifest.mjs` assume the default Tauri bundler output names —
 > adjust them if your `productName`/bundler config changes the filenames.
+>
+> Keep **updater signature**, **Authenticode**, and **SmartScreen reputation**
+> conceptually separate — see [`docs/windows-signing.md`](./windows-signing.md).

--- a/docs/windows-signing.md
+++ b/docs/windows-signing.md
@@ -5,6 +5,10 @@ signing. The installer is still published through GitHub Releases and the
 agentsmirror download mirror, and every release includes `SHA256SUMS` so users
 can verify the bytes they downloaded.
 
+CI already prepares the Authenticode **path** (sign script, verify script, optional
+release step, packaged lifecycle smoke). Certificate secrets are optional and
+non-blocking until budget/demand justify an OV/EV cert.
+
 ## 中文
 
 ### 当前状态
@@ -13,12 +17,13 @@ can verify the bytes they downloaded.
 - Windows 安装器 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 当前没有 Authenticode 代码签名。
 - Windows 应用内自更新包带有 Tauri updater 签名,用于校验下载字节没有被篡改。
 - Windows 首次手动运行安装器时可能出现 SmartScreen 提示;这是预期风险,不是更新器签名失效。
+- CI 已接入安装包冒烟(x64:`install → launch → upgrade → uninstall`)与 Authenticode 探测;证书未配置时签名步骤跳过且校验为非阻塞。
 
 ### 三个概念
 
-**Tauri updater 签名:** `latest.json` 里的 `signature` 对安装包字节签名。它保护应用内自更新下载,确保镜像或网络传输没有改包。它不参与 Windows 系统的发行者信任判断,也不能消除 SmartScreen 提示。
+**Tauri updater 签名:** `latest.json` 里的 `signature` 对安装包字节签名。它保护应用内自更新下载,确保镜像或网络传输没有改包。它不参与 Windows 系统的发行者信任判断,也不能消除 SmartScreen 提示。实现:`npx tauri signer sign` + `TAURI_SIGNING_PRIVATE_KEY`。
 
-**Authenticode 代码签名:** Windows 对 PE 文件和安装器使用的代码签名体系。拥有 OV 或 EV 证书后,安装器可以显示发行者身份,并更容易建立系统信任。本项目当前还没有给 Windows 安装器做 Authenticode 签名。
+**Authenticode 代码签名:** Windows 对 PE 文件和安装器使用的代码签名体系。拥有 OV 或 EV 证书后,安装器可以显示发行者身份,并更容易建立系统信任。本项目当前还没有给 Windows 安装器做 Authenticode 签名。实现路径见下文「CI / 发布管线」。
 
 **SmartScreen 信誉:** Microsoft Defender SmartScreen 会结合签名身份、下载量、历史信誉和风险信号做拦截判断。EV 证书通常能更快建立信誉;OV 证书和未签名分发都需要累积信誉,未签名安装器首次运行更容易被提示。
 
@@ -60,6 +65,46 @@ shasum -a 256 CodexAppManager_x86_64.dmg
 
 未签名 Windows 安装器意味着用户首次运行可能需要在 SmartScreen 中选择更多信息后继续。项目通过公开 release、镜像直链、`SHA256SUMS`、Tauri updater 签名和透明文档降低篡改与误解风险;这不能替代 Authenticode,但可以让用户在证书预算到位前做独立核验。
 
+### CI / 发布管线(Authenticode 路径)
+
+| 阶段 | 行为 | 阻塞? |
+|---|---|---|
+| `ci.yml` Rust | 独立跑 `codex-mac-engine` / `codex-win-engine` 测试 | 是(required) |
+| `win-installer-check.yml` | 构建 x64 NSIS → Authenticode 探测 → 安装/启动/升级/卸载冒烟 | 否(路径变更时跑) |
+| `release.yml` Windows | PE 架构诊断 → 可选 Authenticode 签名 → Authenticode 校验 → Tauri updater `.sig` → 收集**最终**工件 | updater `.sig` 与工件齐全为阻塞;Authenticode 默认非阻塞 |
+| ARM64 | 交叉构建 + PE machine=`0xAA64` 诊断;**不是**实机运行验证 | 交叉构建失败阻塞;运行验证见下 |
+
+**启用 Authenticode(证书就绪后):**
+
+1. 在 `release` environment 配置 secrets:
+   - `WINDOWS_CERTIFICATE` — base64 编码的 OV/EV `.pfx`
+   - `WINDOWS_CERTIFICATE_PASSWORD` — pfx 密码
+2. (可选) repo variable `WINDOWS_TIMESTAMP_URL` 覆盖默认 RFC3161 时间戳。
+3. 确认 `release.yml` 的 *Authenticode-sign Windows installer* 步骤对 `-setup.exe` 签出 `Valid`。
+4. 将 repo variable `AUTHENTICODE_REQUIRED=true`,使 `verify-windows-authenticode.ps1` 在 `required` 模式下失败即阻断发布。
+5. 中期目标:在 `tauri build` 前导入证书并配置 `bundle.windows.certificateThumbprint`,让主程序 + uninstaller + installer 在打包期一并签名(比只签外层 setup 更完整)。
+
+脚本:
+
+- [`scripts/sign-windows-authenticode.ps1`](../scripts/sign-windows-authenticode.ps1) — 有证书则签,无证书则跳过(exit 0)。
+- [`scripts/verify-windows-authenticode.ps1`](../scripts/verify-windows-authenticode.ps1) — `optional` / `required`。
+- [`scripts/windows-packaged-smoke.ps1`](../scripts/windows-packaged-smoke.ps1) — x64 生命周期冒烟。
+- [`scripts/windows-pe-arch.ps1`](../scripts/windows-pe-arch.ps1) — 读取 PE machine type。
+
+失败日志阶段标签:`[build]` / `[sign]` / `[sign-verify]` / `[install]` / `[launch]` / `[upgrade]` / `[uninstall]`。
+
+### ARM64 运行验证策略
+
+- GitHub-hosted `windows-latest` 是 **x64**。`aarch64-pc-windows-msvc` 目标是交叉编译,产物经 `windows-pe-arch.ps1` 确认 machine=`0xAA64`。
+- **交叉构建成功 ≠ 运行验证。** 完整 install/launch/upgrade/uninstall 冒烟只在 x64 runner 上对 x64 安装包执行。
+- ARM64 实机或可信虚拟化验收清单(人工 / 自备 runner):
+  1. 安装 `CodexAppManager_arm64-setup.exe`(被动 `/P` 或 UI)。
+  2. 确认 `%LOCALAPPDATA%\Codex App Manager\codex-app-manager.exe` 存在且 PE 为 ARM64。
+  3. 首次启动管理器 UI,无崩溃。
+  4. 再跑一遍安装器 `/P /UPDATE` 升级路径。
+  5. 卸载后主程序消失。
+  6. 若已配置 Authenticode,确认 installer / 主程序 / uninstaller 的 `Get-AuthenticodeSignature` 为 `Valid`。
+
 ## English
 
 ### Current status
@@ -68,12 +113,13 @@ shasum -a 256 CodexAppManager_x86_64.dmg
 - The Windows installers `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed yet.
 - Windows in-app update artifacts carry the Tauri updater signature, which verifies the downloaded bytes.
 - SmartScreen may warn when users manually run the Windows installer for the first time; that is the known distribution risk, not an updater-signature failure.
+- CI already runs x64 packaged lifecycle smoke (`install → launch → upgrade → uninstall`) and Authenticode probes; signing is skipped and verification is non-blocking until a certificate is configured.
 
 ### Three separate concepts
 
-**Tauri updater signature:** The `signature` field in `latest.json` signs the installer bytes. It protects in-app self-update downloads from tampering across mirrors and network hops. It is not Windows publisher trust and does not remove SmartScreen warnings.
+**Tauri updater signature:** The `signature` field in `latest.json` signs the installer bytes. It protects in-app self-update downloads from tampering across mirrors and network hops. It is not Windows publisher trust and does not remove SmartScreen warnings. Implementation: `npx tauri signer sign` + `TAURI_SIGNING_PRIVATE_KEY`.
 
-**Authenticode code signing:** This is the Windows code-signing system for PE files and installers. With an OV or EV certificate, the installer can show a publisher identity and build operating-system trust. This project does not currently Authenticode-sign the Windows installer.
+**Authenticode code signing:** This is the Windows code-signing system for PE files and installers. With an OV or EV certificate, the installer can show a publisher identity and build operating-system trust. This project does not currently Authenticode-sign the Windows installer. The prepared CI path is documented below.
 
 **SmartScreen reputation:** Microsoft Defender SmartScreen combines signing identity, download volume, historical reputation, and risk signals. EV certificates usually establish reputation faster; OV certificates and unsigned distribution still need reputation to build, and unsigned installers are more likely to warn on first run.
 
@@ -120,3 +166,43 @@ confusion risk with public releases, mirror permalinks, `SHA256SUMS`, Tauri
 updater signatures, and transparent documentation. Those mitigations do not
 replace Authenticode, but they let users verify downloads independently until
 certificate budget and demand justify Windows code signing.
+
+### CI / release pipeline (Authenticode path)
+
+| Stage | Behavior | Blocking? |
+|---|---|---|
+| `ci.yml` Rust | Standalone `codex-mac-engine` / `codex-win-engine` tests | Yes (required) |
+| `win-installer-check.yml` | Build x64 NSIS → Authenticode probe → install/launch/upgrade/uninstall smoke | No (path-filtered) |
+| `release.yml` Windows | PE arch diagnostic → optional Authenticode sign → Authenticode verify → Tauri updater `.sig` → collect **final** artifacts | Updater `.sig` + artifact set block; Authenticode optional by default |
+| ARM64 | Cross-build + PE machine=`0xAA64` diagnostic; **not** runtime verification | Cross-build failure blocks; runtime verification below |
+
+**Turning on Authenticode (when a cert is available):**
+
+1. Add secrets on the `release` environment:
+   - `WINDOWS_CERTIFICATE` — base64-encoded OV/EV `.pfx`
+   - `WINDOWS_CERTIFICATE_PASSWORD` — pfx password
+2. Optionally set repo variable `WINDOWS_TIMESTAMP_URL` for the RFC3161 timestamp server.
+3. Confirm the *Authenticode-sign Windows installer* step produces `Valid` on `-setup.exe`.
+4. Set repo variable `AUTHENTICODE_REQUIRED=true` so `verify-windows-authenticode.ps1` runs in `required` mode and fails the release if unsigned.
+5. Medium-term: import the cert before `tauri build` and set `bundle.windows.certificateThumbprint` so the main binary, uninstaller, and installer are all signed during packaging (more complete than outer-setup-only signing).
+
+Scripts:
+
+- [`scripts/sign-windows-authenticode.ps1`](../scripts/sign-windows-authenticode.ps1) — signs when a cert is present; skips with exit 0 otherwise.
+- [`scripts/verify-windows-authenticode.ps1`](../scripts/verify-windows-authenticode.ps1) — `optional` / `required`.
+- [`scripts/windows-packaged-smoke.ps1`](../scripts/windows-packaged-smoke.ps1) — x64 lifecycle smoke.
+- [`scripts/windows-pe-arch.ps1`](../scripts/windows-pe-arch.ps1) — PE machine type probe.
+
+Failure log stage tags: `[build]` / `[sign]` / `[sign-verify]` / `[install]` / `[launch]` / `[upgrade]` / `[uninstall]`.
+
+### ARM64 runtime verification strategy
+
+- GitHub-hosted `windows-latest` is **x64**. The `aarch64-pc-windows-msvc` target is cross-compiled; `windows-pe-arch.ps1` asserts machine=`0xAA64`.
+- **A successful cross-build is not runtime verification.** Full install/launch/upgrade/uninstall smoke runs only for the x64 installer on x64 runners.
+- ARM64 bare-metal or trusted virtualization checklist (manual / self-hosted runner):
+  1. Install `CodexAppManager_arm64-setup.exe` (passive `/P` or UI).
+  2. Confirm `%LOCALAPPDATA%\Codex App Manager\codex-app-manager.exe` exists and is an ARM64 PE.
+  3. First-launch the manager UI without crash.
+  4. Re-run the installer with `/P /UPDATE` (upgrade path).
+  5. Uninstall and confirm the main binary is gone.
+  6. If Authenticode is configured, confirm installer / main / uninstaller `Get-AuthenticodeSignature` is `Valid`.

--- a/scripts/sign-windows-authenticode.ps1
+++ b/scripts/sign-windows-authenticode.ps1
@@ -1,0 +1,128 @@
+# Authenticode-sign Windows PE files when a code-signing certificate is available.
+#
+# Non-blocking milestone: if WINDOWS_CERTIFICATE (base64 PFX) is unset/empty,
+# the script prints a clear skip message and exits 0. Wire secrets into the
+# `release` environment, then set repo variable AUTHENTICODE_REQUIRED=true to
+# make verify-windows-authenticode.ps1 enforce Valid signatures.
+#
+# Signing order for a full release (see docs/windows-signing.md):
+#   1. Prefer signing during `tauri build` via certificateThumbprint once the
+#      cert is imported (covers main binary + uninstaller + installer).
+#   2. This script is the post-build fallback for final published artifacts
+#      (primarily the NSIS -setup.exe) and for local/CI verification of the path.
+#
+# Usage:
+#   $env:WINDOWS_CERTIFICATE = "<base64 pfx>"
+#   $env:WINDOWS_CERTIFICATE_PASSWORD = "..."
+#   pwsh scripts/sign-windows-authenticode.ps1 -Path path\to\setup.exe
+#
+# Does NOT produce Tauri updater .sig files — use `tauri signer sign` for that.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path,
+
+    [string]$CertificateBase64 = $env:WINDOWS_CERTIFICATE,
+    [string]$CertificatePassword = $env:WINDOWS_CERTIFICATE_PASSWORD,
+    [string]$TimestampUrl = $(if ($env:WINDOWS_TIMESTAMP_URL) { $env:WINDOWS_TIMESTAMP_URL } else { "http://timestamp.digicert.com" }),
+    [string]$Stage = "sign"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Stage([string]$Message) {
+    Write-Host "::group::[$Stage] $Message"
+}
+
+function Close-Stage {
+    Write-Host "::endgroup::"
+}
+
+function Fail-Stage([string]$Message) {
+    Write-Host "::error::[$Stage] $Message"
+    throw "[$Stage] $Message"
+}
+
+if ([string]::IsNullOrWhiteSpace($CertificateBase64)) {
+    Write-Host "[$Stage] WINDOWS_CERTIFICATE not set — skipping Authenticode signing (non-blocking milestone)."
+    Write-Host "[$Stage] Installer remains unsigned; see docs/windows-signing.md."
+    exit 0
+}
+
+Write-Stage "Import certificate and locate signtool"
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("cam-codesign-" + [guid]::NewGuid().ToString("n"))
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+$pfxPath = Join-Path $tempDir "codesign.pfx"
+$securePass = $null
+$cert = $null
+
+try {
+    [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($CertificateBase64.Trim()))
+
+    if ([string]::IsNullOrEmpty($CertificatePassword)) {
+        $securePass = New-Object System.Security.SecureString
+    }
+    else {
+        $securePass = ConvertTo-SecureString -String $CertificatePassword -AsPlainText -Force
+    }
+
+    $cert = Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $securePass
+    if (-not $cert) {
+        Fail-Stage "Import-PfxCertificate returned no certificate"
+    }
+    $thumbprint = $cert.Thumbprint
+    Write-Host "[$Stage] Imported cert thumbprint=$thumbprint subject=$($cert.Subject)"
+
+    $signtool = $null
+    $kitsRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+    if (Test-Path $kitsRoot) {
+        $candidates = Get-ChildItem -Path $kitsRoot -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+            Sort-Object FullName -Descending
+        if ($candidates) { $signtool = $candidates[0].FullName }
+    }
+    if (-not $signtool) {
+        $cmd = Get-Command signtool.exe -ErrorAction SilentlyContinue
+        if ($cmd) { $signtool = $cmd.Source }
+    }
+    if (-not $signtool) {
+        Fail-Stage "signtool.exe not found (install Windows SDK signing tools on the runner)"
+    }
+    Write-Host "[$Stage] Using signtool: $signtool"
+    Close-Stage
+
+    foreach ($raw in $Path) {
+        if ([string]::IsNullOrWhiteSpace($raw)) { continue }
+        $item = Get-Item -LiteralPath $raw -ErrorAction Stop
+        Write-Stage "Sign $($item.Name)"
+        & $signtool sign `
+            /fd SHA256 `
+            /td SHA256 `
+            /tr $TimestampUrl `
+            /sha1 $thumbprint `
+            $item.FullName
+        if ($LASTEXITCODE -ne 0) {
+            Fail-Stage "signtool failed for $($item.FullName) (exit=$LASTEXITCODE)"
+        }
+        $sig = Get-AuthenticodeSignature -LiteralPath $item.FullName
+        if ($sig.Status -ne "Valid") {
+            Fail-Stage "post-sign status for $($item.Name) is $($sig.Status), expected Valid"
+        }
+        Write-Host "[$Stage] Signed OK: $($item.Name) subject=$($sig.SignerCertificate.Subject)"
+        Close-Stage
+    }
+}
+finally {
+    if ($cert -and $cert.Thumbprint) {
+        Remove-Item -LiteralPath "Cert:\CurrentUser\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+    }
+    if (Test-Path $tempDir) {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "[$Stage] Authenticode signing complete"
+exit 0

--- a/scripts/sign-windows-authenticode.ps1
+++ b/scripts/sign-windows-authenticode.ps1
@@ -48,7 +48,8 @@ function Fail-Stage([string]$Message) {
 if ([string]::IsNullOrWhiteSpace($CertificateBase64)) {
     Write-Host "[$Stage] WINDOWS_CERTIFICATE not set — skipping Authenticode signing (non-blocking milestone)."
     Write-Host "[$Stage] Installer remains unsigned; see docs/windows-signing.md."
-    exit 0
+    # Do not `exit` — CI invokes this in-process with `&`.
+    return
 }
 
 Write-Stage "Import certificate and locate signtool"
@@ -125,4 +126,4 @@ finally {
 }
 
 Write-Host "[$Stage] Authenticode signing complete"
-exit 0
+return

--- a/scripts/verify-windows-authenticode.ps1
+++ b/scripts/verify-windows-authenticode.ps1
@@ -121,4 +121,6 @@ if ($failed) {
 }
 
 Write-Host "[$Stage] Authenticode check passed (mode=$Mode, files=$($results.Count))"
-exit 0
+# Do not `exit` — scripts are invoked in-process with `&` from CI steps;
+# `exit` would terminate the whole step (and skip e.g. smoke after verify).
+return

--- a/scripts/verify-windows-authenticode.ps1
+++ b/scripts/verify-windows-authenticode.ps1
@@ -1,0 +1,124 @@
+# Verify Authenticode signatures on Windows PE files (installer, app, uninstaller).
+#
+# Modes:
+#   optional  — report status; unsigned/NotSigned exits 0 (current milestone while
+#               OV/EV cert budget is not in place). Fail only if a path is missing
+#               or Get-AuthenticodeSignature itself errors.
+#   required  — every path must have Status -eq Valid. Use after cert is wired
+#               into release (repo var AUTHENTICODE_REQUIRED=true).
+#
+# Usage:
+#   pwsh scripts/verify-windows-authenticode.ps1 -Path a.exe,b.exe -Mode optional
+#   pwsh scripts/verify-windows-authenticode.ps1 -Path (Get-ChildItem *.exe) -Mode required
+#
+# Does NOT check Tauri updater (.sig / latest.json) signatures — that is a
+# separate system (see docs/windows-signing.md).
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path,
+
+    [ValidateSet("optional", "required")]
+    [string]$Mode = "optional",
+
+    # When set (required mode), SignerCertificate.Subject must contain this.
+    [string]$ExpectedSubject = "",
+
+    [string]$Stage = "sign-verify"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Stage([string]$Message) {
+    Write-Host "::group::[$Stage] $Message"
+}
+
+function Close-Stage {
+    Write-Host "::endgroup::"
+}
+
+function Fail-Stage([string]$Message) {
+    Write-Host "::error::[$Stage] $Message"
+    throw "[$Stage] $Message"
+}
+
+Write-Stage "Authenticode verification (mode=$Mode)"
+
+$results = @()
+$failed = $false
+
+foreach ($raw in $Path) {
+    if ([string]::IsNullOrWhiteSpace($raw)) { continue }
+    $item = Get-Item -LiteralPath $raw -ErrorAction SilentlyContinue
+    if (-not $item) {
+        $failed = $true
+        Write-Host "::error::[$Stage] missing file: $raw"
+        $results += [pscustomobject]@{
+            Path    = $raw
+            Status  = "Missing"
+            Subject = ""
+            Ok      = $false
+        }
+        continue
+    }
+
+    $sig = Get-AuthenticodeSignature -LiteralPath $item.FullName
+    $subject = if ($sig.SignerCertificate) { $sig.SignerCertificate.Subject } else { "" }
+    $status = [string]$sig.Status
+    $ok = $false
+
+    switch ($Mode) {
+        "optional" {
+            # NotSigned is expected until OV/EV is configured. HashMismatch /
+            # NotTrusted / UnknownError still surface as warnings for visibility.
+            if ($status -eq "Valid") {
+                $ok = $true
+            }
+            elseif ($status -eq "NotSigned") {
+                $ok = $true
+                Write-Host "::warning::[$Stage] unsigned (expected until Authenticode cert is configured): $($item.Name)"
+            }
+            else {
+                # Soft-fail in optional mode: report but do not block release.
+                $ok = $true
+                Write-Host "::warning::[$Stage] $($item.Name): Status=$status Subject=$subject"
+            }
+        }
+        "required" {
+            if ($status -ne "Valid") {
+                $ok = $false
+                Write-Host "::error::[$Stage] $($item.Name): expected Valid, got $status"
+            }
+            elseif ($ExpectedSubject -and ($subject -notlike "*$ExpectedSubject*")) {
+                $ok = $false
+                Write-Host "::error::[$Stage] $($item.Name): subject '$subject' does not contain '$ExpectedSubject'"
+            }
+            else {
+                $ok = $true
+            }
+        }
+    }
+
+    if (-not $ok) { $failed = $true }
+
+    $results += [pscustomobject]@{
+        Path    = $item.FullName
+        Status  = $status
+        Subject = $subject
+        Ok      = $ok
+    }
+
+    Write-Host ("  {0,-12} {1}  {2}" -f $status, $item.Name, $subject)
+}
+
+$results | Format-Table -AutoSize | Out-String | Write-Host
+Close-Stage
+
+if ($failed) {
+    Fail-Stage "Authenticode verification failed (mode=$Mode)"
+}
+
+Write-Host "[$Stage] Authenticode check passed (mode=$Mode, files=$($results.Count))"
+exit 0

--- a/scripts/windows-packaged-smoke.ps1
+++ b/scripts/windows-packaged-smoke.ps1
@@ -1,0 +1,171 @@
+# Windows x64 packaged lifecycle smoke test.
+#
+# Stages (each failure message is prefixed so CI logs pin the phase):
+#   build     — caller already built; this script only consumes the installer
+#   install   — passive NSIS install (/P)
+#   launch    — first start of the installed main executable
+#   upgrade   — re-run installer with /P /UPDATE (in-place upgrade path)
+#   uninstall — passive uninstall of the installed product
+#   sign-verify — optional Authenticode probe on installer + installed PE files
+#
+# Usage:
+#   pwsh scripts/windows-packaged-smoke.ps1 -Installer path\to\*-setup.exe
+#
+# Safe for CI: currentUser installMode → %LOCALAPPDATA%\Codex App Manager
+# (no admin elevation). Kills the app between stages. Does not touch ~/.codex.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Installer,
+
+    [string]$ProductName = "Codex App Manager",
+    [string]$MainBinaryName = "codex-app-manager",
+    [int]$LaunchSeconds = 12,
+    [ValidateSet("optional", "required", "skip")]
+    [string]$AuthenticodeMode = "optional"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Stage([string]$Stage, [string]$Message) {
+    Write-Host "::group::[$Stage] $Message"
+}
+
+function Close-Stage {
+    Write-Host "::endgroup::"
+}
+
+function Fail-Stage([string]$Stage, [string]$Message) {
+    Write-Host "::error::[$Stage] $Message"
+    throw "[$Stage] $Message"
+}
+
+function Stop-AppProcesses([string]$BinaryName) {
+    Get-Process -Name $BinaryName -ErrorAction SilentlyContinue | ForEach-Object {
+        Write-Host "Stopping process $($_.Id) ($($_.ProcessName))"
+        Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+    }
+    Start-Sleep -Seconds 2
+}
+
+function Invoke-Installer([string]$Stage, [string]$Exe, [string[]]$Args) {
+    Write-Host "[$Stage] Running: $Exe $($Args -join ' ')"
+    $p = Start-Process -FilePath $Exe -ArgumentList $Args -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -ne 0) {
+        Fail-Stage $Stage "installer/uninstaller exited $($p.ExitCode)"
+    }
+}
+
+$installerItem = Get-Item -LiteralPath $Installer -ErrorAction Stop
+$installDir = Join-Path $env:LOCALAPPDATA $ProductName
+$mainExe = Join-Path $installDir "$MainBinaryName.exe"
+$uninstaller = Join-Path $installDir "uninstall.exe"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$verifyScript = Join-Path $scriptRoot "verify-windows-authenticode.ps1"
+
+Write-Host "Installer: $($installerItem.FullName)"
+Write-Host "InstallDir: $installDir"
+Write-Host "MainExe: $mainExe"
+
+# ── sign-verify (installer artifact, pre-install) ───────────────────────────
+if ($AuthenticodeMode -ne "skip" -and (Test-Path $verifyScript)) {
+    Write-Stage "sign-verify" "Probe Authenticode on installer ($AuthenticodeMode)"
+    & $verifyScript -Path @($installerItem.FullName) -Mode $AuthenticodeMode -Stage "sign-verify"
+    Close-Stage
+}
+
+# Clean slate if a previous run left leftovers.
+if (Test-Path $uninstaller) {
+    Write-Stage "install" "Removing leftover install from a previous run"
+    Stop-AppProcesses $MainBinaryName
+    try {
+        Invoke-Installer "install" $uninstaller @("/P")
+    }
+    catch {
+        Write-Host "::warning::[install] pre-clean uninstall failed: $_"
+    }
+    Close-Stage
+}
+
+# ── install ─────────────────────────────────────────────────────────────────
+Write-Stage "install" "Passive install (/P)"
+Stop-AppProcesses $MainBinaryName
+Invoke-Installer "install" $installerItem.FullName @("/P")
+
+if (-not (Test-Path -LiteralPath $mainExe)) {
+    Fail-Stage "install" "main executable missing after install: $mainExe"
+}
+if (-not (Test-Path -LiteralPath $uninstaller)) {
+    Fail-Stage "install" "uninstaller missing after install: $uninstaller"
+}
+
+$vi = (Get-Item -LiteralPath $mainExe).VersionInfo
+Write-Host "[install] FileVersion=$($vi.FileVersion) ProductVersion=$($vi.ProductVersion)"
+Write-Host "[install] installed PE size=$((Get-Item -LiteralPath $mainExe).Length) bytes"
+Close-Stage
+
+# ── sign-verify (installed PE) ──────────────────────────────────────────────
+if ($AuthenticodeMode -ne "skip" -and (Test-Path $verifyScript)) {
+    Write-Stage "sign-verify" "Probe Authenticode on installed executable + uninstaller"
+    & $verifyScript -Path @($mainExe, $uninstaller) -Mode $AuthenticodeMode -Stage "sign-verify"
+    Close-Stage
+}
+
+# ── launch ──────────────────────────────────────────────────────────────────
+Write-Stage "launch" "First launch (${LaunchSeconds}s observe window)"
+Stop-AppProcesses $MainBinaryName
+
+$proc = Start-Process -FilePath $mainExe -PassThru -WindowStyle Minimized
+Start-Sleep -Seconds $LaunchSeconds
+
+if ($proc.HasExited) {
+    # A GUI app exiting immediately with non-zero is a real failure. Exit 0 can
+    # happen if single-instance hands off, but a brand-new install should stay up.
+    if ($proc.ExitCode -ne 0) {
+        Fail-Stage "launch" "process exited early with code $($proc.ExitCode)"
+    }
+    Write-Host "::warning::[launch] process exited during observe window with code 0 — treating as soft pass"
+}
+else {
+    Write-Host "[launch] process still running (pid=$($proc.Id)) — first launch OK"
+    Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 2
+}
+# Ensure nothing leftover holds files open for upgrade.
+Stop-AppProcesses $MainBinaryName
+Close-Stage
+
+# ── upgrade ─────────────────────────────────────────────────────────────────
+Write-Stage "upgrade" "Re-run installer with /P /UPDATE"
+Stop-AppProcesses $MainBinaryName
+Invoke-Installer "upgrade" $installerItem.FullName @("/P", "/UPDATE")
+
+if (-not (Test-Path -LiteralPath $mainExe)) {
+    Fail-Stage "upgrade" "main executable missing after upgrade: $mainExe"
+}
+if (-not (Test-Path -LiteralPath $uninstaller)) {
+    Fail-Stage "upgrade" "uninstaller missing after upgrade: $uninstaller"
+}
+Write-Host "[upgrade] post-upgrade PE size=$((Get-Item -LiteralPath $mainExe).Length) bytes"
+Close-Stage
+
+# ── uninstall ───────────────────────────────────────────────────────────────
+Write-Stage "uninstall" "Passive uninstall (/P)"
+Stop-AppProcesses $MainBinaryName
+if (-not (Test-Path -LiteralPath $uninstaller)) {
+    Fail-Stage "uninstall" "uninstaller missing: $uninstaller"
+}
+Invoke-Installer "uninstall" $uninstaller @("/P")
+Start-Sleep -Seconds 2
+
+if (Test-Path -LiteralPath $mainExe) {
+    Fail-Stage "uninstall" "main executable still present after uninstall: $mainExe"
+}
+# Install dir may remain empty or with leftover logs; main PE must be gone.
+Write-Host "[uninstall] main executable removed"
+Close-Stage
+
+Write-Host "Packaged lifecycle smoke passed: install → launch → upgrade → uninstall"
+exit 0

--- a/scripts/windows-packaged-smoke.ps1
+++ b/scripts/windows-packaged-smoke.ps1
@@ -5,11 +5,12 @@
 #   install   — passive NSIS install (/P)
 #   launch    — first start of the installed main executable
 #   upgrade   — re-run installer with /P /UPDATE (in-place upgrade path)
-#   uninstall — passive uninstall of the installed product
+#   uninstall — passive uninstall of the installed product (always attempted in finally)
 #   sign-verify — optional Authenticode probe on installer + installed PE files
 #
-# Usage:
-#   pwsh scripts/windows-packaged-smoke.ps1 -Installer path\to\*-setup.exe
+# Usage (prefer in-process from CI shell:pwsh steps — nested `pwsh -File` breaks
+# array binding for -Path on some runners):
+#   & .\scripts\windows-packaged-smoke.ps1 -Installer path\to\*-setup.exe
 #
 # Safe for CI: currentUser installMode → %LOCALAPPDATA%\Codex App Manager
 # (no admin elevation). Kills the app between stages. Does not touch ~/.codex.
@@ -50,11 +51,31 @@ function Stop-AppProcesses([string]$BinaryName) {
     Start-Sleep -Seconds 2
 }
 
-function Invoke-Installer([string]$Stage, [string]$Exe, [string[]]$Args) {
-    Write-Host "[$Stage] Running: $Exe $($Args -join ' ')"
-    $p = Start-Process -FilePath $Exe -ArgumentList $Args -Wait -PassThru -NoNewWindow
+function Invoke-Installer([string]$Stage, [string]$Exe, [string[]]$InstallerArgs) {
+    Write-Host "[$Stage] Running: $Exe $($InstallerArgs -join ' ')"
+    $p = Start-Process -FilePath $Exe -ArgumentList $InstallerArgs -Wait -PassThru -NoNewWindow
     if ($p.ExitCode -ne 0) {
         Fail-Stage $Stage "installer/uninstaller exited $($p.ExitCode)"
+    }
+}
+
+function Invoke-UninstallBestEffort([string]$Stage, [string]$UninstallerPath, [string]$BinaryName, [string]$MainExePath) {
+    Stop-AppProcesses $BinaryName
+    if (-not (Test-Path -LiteralPath $UninstallerPath)) {
+        Write-Host "[$Stage] uninstaller not present; nothing to clean"
+        return
+    }
+    Write-Host "[$Stage] Running: $UninstallerPath /P"
+    $p = Start-Process -FilePath $UninstallerPath -ArgumentList @("/P") -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -ne 0) {
+        Write-Host "::warning::[$Stage] uninstaller exited $($p.ExitCode)"
+    }
+    Start-Sleep -Seconds 2
+    if (Test-Path -LiteralPath $MainExePath) {
+        Write-Host "::warning::[$Stage] main executable still present after uninstall attempt: $MainExePath"
+    }
+    else {
+        Write-Host "[$Stage] main executable removed"
     }
 }
 
@@ -64,108 +85,133 @@ $mainExe = Join-Path $installDir "$MainBinaryName.exe"
 $uninstaller = Join-Path $installDir "uninstall.exe"
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $verifyScript = Join-Path $scriptRoot "verify-windows-authenticode.ps1"
+$didInstall = $false
+$smokeFailed = $false
+$smokeError = $null
 
 Write-Host "Installer: $($installerItem.FullName)"
 Write-Host "InstallDir: $installDir"
 Write-Host "MainExe: $mainExe"
 
-# ── sign-verify (installer artifact, pre-install) ───────────────────────────
-if ($AuthenticodeMode -ne "skip" -and (Test-Path $verifyScript)) {
-    Write-Stage "sign-verify" "Probe Authenticode on installer ($AuthenticodeMode)"
-    & $verifyScript -Path @($installerItem.FullName) -Mode $AuthenticodeMode -Stage "sign-verify"
-    Close-Stage
-}
+try {
+    # ── sign-verify (installer artifact, pre-install) ───────────────────────
+    if ($AuthenticodeMode -ne "skip" -and (Test-Path $verifyScript)) {
+        Write-Stage "sign-verify" "Probe Authenticode on installer ($AuthenticodeMode)"
+        & $verifyScript -Path $installerItem.FullName -Mode $AuthenticodeMode -Stage "sign-verify"
+        Close-Stage
+    }
 
-# Clean slate if a previous run left leftovers.
-if (Test-Path $uninstaller) {
-    Write-Stage "install" "Removing leftover install from a previous run"
+    # Clean slate if a previous run left leftovers.
+    if (Test-Path $uninstaller) {
+        Write-Stage "install" "Removing leftover install from a previous run"
+        Invoke-UninstallBestEffort "install" $uninstaller $MainBinaryName $mainExe
+        Close-Stage
+    }
+
+    # ── install ─────────────────────────────────────────────────────────────
+    Write-Stage "install" "Passive install (/P)"
     Stop-AppProcesses $MainBinaryName
-    try {
-        Invoke-Installer "install" $uninstaller @("/P")
+    Invoke-Installer "install" $installerItem.FullName @("/P")
+    $didInstall = $true
+
+    if (-not (Test-Path -LiteralPath $mainExe)) {
+        Fail-Stage "install" "main executable missing after install: $mainExe"
     }
-    catch {
-        Write-Host "::warning::[install] pre-clean uninstall failed: $_"
+    if (-not (Test-Path -LiteralPath $uninstaller)) {
+        Fail-Stage "install" "uninstaller missing after install: $uninstaller"
     }
+
+    $vi = (Get-Item -LiteralPath $mainExe).VersionInfo
+    Write-Host "[install] FileVersion=$($vi.FileVersion) ProductVersion=$($vi.ProductVersion)"
+    Write-Host "[install] installed PE size=$((Get-Item -LiteralPath $mainExe).Length) bytes"
     Close-Stage
-}
 
-# ── install ─────────────────────────────────────────────────────────────────
-Write-Stage "install" "Passive install (/P)"
-Stop-AppProcesses $MainBinaryName
-Invoke-Installer "install" $installerItem.FullName @("/P")
-
-if (-not (Test-Path -LiteralPath $mainExe)) {
-    Fail-Stage "install" "main executable missing after install: $mainExe"
-}
-if (-not (Test-Path -LiteralPath $uninstaller)) {
-    Fail-Stage "install" "uninstaller missing after install: $uninstaller"
-}
-
-$vi = (Get-Item -LiteralPath $mainExe).VersionInfo
-Write-Host "[install] FileVersion=$($vi.FileVersion) ProductVersion=$($vi.ProductVersion)"
-Write-Host "[install] installed PE size=$((Get-Item -LiteralPath $mainExe).Length) bytes"
-Close-Stage
-
-# ── sign-verify (installed PE) ──────────────────────────────────────────────
-if ($AuthenticodeMode -ne "skip" -and (Test-Path $verifyScript)) {
-    Write-Stage "sign-verify" "Probe Authenticode on installed executable + uninstaller"
-    & $verifyScript -Path @($mainExe, $uninstaller) -Mode $AuthenticodeMode -Stage "sign-verify"
-    Close-Stage
-}
-
-# ── launch ──────────────────────────────────────────────────────────────────
-Write-Stage "launch" "First launch (${LaunchSeconds}s observe window)"
-Stop-AppProcesses $MainBinaryName
-
-$proc = Start-Process -FilePath $mainExe -PassThru -WindowStyle Minimized
-Start-Sleep -Seconds $LaunchSeconds
-
-if ($proc.HasExited) {
-    # A GUI app exiting immediately with non-zero is a real failure. Exit 0 can
-    # happen if single-instance hands off, but a brand-new install should stay up.
-    if ($proc.ExitCode -ne 0) {
-        Fail-Stage "launch" "process exited early with code $($proc.ExitCode)"
+    # ── sign-verify (installed PE) ──────────────────────────────────────────
+    if ($AuthenticodeMode -ne "skip" -and (Test-Path $verifyScript)) {
+        Write-Stage "sign-verify" "Probe Authenticode on installed executable + uninstaller"
+        & $verifyScript -Path @($mainExe, $uninstaller) -Mode $AuthenticodeMode -Stage "sign-verify"
+        Close-Stage
     }
-    Write-Host "::warning::[launch] process exited during observe window with code 0 — treating as soft pass"
-}
-else {
-    Write-Host "[launch] process still running (pid=$($proc.Id)) — first launch OK"
-    Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+
+    # ── launch ──────────────────────────────────────────────────────────────
+    Write-Stage "launch" "First launch (${LaunchSeconds}s observe window)"
+    Stop-AppProcesses $MainBinaryName
+
+    $proc = Start-Process -FilePath $mainExe -PassThru -WindowStyle Minimized
+    Start-Sleep -Seconds $LaunchSeconds
+
+    if ($proc.HasExited) {
+        # A GUI app exiting immediately with non-zero is a real failure. Exit 0 can
+        # happen if single-instance hands off, but a brand-new install should stay up.
+        if ($proc.ExitCode -ne 0) {
+            Fail-Stage "launch" "process exited early with code $($proc.ExitCode)"
+        }
+        Write-Host "::warning::[launch] process exited during observe window with code 0 — treating as soft pass"
+    }
+    else {
+        Write-Host "[launch] process still running (pid=$($proc.Id)) — first launch OK"
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+    }
+    # Ensure nothing leftover holds files open for upgrade.
+    Stop-AppProcesses $MainBinaryName
+    Close-Stage
+
+    # ── upgrade ─────────────────────────────────────────────────────────────
+    Write-Stage "upgrade" "Re-run installer with /P /UPDATE"
+    Stop-AppProcesses $MainBinaryName
+    Invoke-Installer "upgrade" $installerItem.FullName @("/P", "/UPDATE")
+
+    if (-not (Test-Path -LiteralPath $mainExe)) {
+        Fail-Stage "upgrade" "main executable missing after upgrade: $mainExe"
+    }
+    if (-not (Test-Path -LiteralPath $uninstaller)) {
+        Fail-Stage "upgrade" "uninstaller missing after upgrade: $uninstaller"
+    }
+    Write-Host "[upgrade] post-upgrade PE size=$((Get-Item -LiteralPath $mainExe).Length) bytes"
+    Close-Stage
+
+    # ── uninstall (happy path) ──────────────────────────────────────────────
+    Write-Stage "uninstall" "Passive uninstall (/P)"
+    Stop-AppProcesses $MainBinaryName
+    if (-not (Test-Path -LiteralPath $uninstaller)) {
+        Fail-Stage "uninstall" "uninstaller missing: $uninstaller"
+    }
+    Invoke-Installer "uninstall" $uninstaller @("/P")
     Start-Sleep -Seconds 2
-}
-# Ensure nothing leftover holds files open for upgrade.
-Stop-AppProcesses $MainBinaryName
-Close-Stage
 
-# ── upgrade ─────────────────────────────────────────────────────────────────
-Write-Stage "upgrade" "Re-run installer with /P /UPDATE"
-Stop-AppProcesses $MainBinaryName
-Invoke-Installer "upgrade" $installerItem.FullName @("/P", "/UPDATE")
+    if (Test-Path -LiteralPath $mainExe) {
+        Fail-Stage "uninstall" "main executable still present after uninstall: $mainExe"
+    }
+    Write-Host "[uninstall] main executable removed"
+    $didInstall = $false
+    Close-Stage
 
-if (-not (Test-Path -LiteralPath $mainExe)) {
-    Fail-Stage "upgrade" "main executable missing after upgrade: $mainExe"
+    Write-Host "Packaged lifecycle smoke passed: install → launch → upgrade → uninstall"
 }
-if (-not (Test-Path -LiteralPath $uninstaller)) {
-    Fail-Stage "upgrade" "uninstaller missing after upgrade: $uninstaller"
+catch {
+    $smokeFailed = $true
+    $smokeError = $_
+    Write-Host "::error::[smoke] $($_.Exception.Message)"
 }
-Write-Host "[upgrade] post-upgrade PE size=$((Get-Item -LiteralPath $mainExe).Length) bytes"
-Close-Stage
+finally {
+    # Always attempt cleanup so a failed launch/upgrade does not leave the product
+    # installed on the runner (and so retry jobs start clean).
+    if ($didInstall -or (Test-Path -LiteralPath $mainExe) -or (Test-Path -LiteralPath $uninstaller)) {
+        Write-Stage "uninstall" "finally: best-effort uninstall after smoke"
+        try {
+            Invoke-UninstallBestEffort "uninstall" $uninstaller $MainBinaryName $mainExe
+        }
+        catch {
+            Write-Host "::warning::[uninstall] finally cleanup failed: $_"
+        }
+        Close-Stage
+    }
+}
 
-# ── uninstall ───────────────────────────────────────────────────────────────
-Write-Stage "uninstall" "Passive uninstall (/P)"
-Stop-AppProcesses $MainBinaryName
-if (-not (Test-Path -LiteralPath $uninstaller)) {
-    Fail-Stage "uninstall" "uninstaller missing: $uninstaller"
+if ($smokeFailed) {
+    throw $smokeError
 }
-Invoke-Installer "uninstall" $uninstaller @("/P")
-Start-Sleep -Seconds 2
 
-if (Test-Path -LiteralPath $mainExe) {
-    Fail-Stage "uninstall" "main executable still present after uninstall: $mainExe"
-}
-# Install dir may remain empty or with leftover logs; main PE must be gone.
-Write-Host "[uninstall] main executable removed"
-Close-Stage
-
-Write-Host "Packaged lifecycle smoke passed: install → launch → upgrade → uninstall"
-exit 0
+# Do not `exit` — CI invokes this in-process with `&`.
+return

--- a/scripts/windows-pe-arch.ps1
+++ b/scripts/windows-pe-arch.ps1
@@ -1,0 +1,68 @@
+# Print PE machine type for Windows binaries (build diagnostics).
+#
+# Used in release CI for ARM64 cross-builds: confirms the produced PE is
+# IMAGE_FILE_MACHINE_ARM64 without claiming that it was *run* on ARM64 hardware.
+# Cross-compilation ≠ runtime verification (see docs/windows-signing.md).
+#
+# Usage:
+#   pwsh scripts/windows-pe-arch.ps1 -Path path\to\codex-app-manager.exe
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-PeMachine([string]$FilePath) {
+    $fs = [System.IO.File]::OpenRead($FilePath)
+    try {
+        $br = New-Object System.IO.BinaryReader($fs)
+        if ($br.ReadUInt16() -ne 0x5A4D) {
+            return [pscustomobject]@{ Path = $FilePath; Machine = "not-MZ"; Label = "not a PE" }
+        }
+        $fs.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $peOffset = $br.ReadUInt32()
+        $fs.Seek($peOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+        if ($br.ReadUInt32() -ne 0x4550) {
+            return [pscustomobject]@{ Path = $FilePath; Machine = "bad-PE"; Label = "invalid PE signature" }
+        }
+        $machine = $br.ReadUInt16()
+        $label = switch ($machine) {
+            0x014c { "i386" }
+            0x8664 { "x86_64 / AMD64" }
+            0xAA64 { "aarch64 / ARM64" }
+            0x01c4 { "ARMNT" }
+            default { "unknown(0x{0:X4})" -f $machine }
+        }
+        return [pscustomobject]@{
+            Path    = $FilePath
+            Machine = ("0x{0:X4}" -f $machine)
+            Label   = $label
+        }
+    }
+    finally {
+        $fs.Dispose()
+    }
+}
+
+$rows = @()
+foreach ($raw in $Path) {
+    if (-not (Test-Path -LiteralPath $raw)) {
+        Write-Host "::warning::PE arch: missing $raw"
+        continue
+    }
+    $info = Get-PeMachine (Resolve-Path -LiteralPath $raw).Path
+    $rows += $info
+    Write-Host ("PE {0}  machine={1}  {2}" -f (Split-Path $info.Path -Leaf), $info.Machine, $info.Label)
+}
+
+if ($rows.Count -eq 0) {
+    Write-Host "::error::No PE files inspected"
+    exit 1
+}
+
+$rows | Format-Table -AutoSize | Out-String | Write-Host
+exit 0

--- a/scripts/windows-pe-arch.ps1
+++ b/scripts/windows-pe-arch.ps1
@@ -5,12 +5,17 @@
 # Cross-compilation ≠ runtime verification (see docs/windows-signing.md).
 #
 # Usage:
-#   pwsh scripts/windows-pe-arch.ps1 -Path path\to\codex-app-manager.exe
+#   & .\scripts\windows-pe-arch.ps1 -Path path\to\codex-app-manager.exe
+#   & .\scripts\windows-pe-arch.ps1 -Path $main -ExpectMachine 0xAA64
 
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [string[]]$Path
+    [string[]]$Path,
+
+    # Optional hard assert: every inspected PE must match this machine code
+    # (e.g. 0xAA64 for ARM64, 0x8664 for x64). Accepts int or hex string.
+    [string]$ExpectMachine = ""
 )
 
 Set-StrictMode -Version Latest
@@ -21,13 +26,13 @@ function Get-PeMachine([string]$FilePath) {
     try {
         $br = New-Object System.IO.BinaryReader($fs)
         if ($br.ReadUInt16() -ne 0x5A4D) {
-            return [pscustomobject]@{ Path = $FilePath; Machine = "not-MZ"; Label = "not a PE" }
+            return [pscustomobject]@{ Path = $FilePath; MachineValue = -1; Machine = "not-MZ"; Label = "not a PE" }
         }
         $fs.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
         $peOffset = $br.ReadUInt32()
         $fs.Seek($peOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
         if ($br.ReadUInt32() -ne 0x4550) {
-            return [pscustomobject]@{ Path = $FilePath; Machine = "bad-PE"; Label = "invalid PE signature" }
+            return [pscustomobject]@{ Path = $FilePath; MachineValue = -1; Machine = "bad-PE"; Label = "invalid PE signature" }
         }
         $machine = $br.ReadUInt16()
         $label = switch ($machine) {
@@ -38,9 +43,10 @@ function Get-PeMachine([string]$FilePath) {
             default { "unknown(0x{0:X4})" -f $machine }
         }
         return [pscustomobject]@{
-            Path    = $FilePath
-            Machine = ("0x{0:X4}" -f $machine)
-            Label   = $label
+            Path         = $FilePath
+            MachineValue = [int]$machine
+            Machine      = ("0x{0:X4}" -f $machine)
+            Label        = $label
         }
     }
     finally {
@@ -48,21 +54,46 @@ function Get-PeMachine([string]$FilePath) {
     }
 }
 
+$expectValue = $null
+if (-not [string]::IsNullOrWhiteSpace($ExpectMachine)) {
+    $expectValue = [int]($ExpectMachine.Trim())
+}
+
 $rows = @()
+$failed = $false
 foreach ($raw in $Path) {
     if (-not (Test-Path -LiteralPath $raw)) {
-        Write-Host "::warning::PE arch: missing $raw"
+        Write-Host "::error::PE arch: missing $raw"
+        $failed = $true
         continue
     }
     $info = Get-PeMachine (Resolve-Path -LiteralPath $raw).Path
     $rows += $info
     Write-Host ("PE {0}  machine={1}  {2}" -f (Split-Path $info.Path -Leaf), $info.Machine, $info.Label)
+
+    if ($null -ne $expectValue) {
+        if ($info.MachineValue -ne $expectValue) {
+            Write-Host ("::error::PE arch mismatch for {0}: expected 0x{1:X4}, got {2}" -f (Split-Path $info.Path -Leaf), $expectValue, $info.Machine)
+            $failed = $true
+        }
+    }
 }
 
 if ($rows.Count -eq 0) {
     Write-Host "::error::No PE files inspected"
-    exit 1
+    throw "No PE files inspected"
 }
 
 $rows | Format-Table -AutoSize | Out-String | Write-Host
-exit 0
+
+if ($failed) {
+    Write-Host "::error::PE architecture check failed"
+    throw "PE architecture check failed"
+}
+
+if ($null -ne $expectValue) {
+    Write-Host ("PE architecture assert OK (ExpectMachine=0x{0:X4}, files={1})" -f $expectValue, $rows.Count)
+}
+
+# Do not `exit` — CI invokes this in-process with `&`.
+return


### PR DESCRIPTION
## Summary

Implements #152: required engine crate tests, Windows x64 packaged lifecycle smoke, Authenticode preparation, and ARM64 diagnostics.

### Changes

- **Required CI** (`ci.yml`): explicit standalone `cargo test` for `codex-mac-engine` and `codex-win-engine` (path deps are not workspace members, so they were not covered before).
- **Windows x64 packaged smoke** (`win-installer-check.yml` + `scripts/windows-packaged-smoke.ps1`): build NSIS → install (`/P`) → first launch → upgrade (`/P /UPDATE`) → uninstall; verifies real installed executable + uninstaller.
- **Authenticode path** (non-blocking until cert exists):
  - `scripts/sign-windows-authenticode.ps1` — signs when `WINDOWS_CERTIFICATE` is set; skips otherwise
  - `scripts/verify-windows-authenticode.ps1` — `optional` / `required` modes
  - Wired into `release.yml` and the installer check; gate via `AUTHENTICODE_REQUIRED=true`
- **Release final artifacts**: PE arch diagnostic (esp. ARM64 cross-build), collect-time checks for `*-setup.exe` + `.sig`, release-job validation of the merged publishable tree.
- **Docs**: `docs/windows-signing.md` + `docs/release.md` keep updater signature / Authenticode / SmartScreen distinct; document ARM64 runtime strategy (cross-build ≠ run verification).

### Stage-tagged failure logs

`[build]` / `[sign]` / `[sign-verify]` / `[install]` / `[launch]` / `[upgrade]` / `[uninstall]`

### Not in this PR

- No OV/EV certificate secrets configured (intentionally non-blocking)
- No ARM64 hardware runtime smoke (documented checklist only)
- Does not change required Frontend gate

## Test plan

- [x] `cargo test --manifest-path crates/codex-mac-engine/Cargo.toml --all-targets`
- [x] `cargo test --manifest-path crates/codex-win-engine/Cargo.toml --all-targets`
- [x] PowerShell parse + authenticode optional probe + sign-skip path
- [ ] CI Frontend + Rust (macOS/windows) green
- [ ] `win-installer-check` nsis job: build + packaged smoke green
- [ ] Confirm draft is marked ready; do not merge until checks look good