### PR TITLE
fix(windows): harden portable directory replacement

### DIFF
--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -53,8 +53,9 @@ pub use plan::{plan_update, WinInstallRoute, WindowsUpdatePlan};
 pub use portable::{
     cleanup_portable_metadata, close_codex_gracefully_for_root, inject_portable_fault,
     install_portable_from_msix, install_portable_from_msix_with_observer, installed_app_exe,
-    purge_codex_user_data, uninstall_portable, PortableBoundary, PortableFault,
-    PortableInstallReport, PortableUninstallReport,
+    purge_codex_user_data, remove_directory_all_with_retry, rename_directory_with_retry,
+    uninstall_portable, PortableBoundary, PortableFault, PortableInstallReport,
+    PortableUninstallReport,
 };
 pub use sys::{
     close_msix_codex_processes, detect_installed_codex, detect_portable_install, fetch_text,

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -1,6 +1,8 @@
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -49,6 +51,118 @@ struct PreparedPortable {
 
 fn io_err(context: &str, err: impl ToString) -> EngineError {
     EngineError::Io(format!("{context}: {}", err.to_string()))
+}
+
+// Directory replacement can briefly race process teardown, Windows Defender,
+// or another file scanner even after every managed process has exited. Retry
+// only the Windows errors that describe transient handle/lock contention; all
+// other failures still return immediately.
+const WINDOWS_FS_RETRY_DELAYS_MS: [u64; 8] = [50, 100, 200, 400, 800, 1_600, 2_500, 5_000];
+
+fn is_transient_windows_fs_error(err: &io::Error) -> bool {
+    // ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION, ERROR_LOCK_VIOLATION.
+    #[cfg(any(windows, test))]
+    {
+        matches!(err.raw_os_error(), Some(5 | 32 | 33))
+    }
+    #[cfg(not(any(windows, test)))]
+    {
+        let _ = err;
+        false
+    }
+}
+
+fn filesystem_operation_with_retry<F, S>(
+    operation: &str,
+    source: &Path,
+    destination: Option<&Path>,
+    mut action: F,
+    mut sleep: S,
+) -> io::Result<()>
+where
+    F: FnMut() -> io::Result<()>,
+    S: FnMut(Duration),
+{
+    let destination_text = destination
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "none".to_string());
+    let mut attempt = 1usize;
+    loop {
+        match action() {
+            Ok(()) => {
+                if attempt > 1 {
+                    log::info!(
+                        "portable filesystem operation succeeded after retry operation={operation} attempts={attempt} source={} destination={destination_text}",
+                        source.display()
+                    );
+                }
+                return Ok(());
+            }
+            Err(err) => {
+                let retryable = is_transient_windows_fs_error(&err);
+                let next_delay = WINDOWS_FS_RETRY_DELAYS_MS.get(attempt - 1).copied();
+                let retry_delay = if retryable { next_delay } else { None };
+                if let Some(delay_ms) = retry_delay {
+                    log::warn!(
+                        "portable filesystem operation temporarily blocked operation={operation} attempt={attempt} raw_os_error={:?} source_exists={} destination_exists={} source={} destination={destination_text} error={err}; retrying_in_ms={delay_ms}",
+                        err.raw_os_error(),
+                        source.exists(),
+                        destination.is_some_and(Path::exists),
+                        source.display()
+                    );
+                    sleep(Duration::from_millis(delay_ms));
+                    attempt += 1;
+                    continue;
+                }
+
+                log::error!(
+                    "portable filesystem operation failed operation={operation} attempts={attempt} retryable={retryable} raw_os_error={:?} source_exists={} destination_exists={} source={} destination={destination_text} error={err}",
+                    err.raw_os_error(),
+                    source.exists(),
+                    destination.is_some_and(Path::exists),
+                    source.display()
+                );
+                return Err(err);
+            }
+        }
+    }
+}
+
+fn rename_with_retry<F, S>(
+    operation: &str,
+    from: &Path,
+    to: &Path,
+    rename: F,
+    sleep: S,
+) -> io::Result<()>
+where
+    F: FnMut() -> io::Result<()>,
+    S: FnMut(Duration),
+{
+    filesystem_operation_with_retry(operation, from, Some(to), rename, sleep)
+}
+
+/// Rename a portable-install directory, retrying only transient Windows lock
+/// errors with the same bounded backoff used by the real install swap.
+pub fn rename_directory_with_retry(operation: &str, from: &Path, to: &Path) -> io::Result<()> {
+    rename_with_retry(operation, from, to, || fs::rename(from, to), thread::sleep)
+}
+
+/// Remove a portable-install directory with bounded retries for transient
+/// Windows scanner/handle contention.
+pub fn remove_directory_all_with_retry(operation: &str, path: &Path) -> io::Result<()> {
+    filesystem_operation_with_retry(
+        operation,
+        path,
+        None,
+        || fs::remove_dir_all(path),
+        thread::sleep,
+    )
+}
+
+fn rename_portable_dir(operation: &str, from: &Path, to: &Path) -> Result<(), EngineError> {
+    rename_directory_with_retry(operation, from, to)
+        .map_err(|err| io_err(operation, err))
 }
 
 fn copy_dir_all(from: &Path, to: &Path) -> Result<(), EngineError> {
@@ -446,8 +560,7 @@ fn restore_previous_install(
             .map_err(|e| io_err("remove failed portable install", e))?;
     }
     if had_previous {
-        fs::rename(backup, install_root)
-            .map_err(|e| io_err("restore portable rollback backup", e))?;
+        rename_portable_dir("restore portable rollback backup", backup, install_root)?;
     }
     Ok(())
 }
@@ -666,8 +779,7 @@ pub fn install_portable_from_msix_with_observer(
     }
 
     if had_previous {
-        fs::rename(install_root, &backup)
-            .map_err(|e| io_err("move current install to rollback", e))?;
+        rename_portable_dir("move current install to rollback", install_root, &backup)?;
     }
 
     // Observer must persist OldMoved. On failure: restore previous install when
@@ -708,7 +820,7 @@ pub fn install_portable_from_msix_with_observer(
         ));
     }
 
