### PR TITLE
fix(themes): replace reqwest with a raw loopback HTTP reader in the CDP client

### DIFF
--- a/crates/codex-theme-engine/Cargo.lock
+++ b/crates/codex-theme-engine/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,12 +24,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,7 +42,6 @@ dependencies = [
  "base64",
  "futures-util",
  "log",
- "reqwest",
  "serde",
  "serde_json",
  "sha1",
@@ -62,6 +49,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
+ "url",
 ]
 
 [[package]]
@@ -133,15 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -219,76 +198,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "icu_collections"
@@ -394,27 +307,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "js-sys"
-version = "0.3.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
-dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "libc"
@@ -553,35 +449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,12 +460,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
@@ -694,15 +555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,76 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,15 +706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,71 +718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/codex-theme-engine/Cargo.toml
+++ b/crates/codex-theme-engine/Cargo.toml
@@ -9,13 +9,13 @@ description = "Asset-based UI theme engine for the Codex desktop app: loopback C
 base64 = "0.22"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 log = "0.4"
-reqwest = { version = "0.13", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha1 = "0.10"
 thiserror = "2"
-tokio = { version = "1", features = ["rt", "net", "time", "sync", "macros"] }
+tokio = { version = "1", features = ["rt", "net", "time", "sync", "io-util", "macros"] }
 tokio-tungstenite = "0.28"
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/codex-theme-engine/src/cdp.rs
+++ b/crates/codex-theme-engine/src/cdp.rs
@@ -42,7 +42,7 @@ pub struct TargetInfo {
 /// Reject anything that is not `ws://<loopback>:<port>/...` — the daemon must
 /// never follow a debugger URL onto the network.
 pub fn validated_debugger_url(target: &TargetInfo, port: u16) -> Result<String> {
-    let url = reqwest::Url::parse(&target.web_socket_debugger_url)
+    let url = url::Url::parse(&target.web_socket_debugger_url)
         .map_err(|e| err(format!("invalid CDP WebSocket URL: {e}")))?;
     let loopback = matches!(url.host_str(), Some("127.0.0.1") | Some("localhost") | Some("[::1]"))
         || url.host_str() == Some("::1");
@@ -226,28 +226,104 @@ impl CdpSession {
     }
 }
 
-fn loopback_client(timeout: Duration) -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .no_proxy()
-        .timeout(timeout)
-        .build()
-        .map_err(|e| err(format!("http client: {e}")))
+const HTTP_HEADER_CAP: usize = 64 * 1024;
+const HTTP_BODY_CAP: usize = 8 * 1024 * 1024;
+
+/// Minimal loopback HTTP GET over a raw socket. Deliberately not reqwest: a
+/// full HTTP client drags TLS feature-unification along (in the manager
+/// workspace reqwest resolves to `rustls-no-provider` and its Client::build
+/// panics without an installed crypto provider — which, inside a tauri async
+/// command, turns into an invoke that never settles).
+///
+/// Wire notes, measured against Chromium's DevTools HTTP endpoint: it refuses
+/// HTTP/1.0 outright (empty reply) and ignores `Connection: close`, so this
+/// speaks HTTP/1.1 and reads exactly `Content-Length` bytes — these endpoints
+/// always answer identity-encoded with an explicit length; anything else is
+/// rejected rather than mis-parsed.
+async fn loopback_http_get(port: u16, path: &str, timeout: Duration) -> Result<Vec<u8>> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let io = async {
+        let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .map_err(|e| err(format!("connect 127.0.0.1:{port}: {e}")))?;
+        stream
+            .write_all(
+                format!(
+                    "GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .map_err(|e| err(format!("request write: {e}")))?;
+
+        // Accumulate until the header terminator, then drain the body by
+        // declared length (an early EOF from a server that *does* honor the
+        // close is also accepted once the body is complete).
+        let mut response: Vec<u8> = Vec::with_capacity(8 * 1024);
+        let mut buf = [0u8; 8 * 1024];
+        let header_end = loop {
+            if let Some(pos) = response.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos;
+            }
+            if response.len() > HTTP_HEADER_CAP {
+                return Err(err(format!("GET {path}: oversized response header")));
+            }
+            let n = stream
+                .read(&mut buf)
+                .await
+                .map_err(|e| err(format!("response read: {e}")))?;
+            if n == 0 {
+                return Err(err(format!("GET {path}: connection closed mid-header")));
+            }
+            response.extend_from_slice(&buf[..n]);
+        };
+
+        let headers = String::from_utf8_lossy(&response[..header_end]).to_string();
+        let status_line = headers.lines().next().unwrap_or("").to_string();
+        if status_line.split(' ').nth(1) != Some("200") {
+            return Err(err(format!("GET {path}: {status_line}")));
+        }
+        let mut content_length: Option<usize> = None;
+        for line in headers.lines().skip(1) {
+            let lower = line.to_ascii_lowercase();
+            if lower.starts_with("transfer-encoding:") && lower.contains("chunked") {
+                return Err(err(format!("GET {path}: unsupported chunked response")));
+            }
+            if let Some(value) = lower.strip_prefix("content-length:") {
+                content_length = value.trim().parse::<usize>().ok();
+            }
+        }
+        let length = content_length
+            .ok_or_else(|| err(format!("GET {path}: missing Content-Length")))?;
+        if length > HTTP_BODY_CAP {
+            return Err(err(format!("GET {path}: oversized response body")));
+        }
+
+        let mut body = response.split_off(header_end + 4);
+        while body.len() < length {
+            let n = stream
+                .read(&mut buf)
+                .await
+                .map_err(|e| err(format!("response read: {e}")))?;
+            if n == 0 {
+                return Err(err(format!("GET {path}: connection closed mid-body")));
+            }
+            body.extend_from_slice(&buf[..n]);
+        }
+        body.truncate(length);
+        Ok::<Vec<u8>, ThemeEngineError>(body)
+    };
+    tokio::time::timeout(timeout, io)
+        .await
+        .map_err(|_| err(format!("GET {path} timed out")))?
 }
 
 /// Enumerate verified `app://` page targets, main window first (auxiliary
 /// prewarm/panel targets carry query-string routes and sort after it).
 pub async fn list_app_targets(port: u16) -> Result<Vec<TargetInfo>> {
-    let client = loopback_client(LIST_TIMEOUT)?;
-    let body = client
-        .get(format!("http://127.0.0.1:{port}/json/list"))
-        .send()
+    let body = loopback_http_get(port, "/json/list", LIST_TIMEOUT)
         .await
-        .map_err(|e| err(format!("target list failed: {e}")))?
-        .error_for_status()
-        .map_err(|e| err(format!("target list failed: {e}")))?
-        .bytes()
-        .await
-        .map_err(|e| err(format!("target list read failed: {e}")))?;
+        .map_err(|e| err(format!("target list failed: {e}")))?;
     let targets: Vec<TargetInfo> = serde_json::from_slice(&body)
         .map_err(|e| err(format!("target list parse failed: {e}")))?;
     let mut filtered: Vec<TargetInfo> = targets
@@ -266,17 +342,7 @@ pub async fn list_app_targets(port: u16) -> Result<Vec<TargetInfo>> {
 /// Whether a CDP HTTP endpoint answers on the port (does NOT prove it is
 /// Codex — pair with a shell probe before injecting).
 pub async fn cdp_http_ready(port: u16) -> bool {
-    let Ok(client) = loopback_client(VERSION_TIMEOUT) else {
-        return false;
-    };
-    let Ok(response) = client
-        .get(format!("http://127.0.0.1:{port}/json/version"))
-        .send()
-        .await
-    else {
-        return false;
-    };
-    let Ok(bytes) = response.bytes().await else {
+    let Ok(bytes) = loopback_http_get(port, "/json/version", VERSION_TIMEOUT).await else {
         return false;
     };
     let Ok(body) = serde_json::from_slice::<Value>(&bytes) else {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -659,13 +659,13 @@ dependencies = [
  "base64 0.22.1",
  "futures-util",
  "log",
- "reqwest",
  "serde",
  "serde_json",
  "sha1",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+ "url",
 ]
 
 [[package]]


### PR DESCRIPTION
**Bug**: 主题页保存本地目录后既无主题也无空态——`refresh()` 永挂。

**根因**：workspace feature unification 把 engine 的 reqwest 解析成 `rustls-no-provider` 配置，`Client::build()` 运行时 panic（无 crypto provider）；tauri async command 里的 panic 表现为 invoke 永不 settle。engine 独立编译无此 feature 组合，所以 standalone 单测全绿、进 app 即挂。

**修复**：CDP 的 `/json/list` / `/json/version` 是本机明文 HTTP——彻底去掉 reqwest，用 TcpStream 手写 HTTP/1.1 GET，按 Content-Length 精确读。实测 Chromium DevTools server 拒绝 HTTP/1.0（空响应）且忽略 `Connection: close`，所以不能用 close-delimited 读法；chunked 响应显式拒绝。URL 校验改用 url crate（tungstenite 依赖树里已有）。

**验证**：engine 12 单测 + workspace 125 测试 + 双侧 clippy `-D warnings` 全绿；真机 live 测试对 9345 上运行中的 Codex 完成 target 枚举 + probe + stamp 读取（正确识别 studio watcher 的活跃主题并跳过注入）。`cargo tree` 确认 engine 依赖树中 reqwest 归零。