### PR TITLE
docs(release): backfill v0.4.1 notes with pet / curl / run-state fixes

### DIFF
--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -15,6 +15,15 @@
 - **在线商店 26 款皮肤同步重制标志**:商店全部认证皮肤已更新到 v1.2.0,每套都随包附带重新生成的单行「ChatGPT」标志,并保留原标志向后兼容——在皮肤页更新即可。
   Store skins refreshed with the new logos: all 26 certified store skins are bumped to v1.2.0, each shipping the regenerated single-line "ChatGPT" logo alongside the original for backward compatibility — just update from the Skins board.
 
+- **修复皮肤把桌面宠物染成不透明方块**:Codex 的桌面宠物是独立的透明浮层窗口,却和主界面共用 `app://` 地址与 Codex 标题,此前换肤会把它当成普通界面一起注入——给浮层加上背景色后,原本透明的宠物就变成一块不透明的实心矩形。管理器现在会识别并跳过宠物浮层渲染器,宠物保持透明,皮肤只作用于主界面。
+  Skins no longer paint the desktop pet into an opaque block: Codex's desktop pet is a standalone transparent overlay window that happens to share the `app://` scheme and Codex title with the main shell, so theming used to inject into it too — and a background color turned the transparent overlay into a solid rectangle. The manager now detects and skips pet overlay renderers, keeping the pet transparent while the skin applies only to the main UI.
+
+- **消除换肤时闪出的 curl 控制台黑窗(Windows)**:管理器是 GUI 程序,但拉取皮肤目录和预览要调用系统 curl,此前在 Windows 上每次请求都会弹出一个可见的 curl.exe 控制台黑窗。这些调用现在带上 `CREATE_NO_WINDOW` 标志静默执行,浏览皮肤商店不再闪黑框。
+  No more curl console flashes while theming (Windows): the manager is a GUI app but shells out to system curl to fetch the skin catalog and previews, and on Windows every request used to pop a visible curl.exe console window. Those calls now carry the `CREATE_NO_WINDOW` flag and run silently, so browsing the Skins board no longer flashes black boxes.
+
+- **更新后不再擅自拉起已关闭的 Codex(Windows)**:Windows 更新流程会启动一次 Codex 做安装健康检查,此前无论更新前 Codex 是否在运行,这个检查进程都会被保留下来,于是更新前明明关着的 Codex 会在更新后被强行打开。管理器现在会先探测 Codex 的运行状态:原本开着的更新后继续保持打开,原本关着的在健康检查后连整个 Electron 进程树一并关闭。
+  Updates no longer force-open a Codex you had closed (Windows): the Windows update flow launches Codex once as an install health check, and it used to keep that process alive no matter whether Codex was running beforehand — so a Codex you had closed would reappear after updating. The manager now probes Codex's run state first: one that was open stays open, and one that was closed has its whole Electron process tree shut down after the health check.
+
 ## 📦 安装与升级 · Install & Upgrade
 
 **已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。


### PR DESCRIPTION
Backfill the v0.4.1 release notes with three user-facing fixes that shipped in the tag but were left out of the notes.

docs/releases/v0.4.1.md only documented the ChatGPT-logo rebrand (#216). These three also landed in v0.4.0..v0.4.1 and are all user-perceptible:

- #215 — skins no longer paint the transparent desktop pet into an opaque block
- #213 — no curl console-window flashes while theming on Windows
- #214 — updates no longer force-open a Codex you had closed (Windows)

Notes-only change. The GitHub Release body for v0.4.1 has already been updated to match.