### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,68 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 可靠性与诚实状态补丁：操作锁、崩溃可恢复安装、失败可诊断、设置契约与 Windows 健康检查。
+> Reliability and honest-state patch: operation leases, crash-safe installs, diagnosable failures, settings contract, and Windows launchability checks.
+
+## ✨ 亮点 · Highlights
+
+- **阶段感知的退出与崩溃恢复**:下载/安装有明确阶段;提交中途不可中断退出,崩溃后按事务日志继续/回滚/保留人工材料。
+  Phase-aware quit and crash recovery: install/update phases are explicit; point-of-no-return blocks quit, and startup recovers from a durable transaction log.
+
+- **任务丢失后可接回**:页面 Reload / renderer 重建后查询 `OperationSnapshot`,按 operation id 重建进度与操作,迟到事件不会污染新任务。
+  Reattach after renderer loss: reload queries an operation snapshot and resubscribes by id so late events cannot corrupt a new task.
+
+- **配置健康与部分成功真相**:Settings 展示配置健康并可从 `.bak` 恢复;安装/卸载附属步骤失败时结构化呈现,支持只重试附属动作(清用户数据仍需确认)。
+  Config health and partial outcomes: Settings surfaces config health and restore-from-backup; partial install/uninstall results are structured with ancillary-only recovery (purge still confirms).
+
+## 🐛 修复 · Fixes
+
+- **启动 Codex 不再卡死 UI**:Windows 启动改为 async + 按钮 loading,防止二次点击。
+  Launch no longer freezes the UI: Windows launch is async with a loading button to block double-clicks.
+
+- **生产环境隐藏浏览器右键菜单**:正式构建不再出现 Print/Reload 等 WebView 菜单;输入框仍可复制粘贴。
+  Production context menus: release builds suppress browser chrome menus; text fields keep copy/paste.
+
+- **操作锁贯穿任务全生命周期**:已认领的 detached lease 不会仅因 5 分钟墙钟超时被回收。
+  Operation leases last the full task: claimed detached leases no longer expire by wall-clock stale timeout alone.
+
+- **Windows 装后真能启动**:外部探测有超时与清理;MSIX 做真实激活与存活窗口;失败路径会关掉误拉起的进程再回退 portable。
+  Windows post-install launchability: bounded probes, real MSIX activation + liveness, and process cleanup before portable fallback.
+
+- **失败面本地化与可访问性**:稳定错误码映射 11 语言;详情可展开;弹层在大字号下可滚动;焦点与 live-region 更稳。
+  Localized failures and a11y: stable codes map across 11 locales; expandable detail; sheets scroll at large text; focus and live regions improved.
+
+- **设置契约更诚实**:加载期间不可误改被覆盖;空自定义源/代理与运行态一致;定时检查/系统代理/自动源文案与真实能力对齐。
+  Honest settings contract: no hydration clobber, empty custom modes coerce consistently, and copy matches runtime guarantees.
+
+- **发布质量**:CI 独立跑 mac/win engine 测试;Windows 安装包生命周期冒烟与 Authenticode 校验路径已就绪。
+  Release quality: CI runs engine crate tests independently; Windows packaged smoke and Authenticode verify path are prepared.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 当前没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 里的 Tauri updater 签名只用于应用内自更新的字节校验,不代表 Windows 发行者信任。详情见 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed yet, so SmartScreen may warn on first run; the Tauri updater signature in `.sig` / `latest.json` verifies in-app update bytes only and is not Windows publisher trust. See [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.3.0"
+version = "0.3.1"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- Bump **0.3.0 → 0.3.1** (patch) in package/tauri/Cargo (lock app package only)
- Add `docs/releases/v0.3.1.md`

Ships the draft-PR batch: leases, phase quit + install recovery, reattach, Windows health, state truth, failure a11y, settings contract, context menu, launch async, CI packaged validation.

## Test plan

- [ ] Version strings only on app package
- [ ] Required CI + nsis green before merge
- [ ] After merge: tag `v0.3.1` and push to run release.yml