### PR TITLE
fix(themes): exclude pet renderers from injection

### DIFF
--- a/crates/codex-theme-engine/src/cdp.rs
+++ b/crates/codex-theme-engine/src/cdp.rs
@@ -339,6 +339,28 @@ pub async fn list_app_targets(port: u16) -> Result<Vec<TargetInfo>> {
     Ok(filtered)
 }
 
+/// Codex pet windows are independent transparent renderers that share the
+/// `app://` scheme and Codex-branded titles with the main shell. They must
+/// never receive a UI theme: a body background turns the transparent pet
+/// overlay into an opaque rectangle.
+///
+/// Match the dedicated document path as well as the encoded `initialRoute`
+/// used by the overlay host. Keeping this separate from the title/DOM probe
+/// preserves its title fallback for full-screen routes such as Settings.
+pub fn is_theme_excluded_target(target: &TargetInfo) -> bool {
+    let Ok(url) = url::Url::parse(&target.url) else {
+        return false;
+    };
+    if url.scheme() != "app" {
+        return false;
+    }
+    if url.path().starts_with("/avatar-overlay") {
+        return true;
+    }
+    url.query_pairs()
+        .any(|(key, value)| key == "initialRoute" && value.starts_with("/avatar-overlay"))
+}
+
 /// Whether a CDP HTTP endpoint answers on the port (does NOT prove it is
 /// Codex — pair with a shell probe before injecting).
 pub async fn cdp_http_ready(port: u16) -> bool {
@@ -405,6 +427,9 @@ pub async fn connect_codex_targets(
             Ok(targets) => {
                 let mut connected = Vec::new();
                 for target in targets {
+                    if is_theme_excluded_target(&target) {
+                        continue;
+                    }
                     match CdpSession::connect(target, port).await {
                         Ok(session) => match probe_session(&session).await {
                             Ok(probe) if probe.codex => {
@@ -460,5 +485,34 @@ mod tests {
         assert!(validated_debugger_url(&target("wss://127.0.0.1:9345/x"), 9345).is_err());
         assert!(validated_debugger_url(&target("ws://192.168.1.4:9345/x"), 9345).is_err());
         assert!(validated_debugger_url(&target("http://127.0.0.1:9345/x"), 9345).is_err());
+    }
+
+    #[test]
+    fn pet_overlay_targets_are_excluded_from_theming() {
+        for url in [
+            "app://-/index.html?initialRoute=%2Favatar-overlay",
+            "app://-/avatar-overlay",
+            "app://-/avatar-overlay-composition-surface.html?surfaceId=mascot-badge",
+            "app://-/avatar-overlay-composition-surface.html?surfaceId=activity-slot-0",
+            "app://-/avatar-overlay-composition-surface.html?surfaceId=activity-slot-1",
+        ] {
+            let mut candidate = target("ws://127.0.0.1:9345/devtools/page/1");
+            candidate.url = url.into();
+            assert!(is_theme_excluded_target(&candidate), "expected exclusion: {url}");
+        }
+    }
+
+    #[test]
+    fn regular_codex_targets_remain_theme_eligible() {
+        for url in [
+            "app://-/index.html",
+            "app://-/index.html?initialRoute=%2Fsettings",
+            "app://-/index.html?initialRoute=%2Fquick-chat",
+            "app://-/avatar-settings.html",
+        ] {
+            let mut candidate = target("ws://127.0.0.1:9345/devtools/page/1");
+            candidate.url = url.into();
+            assert!(!is_theme_excluded_target(&candidate), "unexpected exclusion: {url}");
+        }
     }
 }

--- a/crates/codex-theme-engine/src/daemon.rs
+++ b/crates/codex-theme-engine/src/daemon.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use serde::Serialize;
 use tokio::sync::watch;
 
-use crate::cdp::{list_app_targets, probe_session, CdpSession};
+use crate::cdp::{is_theme_excluded_target, list_app_targets, probe_session, CdpSession};
 use crate::payload::{build_payload, BuiltPayload, CURRENT_STAMP_EXPRESSION, REMOVE_EXPRESSION};
 
 const TICK: Duration = Duration::from_millis(900);
@@ -50,6 +50,9 @@ pub async fn run_daemon(
     status_tx: watch::Sender<DaemonStatus>,
 ) {
     let mut sessions: HashMap<String, CdpSession> = HashMap::new();
+    // Keep excluded pet renderers connected after cleaning them once. Closing
+    // them would make the census reconnect and repeat cleanup every 900 ms.
+    let mut excluded_sessions: HashMap<String, CdpSession> = HashMap::new();
     let mut built: Option<BuiltPayload>;
     let mut last_error: Option<String> = None;
 
@@ -91,16 +94,38 @@ pub async fn run_daemon(
                         }
                         keep
                     });
+                    excluded_sessions.retain(|id, session| {
+                        let keep = active.contains(id.as_str()) && !session.closed();
+                        if !keep {
+                            session.close();
+                        }
+                        keep
+                    });
                     for target in targets {
-                        if sessions.contains_key(&target.id) {
+                        if sessions.contains_key(&target.id)
+                            || excluded_sessions.contains_key(&target.id)
+                        {
                             continue;
                         }
                         let id = target.id.clone();
                         match CdpSession::connect(target, port).await {
                             Ok(session) => match probe_session(&session).await {
                                 Ok(probe) if probe.codex => {
-                                    log::info!("theme daemon connected target {id}");
-                                    sessions.insert(id, session);
+                                    if is_theme_excluded_target(&session.target) {
+                                        match session.evaluate(REMOVE_EXPRESSION).await {
+                                            Ok(_) => {
+                                                log::info!("theme daemon excluded pet target {id}");
+                                                excluded_sessions.insert(id, session);
+                                            }
+                                            Err(error) => {
+                                                session.close();
+                                                last_error = Some(error.to_string());
+                                            }
+                                        }
+                                    } else {
+                                        log::info!("theme daemon connected target {id}");
+                                        sessions.insert(id, session);
+                                    }
                                 }
                                 Ok(_) => session.close(),
                                 Err(error) => {
@@ -119,6 +144,10 @@ pub async fn run_daemon(
                         session.close();
                     }
                     sessions.clear();
+                    for session in excluded_sessions.values() {
+                        session.close();
+                    }
+                    excluded_sessions.clear();
                     last_error = Some(error.to_string());
                 }
             }
@@ -171,6 +200,9 @@ pub async fn run_daemon(
                     if changed.is_err() {
                         // Manager shutting down: leave renderers as they are.
                         for session in sessions.values() {
+                            session.close();
+                        }
+                        for session in excluded_sessions.values() {
                             session.close();
                         }
                         let _ = status_tx.send(DaemonStatus {

--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -107,6 +107,8 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
   document.documentElement?.removeAttribute('data-cts-shell');
   document.getElementById('cts-style')?.remove();
   document.getElementById('cts-chrome')?.remove();
+  document.getElementById('cts-stage')?.remove();
+  document.getElementById('cts-intro')?.remove();
   delete window.__CODEX_THEME_STUDIO__;
   return true;
 })()"#;
@@ -115,6 +117,8 @@ pub const VERIFY_REMOVED_EXPRESSION: &str = r#"(() =>
   !document.documentElement.classList.contains('codex-theme-studio') &&
   !document.getElementById('cts-style') &&
   !document.getElementById('cts-chrome') &&
+  !document.getElementById('cts-stage') &&
+  !document.getElementById('cts-intro') &&
   !window.__CODEX_THEME_STUDIO__
 )()"#;
 
@@ -226,6 +230,17 @@ mod tests {
         let first = fingerprint("runtime-a", "css", "chrome", "config");
         let second = fingerprint("runtime-b", "css", "chrome", "config");
         assert_ne!(first, second, "runtime change must re-stamp");
+    }
+
+    #[test]
+    fn removal_covers_every_runtime_owned_layer() {
+        for id in ["cts-style", "cts-chrome", "cts-stage", "cts-intro"] {
+            assert!(REMOVE_EXPRESSION.contains(id), "remove expression misses {id}");
+            assert!(
+                VERIFY_REMOVED_EXPRESSION.contains(id),
+                "removal verification misses {id}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

Codex pet/avatar windows are separate transparent renderers but share the `app://` scheme and Codex-branded titles with the main shell. The theme probe therefore accepted them and injected full-page skin CSS, turning the transparent pet overlay into an opaque rectangle.

Related to Wangnov/awesome-codex-skins#2.

## What changed

- classify all current `avatar-overlay` host and composition-surface URLs as theme-excluded
- verify the renderer is Codex before cleaning it, then keep the excluded session out of reconciliation
- remove every runtime-owned fallback layer (`cts-style`, `cts-chrome`, `cts-stage`, `cts-intro`)
- add URL classification and cleanup-contract regression tests

## Verification

- live CDP experiment against the open pet: excluded targets returned to transparent `html/body`; the native activity pill remained rendered
- `cargo test --manifest-path crates/codex-theme-engine/Cargo.toml --all-targets`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace`
- `npm run check && npm run lint && npm test && npm run build`
- `codex review --uncommitted`: no findings after addressing the identity-probe P2
