### PR TITLE
fix(windows): hide theme curl console windows

### DIFF
--- a/src-tauri/src/app/codex_theme.rs
+++ b/src-tauri/src/app/codex_theme.rs
@@ -545,11 +545,30 @@ fn curl_bin() -> &'static str {
     }
 }
 
+fn curl_command() -> std::process::Command {
+    let command = std::process::Command::new(curl_bin());
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        // The manager is a GUI application. Without CREATE_NO_WINDOW, every
+        // catalog or preview request opens a visible curl.exe console window.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        let mut command = command;
+        command.creation_flags(CREATE_NO_WINDOW);
+        command
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        command
+    }
+}
+
 /// Fetch a URL to stdout via system curl: https only, no retries into other
 /// protocols, hard timeout and size cap. `--retry` covers the transient
 /// connection resets this route sees in the wild (CDN + long-haul links).
 fn curl_fetch(url: &str, max_bytes: &str, timeout_secs: &str) -> Result<Vec<u8>, AppError> {
-    let output = std::process::Command::new(curl_bin())
+    let output = curl_command()
         .args([
             "-sfL",
             "--proto",


### PR DESCRIPTION
## Summary

- hide the Windows console window created by theme-related `curl` requests
- apply `CREATE_NO_WINDOW` only on Windows and keep other platforms unchanged

## Root cause

The theme catalog, detail, and image fetch paths launched the system `curl` process directly. On Windows, each request could therefore create a visible console window.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml --lib`
- Windows `CommandExt` path compiled for `x86_64-pc-windows-msvc`
- `codex review --uncommitted` — no findings

Related to #212
