### PR TITLE
fix(shell): workbench edge-to-edge, maximize permission, collapsed lists

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-close",
     "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
     "core:window:allow-scale-factor",
     "dialog:allow-open",
     "process:allow-restart"

--- a/src-tauri/src/app/window_mode.rs
+++ b/src-tauri/src/app/window_mode.rs
@@ -156,8 +156,14 @@ pub fn apply_window_mode(
             window
                 .set_resizable(false)
                 .map_err(|e| win_err("resizable", e))?;
+            // Back to the floating popover: shadow is self-drawn around the
+            // card, inside the transparent gutter.
+            let _ = window.set_shadow(false);
         }
         WindowMode::Expanded => {
+            // The workbench fills the frame edge-to-edge (no transparent
+            // gutter), so the shadow must come from the OS.
+            let _ = window.set_shadow(true);
             window
                 .set_resizable(true)
                 .map_err(|e| win_err("resizable", e))?;

--- a/src/app/securityConfig.test.ts
+++ b/src/app/securityConfig.test.ts
@@ -45,6 +45,8 @@ describe("desktop trust-boundary config", () => {
       "core:window:allow-start-dragging",
       "core:window:allow-close",
       "core:window:allow-minimize",
+      // The expanded workbench offers a native maximize toggle.
+      "core:window:allow-toggle-maximize",
       // Window-mode switching stores the expanded size in logical px; the
       // renderer reads the monitor scale to convert onResized's physical px.
       "core:window:allow-scale-factor",

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -301,14 +301,30 @@ input {
   }
 }
 
-/* Expanded: #root becomes a horizontal card shelf — the rail is a second
-   floating card beside the active view's card, sharing the transparent
-   gutter, so the workbench still reads as the same popover material that
-   simply grew a sibling. */
+/* Expanded: a solid desktop window, edge to edge. The compact popover's
+   transparent gutter would read as a phantom border here (clicks and edge
+   drags land on "air"), so the workbench drops it entirely: no padding, the
+   window IS the surface (native shadow comes from the backend via
+   set_shadow), and the rail becomes a fixed pane behind a hairline instead
+   of a floating card. */
 :root[data-window-mode="expanded"] #root {
   display: flex;
   align-items: stretch;
-  gap: 12px;
+  gap: 0;
+  padding: 0;
+  background: var(--bg);
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--line-2);
+}
+:root[data-window-mode="expanded"] #root > .pop,
+:root[data-window-mode="expanded"] #root > [data-view] > .pop {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+:root[data-window-mode="expanded"] .rail {
+  border-right: 1px solid var(--line);
 }
 /* Only the top-level window cards flex — `.pop` is also borrowed by inner
    decorations (Uninstall's completion Ring), which a descendant selector
@@ -327,6 +343,14 @@ input {
   width: 100%;
   max-width: 640px;
   margin-inline: auto;
+}
+
+/* A scroll container's children must never be squeezed — overflowing content
+   is what the scrollbar is for. Critical for children with overflow:hidden
+   (.list), whose automatic minimum height computes to 0 as a flex item and
+   which therefore collapse to their borders when content overflows. */
+.scroll-wide > * {
+  flex-shrink: 0;
 }
 
 /* The rail — same .pop material, fixed width, its own entrance. */


### PR DESCRIPTION
三个真机反馈修复：

1. **最大化按钮无效**：前端 `toggleMaximize()` 走的是 `core:window:allow-toggle-maximize`，而 capability 里只有 `internal-toggle-maximize`（那是 drag-region 双击的内部命令）。补权限 + 安全白名单测试同步。双击标题栏最大化同样依赖窗口 resizable（expanded 已开启），修复后一并生效。
2. **工作台的隐形空气边缘**：expanded 彻底放弃 compact 的透明 gutter——padding 归零、实体背景、外角 10px、**系统阴影改由 `set_shadow(true)` 提供**（compact 切回自绘）；卡片在实体框架内扁平化，rail 以细线分隔。拖拽边缘所见即所得。
3. **存储/本地主题目录空白**：画廊内容超出滚动容器时，`.list`（overflow:hidden）作为 flex item 的自动最小高度按 0 计算，被压缩成 2px 边框线。滚动容器的孩子统一 `flex-shrink: 0`——溢出本来就该交给滚动条。浅色/深色皆已复现并验证修复。

前端 283 测试、双侧 clippy -D warnings 全绿。