### PR TITLE
fix(windows): preserve Codex run state after updates

### DIFF
--- a/crates/codex-win-engine/src/lib.rs
+++ b/crates/codex-win-engine/src/lib.rs
@@ -51,11 +51,11 @@ pub use msix::{
 pub use network::NetworkConfig;
 pub use plan::{plan_update, WinInstallRoute, WindowsUpdatePlan};
 pub use portable::{
-    cleanup_portable_metadata, close_codex_gracefully_for_root, inject_portable_fault,
-    install_portable_from_msix, install_portable_from_msix_with_observer, installed_app_exe,
-    purge_codex_user_data, remove_directory_all_with_retry, rename_directory_with_retry,
-    uninstall_portable, PortableBoundary, PortableFault, PortableInstallReport,
-    PortableUninstallReport,
+    cleanup_portable_metadata, close_codex_gracefully_for_root, codex_running_for_root,
+    inject_portable_fault, install_portable_from_msix, install_portable_from_msix_with_observer,
+    installed_app_exe, purge_codex_user_data, remove_directory_all_with_retry,
+    rename_directory_with_retry, uninstall_portable, PortableBoundary, PortableFault,
+    PortableInstallReport, PortableUninstallReport,
 };
 pub use sys::{
     close_msix_codex_processes, detect_installed_codex, detect_portable_install, fetch_text,
@@ -63,8 +63,8 @@ pub use sys::{
     remove_msix_package, InstalledWindowsCodex, LaunchOptions, MsixRemoveReport,
 };
 pub use sys::{
-    install_msix_sideload, precheck_msix_dependencies, verify_msix_health, MsixDependencyPrecheck,
-    MsixHealthReport, MsixSideloadReport,
+    install_msix_sideload, precheck_msix_dependencies, verify_msix_health,
+    verify_msix_health_with_options, MsixDependencyPrecheck, MsixHealthReport, MsixSideloadReport,
 };
 // Failure-kind constants for structured MSIX health outcomes.
 pub use sys::msix_failure;

--- a/crates/codex-win-engine/src/portable.rs
+++ b/crates/codex-win-engine/src/portable.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
@@ -385,6 +385,12 @@ pub fn close_codex_gracefully_for_root(timeout_secs: u64, root: &Path) -> Result
     crate::windows_process::close_codex_processes_for_root(timeout_secs, root)
 }
 
+/// Whether Codex currently has any process running from this exact install
+/// root. The same native, path-pinned discovery is used by the close gate.
+pub fn codex_running_for_root(root: &Path) -> Result<bool, EngineError> {
+    crate::windows_process::codex_processes_running_for_root(root)
+}
+
 #[cfg(windows)]
 fn create_start_menu_shortcut(install_root: &Path) -> Result<bool, EngineError> {
     let Some(exe) = installed_app_exe(install_root) else {
@@ -596,7 +602,11 @@ fn rollback_install_error(
     }
 }
 
-fn health_check_portable_install(install_root: &Path, launch: bool) -> Result<bool, EngineError> {
+fn health_check_portable_install(
+    install_root: &Path,
+    launch: bool,
+    keep_running: bool,
+) -> Result<bool, EngineError> {
     let exe = installed_app_exe(install_root).ok_or_else(|| {
         EngineError::Install(format!(
             "portable health check failed: no app entry executable (ChatGPT.exe / Codex.exe) in {}",
@@ -611,10 +621,35 @@ fn health_check_portable_install(install_root: &Path, launch: bool) -> Result<bo
     // process running (this path is the post-install relaunch).
     match spawn_and_require_liveness(hidden_command(&exe), PORTABLE_LIVENESS_WINDOW) {
         Ok(LivenessResult::Survived { child }) => {
-            // Intentionally leak the Child handle so the relaunched app keeps
-            // running after the manager drops the wait loop.
-            std::mem::forget(child);
-            Ok(true)
+            if keep_running {
+                // Intentionally leak the Child handle so the relaunched app
+                // keeps running after the manager drops the wait loop.
+                std::mem::forget(child);
+                Ok(true)
+            } else {
+                // The launch was only a health check. Close the whole Electron
+                // process tree so an update cannot open an app that was closed
+                // beforehand.
+                let deadline = Instant::now() + Duration::from_secs(30);
+                loop {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(EngineError::Install(format!(
+                            "portable health check cleanup failed: Codex is still running from {}",
+                            install_root.display()
+                        )));
+                    }
+                    // A closing Electron parent may replace itself with another
+                    // process. Use bounded close slices and rescan the exact root
+                    // between them instead of trusting one PID snapshot.
+                    close_codex_gracefully_for_root(remaining.as_secs().clamp(1, 5), install_root)?;
+                    if !codex_running_for_root(install_root)? {
+                        break;
+                    }
+                }
+                drop(child);
+                Ok(false)
+            }
         }
         Ok(LivenessResult::ExitedEarly { code }) => Err(EngineError::Install(format!(
             "portable health check failed: entry executable exited immediately after launch (exit={})",
@@ -854,7 +889,11 @@ pub fn install_portable_from_msix_with_observer(
         ));
     }
 
-    let relaunched = match health_check_portable_install(install_root, manage_process && relaunch) {
+    let relaunched = match health_check_portable_install(
+        install_root,
+        manage_process,
+        manage_process && relaunch,
+    ) {
         Ok(relaunched) => relaunched,
         Err(err) => {
             let _ = fs::remove_dir_all(&work_dir);
@@ -1398,7 +1437,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = health_check_portable_install(&root, true).unwrap_err();
+        let err = health_check_portable_install(&root, true, true).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("exited immediately"),

--- a/crates/codex-win-engine/src/sys.rs
+++ b/crates/codex-win-engine/src/sys.rs
@@ -111,7 +111,7 @@ pub struct MsixHealthReport {
     /// Machine-stable failure class for UI / fallback routing. Empty when healthy.
     /// Values: `not-registered` | `status-bad` | `aumid-unresolved` |
     /// `missing-dependencies` | `activation-failed` | `immediate-exit` |
-    /// `timeout` | `probe-failed` | `policy`.
+    /// `timeout` | `probe-failed` | `policy` | `cleanup-failed`.
     #[serde(default)]
     pub failure_kind: String,
     /// Human-facing reason when unhealthy; empty when healthy.
@@ -129,6 +129,7 @@ pub mod msix_failure {
     pub const TIMEOUT: &str = "timeout";
     pub const PROBE_FAILED: &str = "probe-failed";
     pub const POLICY: &str = "policy";
+    pub const CLEANUP_FAILED: &str = "cleanup-failed";
 }
 
 /// Result of the framework-dependency PRE-check run BEFORE attempting an MSIX
@@ -793,8 +794,12 @@ fn best_effort_close_msix_after_probe() {
     }
 }
 
-#[cfg(windows)]
 pub fn verify_msix_health() -> MsixHealthReport {
+    verify_msix_health_with_options(false)
+}
+
+#[cfg(windows)]
+pub fn verify_msix_health_with_options(keep_running: bool) -> MsixHealthReport {
     log::info!("MSIX health check start");
     // Activation is the expensive step — budget deps probe + cold-start window +
     // continuous liveness + cleanup + slack.
@@ -833,6 +838,7 @@ $appId = ''
 $installLoc = ''
 $targetIds = @()
 $activationAttempted = $false
+$keepRunning = {keep_running}
 function Convert-ToVersion($value) {{
   try {{
     $text = [string]$value
@@ -890,12 +896,23 @@ function Get-PackageProcesses([string]$root) {{
   return $found
 }}
 function Stop-PackageProcesses([string]$root, $ids) {{
-  foreach ($id in @($ids)) {{
-    try {{ Stop-Process -Id $id -Force -ErrorAction SilentlyContinue }} catch {{}}
-  }}
-  foreach ($p in @(Get-PackageProcesses $root)) {{
-    try {{ Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }} catch {{}}
-  }}
+  $pendingIds = @($ids)
+  $deadline = (Get-Date).AddSeconds(5)
+  do {{
+    foreach ($id in $pendingIds) {{
+      try {{ Stop-Process -Id $id -Force -ErrorAction SilentlyContinue }} catch {{}}
+    }}
+    foreach ($p in @(Get-PackageProcesses $root)) {{
+      try {{ Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }} catch {{}}
+    }}
+    Start-Sleep -Milliseconds 200
+    $remaining = @(Get-PackageProcesses $root)
+    if ($remaining.Count -eq 0) {{ return $true }}
+    # Electron may replace a process while shutting down. Follow the replacement
+    # PIDs and retry until the bounded cleanup deadline.
+    $pendingIds = @($remaining | ForEach-Object {{ $_.Id }} | Select-Object -Unique)
+  }} while ((Get-Date) -lt $deadline)
+  return (@(Get-PackageProcesses $root).Count -eq 0)
 }}
 try {{
   $manifest = Get-AppxPackageManifest $pkg -ErrorAction Stop
@@ -984,6 +1001,17 @@ if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
     }}
     if ($stillAlive) {{
       $activationOk = $true
+      if (-not $keepRunning) {{
+        if (Stop-PackageProcesses $installLoc $targetIds) {{
+          $targetIds = @()
+        }} else {{
+          # A health check is not successful if it changes a previously-closed
+          # app into a running one. Fail closed so the caller can report/fallback.
+          $activationOk = $false
+          $failureKind = 'cleanup-failed'
+          $activationDetail = 'package process remained running after health-check cleanup'
+        }}
+      }}
     }} elseif ($sawProcess) {{
       $failureKind = 'immediate-exit'
       $activationDetail = 'package process started then exited during the liveness window'
@@ -1003,7 +1031,7 @@ if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
   # Unhealthy activation must not leave Codex holding package files open for
   # the subsequent portable fallback / Remove-AppxPackage.
   if (-not $activationOk -and $activationAttempted) {{
-    Stop-PackageProcesses $installLoc $targetIds
+    $null = Stop-PackageProcesses $installLoc $targetIds
   }}
 }}
 
@@ -1020,7 +1048,8 @@ if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
 "#,
         name = ps_quote(crate::OPENAI_PACKAGE_IDENTITY),
         activation_window = MSIX_ACTIVATION_WINDOW_SECS,
-        liveness_window = MSIX_LIVENESS_WINDOW_SECS
+        liveness_window = MSIX_LIVENESS_WINDOW_SECS,
+        keep_running = if keep_running { "$true" } else { "$false" }
     );
 
     let run_result = run_powershell_json_with_limits(&script, limits);
@@ -1174,7 +1203,7 @@ if ($statusOk -and $aumidResolved -and $missing.Count -eq 0) {{
 }
 
 #[cfg(not(windows))]
-pub fn verify_msix_health() -> MsixHealthReport {
+pub fn verify_msix_health_with_options(_keep_running: bool) -> MsixHealthReport {
     // Non-Windows builds never sideload, so there is nothing to verify; report
     // healthy so this can never be the thing that blocks a (non-existent) path,
     // but leave verified = false since no real check was performed.
@@ -1781,6 +1810,7 @@ function Get-AppxPackage {
         assert_eq!(super::msix_failure::IMMEDIATE_EXIT, "immediate-exit");
         assert_eq!(super::msix_failure::TIMEOUT, "timeout");
         assert_eq!(super::msix_failure::POLICY, "policy");
+        assert_eq!(super::msix_failure::CLEANUP_FAILED, "cleanup-failed");
     }
 
     #[test]

--- a/crates/codex-win-engine/src/windows_process.rs
+++ b/crates/codex-win-engine/src/windows_process.rs
@@ -218,6 +218,12 @@ mod imp {
         Ok(targets)
     }
 
+    pub(crate) fn codex_processes_running_for_root(root: &Path) -> Result<bool, EngineError> {
+        Ok(target_processes_under_root(root)?
+            .iter()
+            .any(TargetProcess::is_running))
+    }
+
     unsafe extern "system" fn post_close_to_pid(hwnd: HWND, target_pid: LPARAM) -> i32 {
         let mut window_pid = 0u32;
         // SAFETY: EnumWindows supplied a live top-level HWND; `window_pid` is a
@@ -356,6 +362,7 @@ mod imp {
                 }
                 thread::sleep(Duration::from_millis(50));
             }
+            assert!(codex_processes_running_for_root(&root).unwrap());
 
             let result = close_codex_processes_for_root(0, &root);
             if result.is_err() {
@@ -363,13 +370,14 @@ mod imp {
             }
             result.unwrap();
             assert!(child.wait().unwrap().code().is_some());
+            assert!(!codex_processes_running_for_root(&root).unwrap());
             let _ = std::fs::remove_dir_all(root);
         }
     }
 }
 
 #[cfg(windows)]
-pub(crate) use imp::close_codex_processes_for_root;
+pub(crate) use imp::{close_codex_processes_for_root, codex_processes_running_for_root};
 
 #[cfg(not(windows))]
 pub(crate) fn close_codex_processes_for_root(
@@ -377,6 +385,11 @@ pub(crate) fn close_codex_processes_for_root(
     _root: &Path,
 ) -> Result<(), EngineError> {
     Ok(())
+}
+
+#[cfg(not(windows))]
+pub(crate) fn codex_processes_running_for_root(_root: &Path) -> Result<bool, EngineError> {
+    Ok(false)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -1379,6 +1379,7 @@ pub fn perform_windows_update_with_install_mode_network_and_phase(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn install_portable_after_stage(
     settings: &AppSettings,
     stage: WinStageReport,

--- a/src-tauri/src/app/win_update.rs
+++ b/src-tauri/src/app/win_update.rs
@@ -13,12 +13,13 @@ use serde::{Deserialize, Serialize};
 
 use codex_win_engine::{
     cancel_active_download, cleanup_portable_metadata, close_codex_gracefully_for_root,
-    close_msix_codex_processes, detect_installed_codex, detect_portable_install,
+    close_msix_codex_processes, codex_running_for_root, detect_installed_codex,
+    detect_portable_install,
     download_to_with_progress_bounded_with_network, fetch_text_with_network, find_msix_sha256,
     install_msix_sideload, install_portable_from_msix_with_observer, limits::MAX_PACKAGE_BYTES,
     parse_manifest, pause_active_download, plan_update, precheck_msix_dependencies,
     probe_capabilities, purge_codex_user_data, read_msix_identity, remove_msix_package,
-    sha256_file, uninstall_portable, validate_codex_identity, verify_msix_health,
+    sha256_file, uninstall_portable, validate_codex_identity, verify_msix_health_with_options,
     verify_openai_authenticode, version_key, AuthenticodeReport, CapabilityState,
     InstalledWindowsCodex, MsixHealthReport, MsixIdentity, MsixRemoveReport, MsixSideloadReport,
     NetworkConfig, PortableBoundary, PortableInstallReport, PortableUninstallReport,
@@ -447,6 +448,30 @@ fn close_existing_codex_before_portable_fallback(
         }
     }
     Ok(())
+}
+
+fn existing_codex_was_running(
+    settings: &AppSettings,
+    previous_installed: Option<&InstalledWindowsCodex>,
+) -> Result<bool, AppError> {
+    let mut roots = Vec::new();
+    if let Some(installed) = detect_installed_codex(PathBuf::from(&settings.install_root).as_path())
+    {
+        roots.push(PathBuf::from(installed.path));
+    }
+    if let Some(previous) = previous_installed {
+        let root = PathBuf::from(&previous.path);
+        if !roots.contains(&root) {
+            roots.push(root);
+        }
+    }
+
+    for root in roots {
+        if codex_running_for_root(&root).map_err(engine_err)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Detect the installed Codex, preferring a manager-managed PORTABLE build over
@@ -1112,6 +1137,11 @@ pub fn perform_windows_update_with_install_mode_network_and_phase(
         });
     }
 
+    // Capture the user's app state before any update path closes or probes
+    // Codex. Both MSIX and portable installs perform a real launch health check;
+    // this decides whether that checked process remains open afterward.
+    let was_running = existing_codex_was_running(settings, current_installed.as_ref())?;
+
     // Point of no return. Honor a cancel one last time BEFORE closing Codex or
     // sideloading — closes the gap after staging where a fully-cached MSIX skips
     // the download loop (so its cancel flag never arms) yet still reaches here.
@@ -1129,6 +1159,7 @@ pub fn perform_windows_update_with_install_mode_network_and_phase(
             stage,
             None,
             None,
+            was_running,
             current_installed,
             phase,
             evidence,
@@ -1166,6 +1197,7 @@ pub fn perform_windows_update_with_install_mode_network_and_phase(
             stage,
             None,
             None,
+            was_running,
             current_installed,
             phase,
             evidence,
@@ -1207,7 +1239,7 @@ pub fn perform_windows_update_with_install_mode_network_and_phase(
         // stripped Windows it can register yet fail to launch. If it's unhealthy,
         // first install the portable fallback so the user is never left without
         // a runnable build, then clean up the bad MSIX best-effort.
-        let health = verify_msix_health();
+        let health = verify_msix_health_with_options(was_running);
         if !health.healthy {
             log::warn!("Windows route changed to portable fallback from_route=msix-sideload to_route=portable-fallback");
             // Activation probe may have started Codex (or left a half-started
@@ -1233,6 +1265,7 @@ pub fn perform_windows_update_with_install_mode_network_and_phase(
                 stage,
                 Some(sideload),
                 Some(health),
+                was_running,
                 current_installed,
                 phase,
                 evidence,
@@ -1339,6 +1372,7 @@ pub fn perform_windows_update_with_install_mode_network_and_phase(
         stage,
         Some(sideload),
         None,
+        was_running,
         current_installed,
         phase,
         evidence,
@@ -1350,6 +1384,7 @@ fn install_portable_after_stage(
     stage: WinStageReport,
     sideload: Option<MsixSideloadReport>,
     health: Option<MsixHealthReport>,
+    relaunch: bool,
     previous_installed: Option<InstalledWindowsCodex>,
     phase: Option<&PhaseHook<'_>>,
     evidence: Option<&EvidenceHook<'_>>,
@@ -1436,7 +1471,7 @@ fn install_portable_after_stage(
         msix_path.as_path(),
         install_root_path.as_path(),
         true,
-        true,
+        relaunch,
         &mut observer,
     )
     .map_err(|err| {


### PR DESCRIPTION
## Summary

- preserve whether Codex was running before a Windows update
- keep Codex running after a validated MSIX or portable update only when it was running beforehand
- still perform real launch/liveness health checks when Codex was closed, then verify the probe processes have exited
- detect processes by exact install root and fail closed when cleanup cannot restore the prior state

## Root cause

The Windows update paths always left their post-install launch probe running. Portable fallback also hard-coded relaunching, so an update could open Codex even when it had been closed before the update.

## Validation

- `cargo test --manifest-path crates/codex-win-engine/Cargo.toml` — 79 passed
- `cargo test --manifest-path src-tauri/Cargo.toml win_update` — 14 passed
- `cargo check --target x86_64-pc-windows-msvc --manifest-path crates/codex-win-engine/Cargo.toml --tests`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `codex review --uncommitted` — no findings after three review/fix rounds

The required Windows CI will perform the full native Tauri build; the macOS host cannot compile `ring` for MSVC because the Windows C SDK headers are unavailable.

Related to #212
