### PR TITLE
fix(themes): refuse symlink store packages on delete + restore focus

### DIFF
--- a/src-tauri/src/app/codex_theme.rs
+++ b/src-tauri/src/app/codex_theme.rs
@@ -321,6 +321,16 @@ pub fn delete_store_skin(settings: &AppSettings, skin_id: &str) -> Result<(), Ap
     if dir.parent() != Some(store.as_path()) {
         return Err(AppError::Engine("路径越界，拒绝删除".to_string()));
     }
+    // Refuse a symlink outright: the is_dir / theme.json checks below both
+    // follow links, so a link planted in the store could smuggle the delete to
+    // its target. Store packages are always real directories placed by
+    // move_dir — a link here is never legitimate. (symlink_metadata does not
+    // follow; a missing path falls through to the "not found" check below.)
+    if let Ok(meta) = std::fs::symlink_metadata(&dir) {
+        if meta.file_type().is_symlink() {
+            return Err(AppError::Engine(format!("{skin_id} 是符号链接，拒绝删除")));
+        }
+    }
     if !dir.is_dir() {
         return Err(AppError::Engine(format!("商店中没有该皮肤: {skin_id}")));
     }
@@ -1375,5 +1385,77 @@ pub async fn launch_with_active_theme(
             log::warn!("themed launch failed, falling back to plain launch: {error}");
             Ok(false)
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod delete_store_skin_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn test_dir(name: &str) -> PathBuf {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test-data")
+            .join(format!("{name}-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn settings_with_store(store: &Path) -> AppSettings {
+        AppSettings {
+            codex_theme_store_dir: Some(store.to_string_lossy().into_owned()),
+            ..AppSettings::default()
+        }
+    }
+
+    #[test]
+    fn removes_a_real_package() {
+        let base = test_dir("delete-real");
+        let store = base.join("store");
+        let pkg = store.join("good");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("theme.json"), b"{}").unwrap();
+
+        delete_store_skin(&settings_with_store(&store), "good").unwrap();
+        assert!(!pkg.exists(), "the real package should be deleted");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn refuses_a_symlink_and_spares_its_target() {
+        let base = test_dir("delete-symlink");
+        let store = base.join("store");
+        std::fs::create_dir_all(&store).unwrap();
+
+        // A real package the link resolves to; its manifest would let the
+        // follow-through is_dir()/theme.json checks pass without the guard.
+        let target = base.join("outside");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("theme.json"), b"{}").unwrap();
+
+        let link = store.join("linky");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = delete_store_skin(&settings_with_store(&store), "linky").unwrap_err();
+        assert!(matches!(err, AppError::Engine(_)), "a symlink must be refused");
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the symlink itself must be left in place",
+        );
+        assert!(
+            target.join("theme.json").is_file(),
+            "the link target must survive untouched",
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src/app/views/CodexThemes.tsx
+++ b/src/app/views/CodexThemes.tsx
@@ -305,6 +305,8 @@ export function CodexThemes({ onBack }: { onBack: () => void }) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [detail, setDetail] = useState<Item | null>(null);
   const [confirmIds, setConfirmIds] = useState<string[] | null>(null);
+  const [refocusTick, setRefocusTick] = useState(0);
+  const selectBtnRef = useRef<HTMLButtonElement>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -467,7 +469,20 @@ export function CodexThemes({ onBack }: { onBack: () => void }) {
       setSelected(new Set());
       setSelecting(false);
       setDetail(null);
+      // The confirm dialog is about to unmount; its focus trap would restore
+      // focus to a now-removed control (dropping to <body>). Steer focus to a
+      // stable toolbar control instead — see the effect below.
+      setRefocusTick((t) => t + 1);
     });
+
+  // Land focus on the stable "manage selection" toolbar button after a delete,
+  // so keyboard users aren't stranded on <body> once the dialog and the deleted
+  // card are gone. Guarded to skip the initial mount (tick 0).
+  useEffect(() => {
+    if (refocusTick > 0) {
+      selectBtnRef.current?.focus();
+    }
+  }, [refocusTick]);
 
   const tryOn = (it: Item) =>
     run(status?.cdpReady ? `tryon:${it.id}` : `tryon-restart:${it.id}`, () =>
@@ -847,6 +862,7 @@ export function CodexThemes({ onBack }: { onBack: () => void }) {
           </div>
           {tab === "local" ? (
             <button
+              ref={selectBtnRef}
               className={`btn ghost sm${selecting ? " active" : ""}`}
               onClick={() => (selecting ? exitSelect() : setSelecting(true))}
             >


### PR DESCRIPTION
Fast-follow to #218 (skin management).

## What & why

Re-auditing the **merged** code (not the mid-iteration review notes) showed the shipped delete path is already the conservative one — `delete_store_skin` removes only the store copy behind a lexical-containment + `theme.json` manifest check, `off_full` is `installed_codex_path()?` fail-closed, and the delete UI has no partial-failure backfill to mis-clear. So the earlier review's exotic findings mostly don't apply to what actually landed. Two genuine, small hardening items remain:

### 1. Refuse symlinks on store delete (defense in depth)

`delete_store_skin`'s `is_dir()` / `theme.json` checks both follow symlinks, so a link planted in the store could point the delete at its target. A `symlink_metadata` check now rejects any symlink before those follow-through checks run. Rust 1.77+'s `remove_dir_all` already refuses a top-level symlink, so this is belt-and-suspenders — plus a clearer error and cross-platform-consistent semantics. Adds the first unit tests for this function (unix-gated): a real-package delete succeeds; a symlink is refused and its target survives untouched.

### 2. Restore focus after delete

After a delete, the confirm dialog unmounts and its focus trap restored focus to a now-removed control, dropping to `<body>`. Focus now lands on the stable "manage selection" toolbar button via a refocus tick + effect.

## Verification

- Frontend: `tsc` 0, `eslint --max-warnings=0` 0, `vitest` 283/283
- Backend: `clippy --all-targets -D warnings` 0, `cargo test` 127/127 (+2 new)
- The focus fix's real trigger (the card is removed on refresh) needs a real Tauri build; the browser mock's `codexThemeDelete` doesn't remove the card, so that path isn't reproduced there.
