### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,58 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 给 Codex 桌面版换装：全新「皮肤」板块带来素材化 UI 主题、秒级热换肤与在线皮肤商店，管理器窗口也学会了展开成桌面工作台。
+> Dress up the Codex desktop app: a new Skins board brings asset-based UI themes, instant hot skin switching and an online skin store — and the manager window now expands into a desktop workbench.
+
+## ✨ 亮点 · Highlights
+
+- **全新「皮肤」板块（macOS 先行）**:为官方 Codex 桌面版换上素材化 UI 皮肤——背景、图标、装饰层与配色整体换装。注入只发生在运行中的渲染进程,**不改动 Codex 的任何文件与签名**,关闭主题即回到原生外观。
+  A new Skins board (macOS first): dress the official Codex desktop app in asset-based UI skins — backdrops, icons, chrome layers and palettes as one look. Injection happens only in the live renderer; **no Codex file or signature is ever touched**, and turning the theme off returns to stock.
+
+- **秒级热换肤,原生外观一起切**:试穿、换肤、应用在 Codex 运行时直接热切换,连官方原生配色、代码高亮主题与亮暗模式都随皮肤即时联动,无需重启。试穿随时可还原;「完全恢复」把 `config.toml` 精确还原到你自己的原生设置,过程带事务与崩溃自恢复。
+  Instant hot skin switching, native appearance included: try-on, switch and apply happen live while Codex runs — the official palette, code-highlighting theme and light/dark mode follow the skin instantly, no restart. Try-ons are always revertible, and Full Restore puts `config.toml` back to your own native settings exactly, guarded by a transaction with crash recovery.
+
+- **在线皮肤商店**:内置商店对接 [skins.agentsmirror.com](https://skins.agentsmirror.com),26 款认证皮肤支持截图预览、多字段搜索、一键安装与版本更新,下载全程 sha256 校验。皮肤生态由开放标准仓库 [awesome-codex-skins](https://github.com/Wangnov/awesome-codex-skins) 驱动,欢迎投稿。
+  An online skin store: the built-in store talks to [skins.agentsmirror.com](https://skins.agentsmirror.com) — 26 certified skins with screenshot previews, multi-field search, one-click install and version updates, every download sha256-verified. The ecosystem is driven by the open-standard [awesome-codex-skins](https://github.com/Wangnov/awesome-codex-skins) repository; submissions welcome.
+
+- **`.codexskin` 皮肤包**:皮肤以单文件包分发,拖进窗口或点击导入即可安装;包内自带真实截图预览、作者、版本与验证元数据,导入前完成结构校验。
+  The `.codexskin` package: skins ship as a single file — drop it on the window or click import; packages carry real-screenshot previews plus author/version/verification metadata and are structurally validated before install.
+
+- **桌面工作台形态**:紧凑小窗一键展开为可自由缩放的桌面工作台——左侧导航栏、窗口最大化(按钮或双击标题栏)、拖拽调整并记住你的尺寸;皮肤画廊在宽窗下自动多列展示。
+  A desktop workbench mode: the compact popover expands into a freely resizable workbench — navigation rail, window maximize (button or title-bar double-click), drag-to-resize with size memory, and the skin gallery flows into more columns on wider windows.
+
+## 🐛 修复 · Fixes
+
+- **设置页恢复操作更清爽**:安装恢复相关的控件重新编排,只在需要时出现对应操作,不再堆满整屏。
+  Cleaner recovery controls in Settings: install-recovery actions are reorganized and only surface when applicable, instead of crowding the page.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "codex-mac-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.3.3"
+version = "0.4.0"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
0.3.3 → 0.4.0（minor）：皮肤功能线（引擎/画廊/商店/.codexskin/热换肤事务）+ 桌面工作台形态。

- bump 5 文件 6 处（package.json、package-lock ×2、tauri.conf.json、Cargo.toml、Cargo.lock 仅 codex-app-manager 块）
- docs/releases/v0.4.0.md 双语 release note（素材：v0.3.3..main 的 #199–#210，只写用户可感知变化；皮肤功能标注 macOS 先行；商店 26 款皮肤数字已核对 catalog）

等 nsis 检查也绿后合并；合并后在 main HEAD 打 v0.4.0 tag 触发 release.yml。