### PR TITLE
chore(release): bump version to 0.4.1

### DIFF
--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -118,6 +118,52 @@
   const EXTENDED_ICONS = new Set(["settings", "folder"]);
   const PROJECT_ROW_SELECTOR = "[data-project-row], [data-app-action-sidebar-project-row]";
 
+  // ── Workspace wordmark → logo variant ─────────────────────────────────────
+  // Structural class names (app-shell-left-panel, main-surface, …) have held
+  // stable across releases, so the CSS layer is version-robust. What drifts is
+  // the workspace *wordmark* — the 2026-07 ChatGPT rebrand renamed it from
+  // "ChatGPT 工作" / "ChatGPT Work" (Codex ≤ 26.707) to a bare "ChatGPT"
+  // (26.715+). The styled logo art is baked with the words it shows, so the
+  // OLD art must keep serving old clients while regenerated art serves new
+  // ones. The choice is driven by the Codex *version*, not the wordmark text:
+  // the text is localized (工作/Work/…) but the version is not, so version is
+  // the robust, locale-independent signal for which art matches the shell.
+  // Text below only *locates* the workspace button and splits personal(Codex)
+  // vs work(ChatGPT) — it never selects the old/new art. Adapting to a future
+  // wordmark change = one more boundary here plus its regenerated art, never a
+  // per-user migration; the CSS falls `chatgpt` back to `chatgpt-work` art so
+  // a theme that hasn't shipped the new art yet degrades instead of blanking.
+  const codexVersion = () => {
+    try {
+      const v = window.electronBridge?.getSentryInitOptions?.()?.appVersion;
+      return typeof v === "string" && /^\d+\./.test(v) ? v : null;
+    } catch {
+      return null;
+    }
+  };
+  const versionAtLeast = (version, floor) => {
+    const a = String(version).split(".");
+    const b = floor.split(".");
+    for (let i = 0; i < b.length; i += 1) {
+      const d = (parseInt(a[i], 10) || 0) - (parseInt(b[i], 10) || 0);
+      if (d !== 0) return d > 0;
+    }
+    return true;
+  };
+  // The work-wordmark art for THIS Codex. Undetected version → current-
+  // generation art (`chatgpt`), which the CSS degrades to `chatgpt-work` when
+  // a theme hasn't shipped the regenerated asset.
+  const WORK_LOGO = (() => {
+    const version = codexVersion();
+    return version && !versionAtLeast(version, "26.715") ? "chatgpt-work" : "chatgpt";
+  })();
+  const workspaceLogo = (text) => {
+    if (/^Codex$/i.test(text)) return "codex";
+    if (/^ChatGPT( ?(工作|Work))?$/i.test(text)) return WORK_LOGO;
+    return null;
+  };
+  const isWorkspaceTitle = (text) => workspaceLogo(text) !== null;
+
   // settings/folder annotation was added after the original 14-glyph runtime.
   // Gate those two on an explicit theme rule so older themes that hide native
   // paths without mapping the new glyphs never render blank controls.
