### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,65 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 跟上上游 Codex 并入 ChatGPT 品牌后的身份变化——按产品身份识别、安装与启动,不再依赖文件名。
+> Follow Codex through the ChatGPT rebrand: detect, install, and launch by product identity, not by filename.
+
+## ✨ 亮点 · Highlights
+
+- **兼容 ChatGPT 品牌合并后的 Codex**:上游把桌面 Codex 并入 ChatGPT 品牌(macOS 可能是 `ChatGPT.app`,Windows 入口可能是 `ChatGPT.exe`),产品身份仍是 `com.openai.codex` / `OpenAI.Codex`。Manager 现在按身份识别,不会把 ChatGPT Classic 当成 Codex,也不会漏掉改名后的新版。
+  ChatGPT-rebranded Codex support: upstream merged desktop Codex into the ChatGPT brand (`ChatGPT.app` / `ChatGPT.exe` are possible on disk, identity remains `com.openai.codex` / `OpenAI.Codex`). Manager now keys off identity so Classic is never mistaken for Codex, and renamed installs still work.
+
+- **安装与启动走真实入口**:Windows portable/MSIX 从清单解析入口可执行文件,旧布局(`Codex.exe`)与新布局(`ChatGPT.exe`)都能检测、启动和健康检查;macOS 安装后仍规范到本地 `Codex.app` 目录名。
+  Real entry resolution: Windows portable/MSIX paths read the manifest entry exe so both legacy (`Codex.exe`) and rebranded (`ChatGPT.exe`) layouts detect, launch, and health-check correctly; macOS still normalizes installs to a local `Codex.app` directory name.
+
+- **歧义安装更安全**:多个血统安装并存时会上报歧义并引导明确选择,破坏性操作前重新校验路径、版本与身份;macOS 对仍处于 App Translocation 的实例 fail-closed。
+  Safer ambiguous installs: coexisting lineage installs report ambiguity and ask for an explicit pick; destructive steps re-verify path, build, and identity; macOS fails closed on live App Translocation.
+
+- **自研图标与交互动效**:界面图标改为自研描边图标,并补上轻量 hover 微动画,视觉更统一。
+  In-house icons and micro-motion: UI icons move to a custom stroke set with light hover animations for a more consistent look.
+
+## 🐛 修复 · Fixes
+
+- **Windows 更新服务器连不上(证书吊销离线)**:当 Schannel 报 `CRYPT_E_REVOCATION_OFFLINE` 时自动用 `--ssl-no-revoke` 重试,不再误报“无法连接更新服务器”。
+  Windows update fetch when certificate revocation is offline: on Schannel `CRYPT_E_REVOCATION_OFFLINE`, Manager retries with `--ssl-no-revoke` instead of a false “cannot reach update server” failure.
+
+- **主题与系统外观**:减少启动时主题闪烁,系统浅/深色切换时跨页平滑过渡。
+  Theme and system appearance: less FOUC on launch, and smoother cross-page transitions when the OS light/dark theme changes.
+
+- **无障碍**:开关与单选组补齐可访问名称与语义,读屏更准确。
+  Accessibility: switches and radio groups get proper accessible names and semantics for screen readers.
+
+- **Windows 焦点重检**:切回 Manager 窗口时会重新核对安装状态,避免界面停留在过时结论。
+  Windows focus re-check: returning focus to Manager revalidates install status so the UI does not stick on a stale conclusion.
+
+- **文案与动效细节**:标题行间距在动画后恢复正确;退出确认 sheet 的滑出动画锚点更稳;全局错误提示更克制、少误导。
+  Copy and motion polish: headline spacing stays correct after animation; quit-confirm sheet slide is better anchored; global error surfaces are calmer and less misleading.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.2.4"
+version = "0.3.0"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- Bump version **0.2.4 → 0.3.0** in `package.json`, `package-lock.json` (root + `packages["]`), `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and the `codex-app-manager` block in `Cargo.lock` only.
- Add `docs/releases/v0.3.0.md` (bilingual highlights + fixes; install table unchanged per template).

## User-facing focus (from `v0.2.4..main`)

- ChatGPT rebrand Codex identity support (#142)
- Windows Schannel revocation-offline retry (#143)
- UI icons / theme / a11y / focus re-check and small polish

## Release steps after merge

1. Wait for required checks **and** the optional **nsis** job (~8min).
2. Squash-merge this PR.
3. Annotated tag `v0.3.0` on main HEAD and push — `release.yml` builds, mirrors, and publishes.

## Test plan

- [ ] Version strings are 0.3.0 in all five files (Cargo.lock only the app package)
- [ ] `docs/releases/v0.3.0.md` matches template structure
- [ ] CI Frontend + Rust (macos/windows) green
- [ ] nsis check green before merge