-    match fs::rename(&payload, install_root) {
+    match rename_portable_dir("install portable payload", &payload, install_root) {
         Ok(()) => {
             if let Err(obs_err) = observer(PortableBoundary::AfterMoveNew {
                 install_root: install_root.to_path_buf(),
@@ -726,7 +838,7 @@ pub fn install_portable_from_msix_with_observer(
                 &backup,
                 had_previous,
                 observer,
-                io_err("install portable payload", err),
+                err,
             ));
         }
     }
@@ -915,6 +1027,7 @@ pub fn uninstall_portable(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::{Cell, RefCell};
     use std::io::Write;
     use std::sync::atomic::{AtomicU64, Ordering};
     use zip::write::SimpleFileOptions;
@@ -930,6 +1043,91 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn portable_directory_rename_retries_transient_windows_lock_errors() {
+        let attempts = Cell::new(0usize);
+        let sleeps = RefCell::new(Vec::new());
+
+        rename_with_retry(
+            "test rename",
+            Path::new("source"),
+            Path::new("destination"),
+            || {
+                let attempt = attempts.get() + 1;
+                attempts.set(attempt);
+                if attempt < 3 {
+                    Err(io::Error::from_raw_os_error(32))
+                } else {
+                    Ok(())
+                }
+            },
+            |duration| sleeps.borrow_mut().push(duration),
+        )
+        .unwrap();
+
+        assert_eq!(attempts.get(), 3);
+        assert_eq!(
+            sleeps.into_inner(),
+            vec![Duration::from_millis(50), Duration::from_millis(100)]
+        );
+    }
+
+    #[test]
+    fn portable_directory_rename_recognizes_all_transient_windows_codes() {
+        for code in [5, 32, 33] {
+            assert!(is_transient_windows_fs_error(
+                &io::Error::from_raw_os_error(code)
+            ));
+        }
+        assert!(!is_transient_windows_fs_error(
+            &io::Error::from_raw_os_error(2)
+        ));
+    }
+
+    #[test]
+    fn portable_directory_rename_does_not_retry_permanent_errors() {
+        let attempts = Cell::new(0usize);
+        let sleeps = Cell::new(0usize);
+
+        let err = rename_with_retry(
+            "test rename",
+            Path::new("source"),
+            Path::new("destination"),
+            || {
+                attempts.set(attempts.get() + 1);
+                Err(io::Error::from_raw_os_error(2))
+            },
+            |_| sleeps.set(sleeps.get() + 1),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.raw_os_error(), Some(2));
+        assert_eq!(attempts.get(), 1);
+        assert_eq!(sleeps.get(), 0);
+    }
+
+    #[test]
+    fn portable_directory_rename_retry_is_bounded() {
+        let attempts = Cell::new(0usize);
+        let sleeps = Cell::new(0usize);
+
+        let err = rename_with_retry(
+            "test rename",
+            Path::new("source"),
+            Path::new("destination"),
+            || {
+                attempts.set(attempts.get() + 1);
+                Err(io::Error::from_raw_os_error(5))
+            },
+            |_| sleeps.set(sleeps.get() + 1),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.raw_os_error(), Some(5));
+        assert_eq!(attempts.get(), WINDOWS_FS_RETRY_DELAYS_MS.len() + 1);
+        assert_eq!(sleeps.get(), WINDOWS_FS_RETRY_DELAYS_MS.len());
     }
 
     /// When `~/.codex` is a file (not a directory), purge fails — must stay

--- a/crates/codex-win-engine/src/windows_process.rs
+++ b/crates/codex-win-engine/src/windows_process.rs
@@ -3,15 +3,13 @@
 //! The pre-replacement close gate must not add a PowerShell dependency: policy
 //! can block a later PowerShell launch even after an artifact was staged and
 //! verified. Keep the close path in process and pin every target to its
-//! executable path so the post-rebrand `ChatGPT.exe` never causes us to close
-//! the separate ChatGPT product.
+//! executable path. Every process loaded from the managed install root is a
+//! target, regardless of filename, while a separate ChatGPT product remains
+//! out of scope because its executable lives outside that root.
 
 use std::path::Path;
 
 use crate::EngineError;
-
-#[cfg(windows)]
-const TARGET_EXE_NAMES: [&str; 2] = ["Codex.exe", "ChatGPT.exe"];
 
 #[cfg(any(windows, test))]
 fn normalize_windows_path_text(value: &str) -> String {
@@ -68,7 +66,7 @@ mod imp {
         EnumWindows, GetWindowThreadProcessId, PostMessageW, WM_CLOSE,
     };
 
-    use super::{path_is_within_root, EngineError, TARGET_EXE_NAMES};
+    use super::{path_is_within_root, EngineError};
 
     const PROCESS_SYNCHRONIZE: u32 = 0x0010_0000;
     const FORCE_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -110,12 +108,12 @@ mod imp {
                 WAIT_OBJECT_0 => false,
                 WAIT_TIMEOUT => true,
                 WAIT_FAILED => {
-                    log::warn!("wait for target Codex process failed pid={}", self.pid);
+                    log::warn!("wait for managed install process failed pid={}", self.pid);
                     true
                 }
                 status => {
                     log::warn!(
-                        "wait for target Codex process returned unexpected status pid={} status={status}",
+                        "wait for managed install process returned unexpected status pid={} status={status}",
                         self.pid
                     );
                     true
@@ -128,60 +126,42 @@ mod imp {
         EngineError::Install(format!("{context}: {}", std::io::Error::last_os_error()))
     }
 
-    fn process_name(entry: &PROCESSENTRY32W) -> String {
-        let end = entry
-            .szExeFile
-            .iter()
-            .position(|unit| *unit == 0)
-            .unwrap_or(entry.szExeFile.len());
-        String::from_utf16_lossy(&entry.szExeFile[..end])
-    }
-
-    fn open_target_process(pid: u32, root: &Path) -> Option<TargetProcess> {
-        let full_access =
-            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | PROCESS_SYNCHRONIZE;
-        // SAFETY: access flags and PID come from the process snapshot.
-        let mut handle = unsafe { OpenProcess(full_access, 0, pid) };
-        let can_terminate = !handle.is_null();
-        if handle.is_null() {
-            // Query-only access still lets us identify and gracefully close a
-            // process when policy denies PROCESS_TERMINATE.
-            handle = unsafe {
-                OpenProcess(
-                    PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
-                    0,
-                    pid,
-                )
-            };
-        }
-        let handle = match OwnedHandle::new(handle) {
-            Some(handle) => handle,
-            None => {
-                log::debug!(
-                    "skip Codex-name process whose image path cannot be queried pid={pid} error={}",
-                    std::io::Error::last_os_error()
-                );
-                return None;
-            }
-        };
+    fn open_process_under_root(pid: u32, root: &Path) -> Option<TargetProcess> {
+        let query_access = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE;
+        // Query every snapshot entry without requesting termination rights on
+        // unrelated system processes. Escalate access only after the image path
+        // has matched the managed root.
+        // Access-denied and already-exited processes are routine while walking
+        // the system-wide snapshot, so an unavailable query handle is skipped.
+        let query_handle = OwnedHandle::new(unsafe { OpenProcess(query_access, 0, pid) })?;
 
         let mut buffer = vec![0u16; MAX_PROCESS_PATH_UTF16];
         let mut length = buffer.len() as u32;
         // SAFETY: buffer is writable for `length` UTF-16 units and the process
         // handle has PROCESS_QUERY_LIMITED_INFORMATION access.
-        if unsafe { QueryFullProcessImageNameW(handle.raw(), 0, buffer.as_mut_ptr(), &mut length) }
-            == 0
+        if unsafe {
+            QueryFullProcessImageNameW(query_handle.raw(), 0, buffer.as_mut_ptr(), &mut length)
+        } == 0
         {
-            log::debug!(
-                "skip Codex-name process whose image path query failed pid={pid} error={}",
-                std::io::Error::last_os_error()
-            );
             return None;
         }
         let image_path = PathBuf::from(OsString::from_wide(&buffer[..length as usize]));
         if !path_is_within_root(&image_path, root) {
             return None;
         }
+
+        log::info!(
+            "managed install process discovered pid={pid} image={}",
+            image_path.display()
+        );
+
+        let full_access = query_access | PROCESS_TERMINATE;
+        // SAFETY: access flags and PID come from the process snapshot. If
+        // policy denies termination, keep the query/synchronize handle so a
+        // graceful close can still succeed.
+        let terminate_handle = OwnedHandle::new(unsafe { OpenProcess(full_access, 0, pid) });
+        let can_terminate = terminate_handle.is_some();
+        let handle = terminate_handle.unwrap_or(query_handle);
 
         Some(TargetProcess {
             pid,
@@ -211,15 +191,17 @@ mod imp {
         }
 
         let mut targets = Vec::new();
+        let manager_pid = std::process::id();
         loop {
-            let name = process_name(&entry);
-            if TARGET_EXE_NAMES
-                .iter()
-                .any(|candidate| name.eq_ignore_ascii_case(candidate))
-            {
-                if let Some(target) = open_target_process(entry.th32ProcessID, root) {
-                    targets.push(target);
-                }
+            // The Manager itself can be installed under a user-selected tree;
+            // never include the process performing the replacement.
+            let target = if entry.th32ProcessID != manager_pid {
+                open_process_under_root(entry.th32ProcessID, root)
+            } else {
+                None
+            };
+            if let Some(target) = target {
+                targets.push(target);
             }
 
             // SAFETY: same valid snapshot and entry buffer as Process32FirstW.
@@ -298,7 +280,7 @@ mod imp {
         for target in targets.iter().filter(|target| target.is_running()) {
             if !target.can_terminate {
                 log::warn!(
-                    "target Codex process cannot be force-closed without PROCESS_TERMINATE access pid={}",
+                    "managed install process cannot be force-closed without PROCESS_TERMINATE access pid={}",
                     target.pid
                 );
                 continue;
@@ -306,7 +288,7 @@ mod imp {
             // SAFETY: handle was opened with PROCESS_TERMINATE and is still owned.
             if unsafe { TerminateProcess(target.handle.raw(), 1) } == 0 {
                 log::warn!(
-                    "force-close target Codex process failed pid={} error={}",
+                    "force-close managed install process failed pid={} error={}",
                     target.pid,
                     std::io::Error::last_os_error()
                 );
@@ -315,7 +297,7 @@ mod imp {
 
         if wait_until_exited(&targets, FORCE_CLOSE_TIMEOUT) {
             log::warn!(
-                "target Codex processes required native force-close pids={:?}",
+                "managed install processes required native force-close pids={:?}",
                 force_ids
             );
             return Ok(());
@@ -327,7 +309,7 @@ mod imp {
             .map(|target| target.pid)
             .collect();
         Err(EngineError::Install(format!(
-            "target Codex process is still running after native close request (pids={remaining:?}); no files were replaced"
+            "managed install process is still running after native close request (pids={remaining:?}); no files were replaced"
         )))
     }
 
@@ -340,7 +322,7 @@ mod imp {
         const HELPER_ENV: &str = "CODEX_APP_MANAGER_PROCESS_HELPER";
 
         #[test]
-        fn closes_matching_process_without_powershell() {
+        fn closes_unlisted_helper_process_without_powershell() {
             if std::env::var_os(HELPER_ENV).is_some() {
                 thread::sleep(Duration::from_secs(30));
                 return;
@@ -352,12 +334,14 @@ mod imp {
                 uuid::Uuid::new_v4()
             ));
             std::fs::create_dir_all(&root).unwrap();
-            let helper = root.join("Codex.exe");
+            // The scanner must not depend on the two known entrypoint names:
+            // Chromium/Electron helpers can hold payload files open too.
+            let helper = root.join("Codex.Helper.exe");
             std::fs::copy(std::env::current_exe().unwrap(), &helper).unwrap();
             let mut child = Command::new(&helper)
                 .args([
                     "--exact",
-                    "windows_process::imp::windows_tests::closes_matching_process_without_powershell",
+                    "windows_process::imp::windows_tests::closes_unlisted_helper_process_without_powershell",
                     "--nocapture",
                 ])
                 .env(HELPER_ENV, "1")

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -1439,7 +1439,13 @@ fn install_portable_after_stage(
         true,
         &mut observer,
     )
-    .map_err(engine_err)?;
+    .map_err(|err| {
+        log::error!(
+            "Windows portable install failed install_root={} error={err}",
+            install_root_path.display()
+        );
+        engine_err(err)
+    })?;
     if let Some(active) = tx.take() {
         active.succeed()?;
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -273,6 +273,7 @@ fn mac_existing_install_start_dir() -> PathBuf {
 }
 
 const MIN_PORTABLE_FREE_SPACE_BYTES: u64 = 1_073_741_824;
+const INSTALL_LOCATION_PROBE_PREFIX: &str = ".codex-manager-install-test-";
 
 fn begin_guard(state: &ManagerState, kind: OperationKind) -> Result<OperationGuard, CommandError> {
     state
@@ -533,6 +534,70 @@ fn directory_is_empty(path: &Path) -> Result<bool, AppError> {
     Ok(entries.next().is_none())
 }
 
+/// Probe the operation the portable installer ultimately needs: create a
+/// non-empty child directory and atomically rename it beside the install root.
+/// A plain file write inside an existing install only proves file creation; it
+/// does not prove the parent grants directory replacement/delete-child rights.
+fn probe_install_parent_replace(path: &Path) -> Result<PathBuf, AppError> {
+    let requested_parent = path.parent().unwrap_or(path);
+    let probe_dir = nearest_existing_dir(requested_parent);
+    let probe_id = uuid::Uuid::new_v4();
+    let source = probe_dir.join(format!("{INSTALL_LOCATION_PROBE_PREFIX}{probe_id}-source"));
+    let destination =
+        probe_dir.join(format!("{INSTALL_LOCATION_PROBE_PREFIX}{probe_id}-destination"));
+
+    let probe_result = (|| -> std::io::Result<()> {
+        std::fs::create_dir(&source)?;
+        std::fs::write(source.join("probe"), b"ok")?;
+        codex_win_engine::rename_directory_with_retry(
+            "probe install parent directory rename",
+            &source,
+            &destination,
+        )?;
+        Ok(())
+    })();
+
+    // Validation must remain side-effect free. Clean both names because the
+    // probe can fail before or after the rename boundary.
+    let source_cleanup = if source.exists() {
+        codex_win_engine::remove_directory_all_with_retry(
+            "clean install parent source probe",
+            &source,
+        )
+    } else {
+        Ok(())
+    };
+    let destination_cleanup = if destination.exists() {
+        codex_win_engine::remove_directory_all_with_retry(
+            "clean install parent destination probe",
+            &destination,
+        )
+    } else {
+        Ok(())
+    };
+
+    let cleanup_result = source_cleanup.and(destination_cleanup);
+    match (probe_result, cleanup_result) {
+        (Ok(()), Ok(())) => {}
+        (Err(probe_err), Ok(())) => {
+            return Err(AppError::Internal(format!(
+                "安装位置父目录不可写或不支持目录替换: {probe_err}"
+            )));
+        }
+        (Ok(()), Err(cleanup_err)) => {
+            return Err(AppError::Internal(format!(
+                "安装位置探测目录清理失败: {cleanup_err}"
+            )));
+        }
+        (Err(probe_err), Err(cleanup_err)) => {
+            return Err(AppError::Internal(format!(
+                "安装位置父目录不可写或不支持目录替换: {probe_err}; 探测目录清理也失败: {cleanup_err}"
+            )));
+        }
+    }
+    Ok(probe_dir)
+}
+
 fn validate_install_root_path(raw: &str) -> Result<String, AppError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -555,17 +620,10 @@ fn validate_install_root_path(raw: &str) -> Result<String, AppError> {
             "安装位置必须是空文件夹，或已有的 Codex 免安装版目录".to_string(),
         ));
     }
-    // Probe writability and free space WITHOUT creating the target directory:
-    // merely validating or remembering a location must not leave folders on
-    // disk. We probe the nearest existing ancestor — it shares the volume (so
-    // the free-space figure matches) and a writable parent means the installer
-    // can create the leaf later. The directory is created at install time by
-    // install_portable_from_msix, not here.
-    let probe_dir = nearest_existing_dir(&path);
-    let probe = probe_dir.join(format!(".codex-manager-write-test-{}", std::process::id()));
-    std::fs::write(&probe, b"ok")
-        .map_err(|e| AppError::Internal(format!("安装位置不可写: {e}")))?;
-    let _ = std::fs::remove_file(&probe);
+    // Probe parent-level directory creation and rename WITHOUT creating the
+    // requested target itself. This mirrors the install swap and also gives us
+    // the same-volume ancestor for the free-space check.
+    let probe_dir = probe_install_parent_replace(&path)?;
     if let Some(free) = available_space(&probe_dir)? {
         if free < MIN_PORTABLE_FREE_SPACE_BYTES {
             return Err(AppError::Internal(
@@ -1307,11 +1365,15 @@ pub async fn win_pick_install_dir(
     })
     .await
     .map_err(|e| AppError::Internal(format!("join: {e}")))??;
-    selected
-        .as_deref()
-        .map(install_root_from_picked_dir)
-        .transpose()
-        .map_err(Into::into)
+    match selected {
+        Some(path) => tauri::async_runtime::spawn_blocking(move || {
+            install_root_from_picked_dir(&path).map(Some)
+        })
+        .await
+        .map_err(|e| AppError::Internal(format!("join: {e}")))?
+        .map_err(Into::into),
+        None => Ok(None),
+    }
 }
 
 /// Windows-only: let the user pick an existing portable/self-extracted Codex directory.
@@ -1362,7 +1424,7 @@ pub fn win_adopt_path(
 
 /// Windows-only: persist a validated portable install root.
 #[tauri::command]
-pub fn win_set_install_root(
+pub async fn win_set_install_root(
     state: State<'_, ManagerState>,
     path: String,
 ) -> Result<PersistedAppSettings, CommandError> {
@@ -1370,7 +1432,10 @@ pub fn win_set_install_root(
         return Err(AppError::UnsupportedPlatform.into());
     }
     let _op = begin_guard(&state, OperationKind::SetInstallRoot)?;
-    let install_root = validate_install_root_path(&path)?;
+    let install_root =
+        tauri::async_runtime::spawn_blocking(move || validate_install_root_path(&path))
+            .await
+            .map_err(|e| AppError::Internal(format!("join: {e}")))??;
     let mut settings = PersistedAppSettings::load();
     settings.install_root = install_root;
     settings.normalize();
@@ -1382,14 +1447,19 @@ pub fn win_set_install_root(
 
 /// Windows-only: reset the remembered portable install root to the per-user default.
 #[tauri::command]
-pub fn win_reset_install_root(
+pub async fn win_reset_install_root(
     state: State<'_, ManagerState>,
 ) -> Result<PersistedAppSettings, CommandError> {
     if !matches!(state.target.os, OperatingSystem::Windows) {
         return Err(AppError::UnsupportedPlatform.into());
     }
     let _op = begin_guard(&state, OperationKind::SetInstallRoot)?;
-    let install_root = validate_install_root_path(&PersistedAppSettings::default().install_root)?;
+    let default_install_root = PersistedAppSettings::default().install_root;
+    let install_root = tauri::async_runtime::spawn_blocking(move || {
+        validate_install_root_path(&default_install_root)
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("join: {e}")))??;
     let mut settings = PersistedAppSettings::load();
     settings.install_root = install_root;
     settings.normalize();
@@ -1800,7 +1870,10 @@ pub async fn win_perform_update(
     // so a failed or cancelled attempt never changes the user's saved location.
     let pending_install_root = match install_root {
         Some(raw) => {
-            let validated = validate_install_root_path(&raw)?;
+            let validated =
+                tauri::async_runtime::spawn_blocking(move || validate_install_root_path(&raw))
+                    .await
+                    .map_err(|e| AppError::Internal(format!("join: {e}")))??;
             settings.install_root = validated.clone();
             Some(validated)
         }
@@ -1915,7 +1988,7 @@ pub async fn win_uninstall(
 mod tests {
     use super::{
         install_root_from_picked_dir, manager_update_matches_confirmation,
-        normalize_windows_source_base, validate_install_root_path,
+        normalize_windows_source_base, validate_install_root_path, INSTALL_LOCATION_PROBE_PREFIX,
         validated_custom_proxy_for_settings,
     };
     use std::fs;
@@ -2062,6 +2135,27 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn validation_removes_parent_replace_probe() {
+        let parent = temp_path("codex-manager-validate-probe-cleanup");
+        let root = parent.join("Codex");
+        let _ = fs::remove_dir_all(&parent);
+        fs::create_dir_all(&parent).unwrap();
+
+        validate_install_root_path(&root.to_string_lossy()).unwrap();
+
+        assert!(!fs::read_dir(&parent).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(INSTALL_LOCATION_PROBE_PREFIX)
+        }));
+        assert!(!root.exists());
+
+        let _ = fs::remove_dir_all(parent);
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Fixes #181

## Summary
- retry portable directory swaps only for transient Windows access, sharing, and lock errors with bounded backoff and detailed diagnostics
- discover and close every helper process whose executable is inside the managed install root, independent of filename
- validate parent-directory rename permissions without blocking Tauri or Tokio workers
- log the exact portable engine error before mapping it to the UI error contract

## Evidence
The issue logs showed failures on both rename boundaries: moving the current install to rollback and moving the staged payload into the install root. The varying boundary is consistent with transient handle contention from a remaining helper process or filesystem scanner.

## Validation
- codex review --uncommitted: no findings
- npm run check
- npm run lint
- npm run test --if-present: 275 passed
- npm run build
- cargo clippy workspace all targets with warnings denied
- Tauri workspace tests: 121 passed
- Windows engine all-target tests: 79 passed
- macOS engine all-target tests: 24 passed
- Windows engine x64 and ARM64 MSVC cross checks