@@ -206,8 +252,7 @@
     if (aside) {
       for (const button of aside.querySelectorAll("button:not([data-cts-icon])")) {
         const text = (button.textContent || "").replace(/\s+/g, " ").trim();
-        const isWorkspace = text === "Codex" || /^ChatGPT ?(工作|Work)$/i.test(text);
-        if (isWorkspace) {
+        if (isWorkspaceTitle(text)) {
           clearGlyph(button);
           continue;
         }
@@ -233,24 +278,23 @@
         'button, a, [role="button"], [data-project-row], [data-app-action-sidebar-project-row]'
       )) {
         const controlText = (control.textContent || "").replace(/\s+/g, " ").trim();
-        if (controlText === "Codex" || /^ChatGPT ?(工作|Work)$/i.test(controlText)) continue;
+        if (isWorkspaceTitle(controlText)) continue;
         const row = control.closest(PROJECT_ROW_SELECTOR);
         if (row && row !== control) continue;
         if (isProjectControl(control)) tagGlyph(control, "folder");
       }
-      // Workspace title → theme-specific logo. The title text is split across
-      // child spans ("ChatGPT" + "工作"), so match on the whole button and
-      // re-evaluate every pass (the same button swaps text on switch).
+      // Workspace title → theme-specific logo. Text can be split across child
+      // spans and swaps on workspace switch, so match the whole button every
+      // pass. The active UI profile owns the text→variant mapping, absorbing
+      // wordmark drift (e.g. the 26.715 "ChatGPT 工作"→"ChatGPT" rebrand).
       for (const button of aside.querySelectorAll("button")) {
         const text = button.textContent.replace(/\s+/g, " ").trim();
-        const isCodex = text === "Codex";
-        const isWork = /^ChatGPT ?(工作|Work)$/i.test(text);
-        if (!isCodex && !isWork) {
+        const want = workspaceLogo(text);
+        if (!want) {
           if (button.dataset.ctsLogo) delete button.dataset.ctsLogo;
           continue;
         }
         clearGlyph(button);
-        const want = isCodex ? "codex" : "chatgpt-work";
         if (button.dataset.ctsLogo !== want) button.dataset.ctsLogo = want;
       }
     }

--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,44 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 跟上 Codex 26.715 的 ChatGPT 改名：皮肤的风格化标志按 Codex 版本自动匹配，新版显示重制的单行「ChatGPT」标志，旧版仍显示原「ChatGPT WORK」标志。
+> Keeping up with Codex 26.715's ChatGPT rebrand: a skin's styled wordmark now matches the running Codex version — newer builds show a regenerated single-line "ChatGPT" logo, older ones still show the original "ChatGPT WORK" logo.
+
+## 🐛 修复 · Fixes
+
+- **适配 Codex 26.715 的工作区标志改名**:Codex 26.715 起把工作区标志从「ChatGPT 工作 / ChatGPT Work」精简为「ChatGPT」,皮肤原本按双行「ChatGPT WORK」绘制的风格化标志因此对不上、无法显示。管理器现在在渲染进程内识别 Codex 版本,按版本挑选对应素材——26.715+ 显示重新生成的单行「ChatGPT」标志,≤26.707 仍显示原「ChatGPT WORK」标志,**同一套皮肤对新旧 Codex 都正确**。
+  Adapt to Codex 26.715's workspace-wordmark rename: from 26.715 the workspace title shrank from "ChatGPT 工作 / ChatGPT Work" to a bare "ChatGPT", so a skin's styled logo — drawn for the two-line "ChatGPT WORK" — no longer matched and stopped showing. The manager now detects the Codex version in the renderer and serves the version-appropriate art: 26.715+ shows a regenerated single-line "ChatGPT" logo, ≤26.707 still shows the original "ChatGPT WORK" logo, so **one skin package renders correctly on both old and new Codex**.
+
+- **在线商店 26 款皮肤同步重制标志**:商店全部认证皮肤已更新到 v1.2.0,每套都随包附带重新生成的单行「ChatGPT」标志,并保留原标志向后兼容——在皮肤页更新即可。
+  Store skins refreshed with the new logos: all 26 certified store skins are bumped to v1.2.0, each shipping the regenerated single-line "ChatGPT" logo alongside the original for backward compatibility — just update from the Skins board.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "codex-mac-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.4.0"
+version = "0.4.1"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Adapts skin logos to Codex 26.715's ChatGPT rebrand and ships the 0.4.1 release.

## What changed
- **Runtime: version-aware workspace logo.** Codex 26.715 renamed the workspace wordmark from "ChatGPT 工作"/"ChatGPT Work" to a bare "ChatGPT", so a skin's styled two-line "ChatGPT WORK" art no longer matched and stopped showing. The injected runtime now detects the running Codex version in the renderer (`electronBridge` sentry `appVersion`) and picks the logo variant **by version, not text**: `<26.715` → `chatgpt-work` (original art), `>=26.715` → `chatgpt` (regenerated single-line art). Text still only *locates* the workspace button and splits personal(Codex)/work(ChatGPT). CSS falls `chatgpt` back to `chatgpt-work` so a theme without the new asset degrades instead of blanking.
- **Store skins**: all 26 certified skins regenerated their single-line "ChatGPT" logo and shipped both assets — [awesome-codex-skins](https://github.com/Wangnov/awesome-codex-skins) **v1.2.0**, live on the catalog.
- Version bump 0.4.0 → 0.4.1 + release note `docs/releases/v0.4.1.md`.

## Verified
- End-to-end on live Codex 26.715: sole-injector run stamps `chatgpt` and the regenerated logo renders + persists in the real sidebar.
- Version-driven matcher proven live (`workspaceLogo("ChatGPT")` → `chatgpt` at 26.715; old art path preserved for ≤26.707).
- `cargo clippy --workspace --all-targets -D warnings` clean; engine tests 36 pass; frontend 283 tests pass.
- All 26 skins pass the delivery pack gate; catalog republished at v1.2.0.