### PR TITLE
chore(release): bump version to 0.3.3

### DIFF
--- a/docs/releases/v0.3.3.md
+++ b/docs/releases/v0.3.3.md
@@ -1,0 +1,47 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> Windows 免安装版更新可靠性补丁：残留辅助进程或安全软件短暂占用文件时，目录替换会自动重试并保留精确诊断。
+> A Windows portable-update reliability patch: directory replacement now retries transient locks from helper processes or security scanners and preserves precise diagnostics.
+
+## 🐛 修复 · Fixes
+
+- **短暂文件占用不再直接打断更新**:Codex 退出或 Defender / EDR 扫描造成 Windows 错误 5、32、33 时，旧版本备份、新版本就位和回滚恢复会进行有界重试，而不是第一次重命名失败就终止。
+  Transient file contention no longer aborts an update immediately: when Codex shutdown or Defender / EDR scanning causes Windows errors 5, 32, or 33, backup, replacement, and rollback renames use bounded retries instead of failing on the first attempt.
+
+- **残留辅助进程也会被正确关闭**:更新前会识别当前安装目录内的所有可执行进程，不再只依赖 `Codex.exe` / `ChatGPT.exe` 文件名；匹配仍严格限定到托管安装根目录，不会影响其他位置的 ChatGPT。
+  Leftover helper processes are closed correctly: the updater now discovers every executable process under the managed install root instead of relying only on `Codex.exe` / `ChatGPT.exe` names, while the exact-root boundary keeps separate ChatGPT installs out of scope.
+
+- **安装位置校验更贴近真实替换**:选择路径时会在父目录执行非空目录重命名探测，并把可能的退避等待移出界面与异步运行线程；失败日志会记录具体操作边界、系统错误码和源/目标目录状态。
+  Install-location validation now mirrors the real swap: it probes a non-empty directory rename in the parent directory, keeps retry waits off UI and async runtime threads, and logs the exact operation boundary, OS error code, and source/destination state on failure.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "codex-mac-engine",
  "codex-win-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.3.2"
+version = "0.3.3"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump all six application version declarations to `0.3.3`
- add bilingual `v0.3.3` release notes for the Windows portable update reliability fix from #181/#197
- preserve the verified installation, mirror, updater-artifact, and Windows signing guidance

## Validation

- `codex review --uncommitted` — no findings
- `node scripts/check-release-version.mjs source v0.3.3 .`
- `npm run check`
- `npm run lint`
- `npm run test --if-present` — 275 tests passed
- `npm run build`
- `npm run test:release` — 56 tests passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace` — 121 tests passed
- `cargo test --manifest-path crates/codex-mac-engine/Cargo.toml --all-targets` — 24 tests passed
- `cargo test --manifest-path crates/codex-win-engine/Cargo.toml --all-targets` — 79 tests passed