### PR TITLE
chore(release): bump version to 0.3.2

### DIFF
--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,0 +1,58 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 受限 Windows 环境与故障恢复补丁：便携版更新不再依赖 PowerShell 关闭 Codex，任务恢复与镜像交付也更可靠。
+> A constrained-Windows and recovery patch: portable updates no longer need PowerShell to close Codex, while task recovery and mirror delivery are more reliable.
+
+## ✨ 亮点 · Highlights
+
+- **原生外壳更稳**:原生菜单覆盖 11 种语言；第二次打开应用会恢复被最小化或隐藏的窗口，切换语言也会立即刷新菜单。
+  A steadier native shell: native menus cover all 11 locales; opening the app again restores a minimized or hidden window, and language changes refresh menus immediately.
+
+- **故障后接着处理**:renderer 崩溃或重载后会重新读取正在进行的任务；安装/卸载部分完成时保留尚未处理的恢复步骤，并用完整本地化文案引导精确重试。
+  Recovery without losing the task: after a renderer crash or reload, the app reconnects to the active operation; partial install/uninstall outcomes keep unfinished recovery steps and provide fully localized, targeted retry guidance.
+
+## 🐛 修复 · Fixes
+
+- **受限 Windows 策略不再卡住更新**:Authenticode 与 MSIX 报告兼容 PowerShell ConstrainedLanguage；便携版更新改用原生 Win32 API 关闭当前安装目录内的 Codex，不再因 PowerShell 被策略禁止而报错 786，也不会误关独立的 ChatGPT 应用。
+  Restricted Windows policies no longer block updates: Authenticode and MSIX reports work in PowerShell ConstrainedLanguage, while portable updates now close only the Codex process under the managed install root through native Win32 APIs — avoiding policy error 786 without touching the separate ChatGPT app.
+
+- **暂停与取消失败可见、可重试**:后端拒绝或请求发送失败时保留真实任务状态与错误提示；旧任务的迟到请求不会影响新的下载或安装。
+  Pause and cancel failures stay visible and retryable: backend refusals and delivery failures preserve the real operation state and error, while stale requests from an older task cannot affect a newer download or install.
+
+- **崩溃与 WebView 边界更安全**:根界面异常时提供可恢复的静态后备页；正式构建阻止打印、Reload、DevTools、危险导航与意外新窗口，同时保留输入框复制粘贴和受控的外部链接打开。
+  Safer crash and WebView boundaries: a recoverable static fallback covers root-renderer failures; production builds block print, reload, DevTools, unsafe navigation, and unexpected windows while preserving text editing and validated external links.
+
+- **镜像最新版不会倒退**:R2 作为权威端、IHEP 作为跟随端进行单调版本发布，并在上线前核验两个后端及公开路由，避免 `latest.json` 降级或双镜像分叉。
+  Mirror latest cannot move backward: R2 is the authority and IHEP follows a monotonic promotion, with both backends and public routes verified before publication to prevent `latest.json` downgrades or split mirrors.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.3.1"
+version = "0.3.2"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump Codex App Manager from 0.3.1 to 0.3.2 across all 5 files / 6 version declarations
- add the bilingual `docs/releases/v0.3.2.md` release note for all user-visible changes since `v0.3.1`
- prepare the protected, tag-driven patch release after this PR is merged

## Release readiness

- GitHub Immutable Releases enabled and verified
- `release` environment restricted to protected `main`
- both active tag rulesets verified: authorized creation plus update/deletion protection
- new R2/IHEP `*_PROMOTION_*` credentials are present in the `release` environment
- four legacy repository-level mirror write secrets removed

## Validation

- `node scripts/check-release-version.mjs source v0.3.2 .`
- `npm run check`
- `npm run lint`
- `npm run test` (275 tests)
- `npm run test:release` (56 tests)
- `npm run build`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace` (120 tests)
- macOS engine tests (24 tests)
- Windows engine tests (75 tests)
- Windows x64 and ARM64 cross-target checks
- `codex review --uncommitted`: no findings