### PR TITLE
fix(themes): cover Windows application menu

### DIFF
--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -107,6 +107,9 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
   document.documentElement?.removeAttribute('data-cts-shell');
   document.querySelectorAll('.cts-windows-menu-bar').forEach((node) => node.classList.remove('cts-windows-menu-bar'));
   document.querySelectorAll('[data-cts-menu-region]').forEach((node) => node.removeAttribute('data-cts-menu-region'));
+  document.documentElement?.style.removeProperty('--cts-windows-menu-height');
+  document.documentElement?.style.removeProperty('--cts-windows-sidebar-foreground');
+  document.documentElement?.style.removeProperty('--cts-windows-main-foreground');
   document.getElementById('cts-style')?.remove();
   document.getElementById('cts-chrome')?.remove();
   document.getElementById('cts-stage')?.remove();
@@ -119,6 +122,9 @@ pub const VERIFY_REMOVED_EXPRESSION: &str = r#"(() =>
   !document.documentElement.classList.contains('codex-theme-studio') &&
   !document.querySelector('.cts-windows-menu-bar') &&
   !document.querySelector('[data-cts-menu-region]') &&
+  !document.documentElement.style.getPropertyValue('--cts-windows-menu-height') &&
+  !document.documentElement.style.getPropertyValue('--cts-windows-sidebar-foreground') &&
+  !document.documentElement.style.getPropertyValue('--cts-windows-main-foreground') &&
   !document.getElementById('cts-style') &&
   !document.getElementById('cts-chrome') &&
   !document.getElementById('cts-stage') &&
@@ -245,7 +251,13 @@ mod tests {
                 "removal verification misses {id}"
             );
         }
-        for marker in ["cts-windows-menu-bar", "data-cts-menu-region"] {
+        for marker in [
+            "cts-windows-menu-bar",
+            "data-cts-menu-region",
+            "--cts-windows-menu-height",
+            "--cts-windows-sidebar-foreground",
+            "--cts-windows-main-foreground",
+        ] {
             assert!(
                 REMOVE_EXPRESSION.contains(marker),
                 "remove expression misses {marker}"

--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -108,6 +108,8 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
   document.querySelectorAll('.cts-windows-menu-bar').forEach((node) => node.classList.remove('cts-windows-menu-bar'));
   document.querySelectorAll('[data-cts-menu-region]').forEach((node) => node.removeAttribute('data-cts-menu-region'));
   document.documentElement?.style.removeProperty('--cts-windows-menu-height');
+  document.documentElement?.style.removeProperty('--cts-windows-sidebar-padding-top');
+  document.documentElement?.style.removeProperty('--cts-windows-main-padding-top');
   document.documentElement?.style.removeProperty('--cts-windows-sidebar-foreground');
   document.documentElement?.style.removeProperty('--cts-windows-main-foreground');
   document.getElementById('cts-style')?.remove();
@@ -123,6 +125,8 @@ pub const VERIFY_REMOVED_EXPRESSION: &str = r#"(() =>
   !document.querySelector('.cts-windows-menu-bar') &&
   !document.querySelector('[data-cts-menu-region]') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-menu-height') &&
+  !document.documentElement.style.getPropertyValue('--cts-windows-sidebar-padding-top') &&
+  !document.documentElement.style.getPropertyValue('--cts-windows-main-padding-top') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-sidebar-foreground') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-main-foreground') &&
   !document.getElementById('cts-style') &&
@@ -255,6 +259,8 @@ mod tests {
             "cts-windows-menu-bar",
             "data-cts-menu-region",
             "--cts-windows-menu-height",
+            "--cts-windows-sidebar-padding-top",
+            "--cts-windows-main-padding-top",
             "--cts-windows-sidebar-foreground",
             "--cts-windows-main-foreground",
         ] {

--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -105,6 +105,8 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
   document.documentElement?.classList.remove('codex-theme-studio');
   document.documentElement?.removeAttribute('data-cts-theme');
   document.documentElement?.removeAttribute('data-cts-shell');
+  document.querySelectorAll('.cts-windows-menu-bar').forEach((node) => node.classList.remove('cts-windows-menu-bar'));
+  document.querySelectorAll('[data-cts-menu-region]').forEach((node) => node.removeAttribute('data-cts-menu-region'));
   document.getElementById('cts-style')?.remove();
   document.getElementById('cts-chrome')?.remove();
   document.getElementById('cts-stage')?.remove();
@@ -115,6 +117,8 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
 
 pub const VERIFY_REMOVED_EXPRESSION: &str = r#"(() =>
   !document.documentElement.classList.contains('codex-theme-studio') &&
+  !document.querySelector('.cts-windows-menu-bar') &&
+  !document.querySelector('[data-cts-menu-region]') &&
   !document.getElementById('cts-style') &&
   !document.getElementById('cts-chrome') &&
   !document.getElementById('cts-stage') &&
@@ -239,6 +243,16 @@ mod tests {
             assert!(
                 VERIFY_REMOVED_EXPRESSION.contains(id),
                 "removal verification misses {id}"
+            );
+        }
+        for marker in ["cts-windows-menu-bar", "data-cts-menu-region"] {
+            assert!(
+                REMOVE_EXPRESSION.contains(marker),
+                "remove expression misses {marker}"
+            );
+            assert!(
+                VERIFY_REMOVED_EXPRESSION.contains(marker),
+                "removal verification misses {marker}"
             );
         }
     }

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -23,8 +23,8 @@ html.codex-theme-studio .cts-windows-menu-bar {
   inset: 0 0 auto 0 !important;
   height: var(--cts-windows-menu-height, 36px) !important;
 }
-html.codex-theme-studio .cts-windows-menu-bar + div > aside.app-shell-left-panel,
-html.codex-theme-studio .cts-windows-menu-bar + div > main.main-surface {
+html.codex-theme-studio .cts-windows-menu-bar + * > aside.app-shell-left-panel,
+html.codex-theme-studio .cts-windows-menu-bar + * > main.main-surface {
   padding-top: var(--cts-windows-menu-height, 36px) !important;
 }
 html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="sidebar"] {

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -53,6 +53,12 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
   if (previous?.mediaHandler && previous?.mediaQuery) {
     try { previous.mediaQuery.removeEventListener("change", previous.mediaHandler); } catch {}
   }
+  // Disable the old menu rule before its variables are cleared so the first
+  // pass of a hot-switched theme measures the shell's real base padding.
+  document.querySelectorAll(`.${WINDOWS_MENU_CLASS}`)
+    .forEach((node) => node.classList.remove(WINDOWS_MENU_CLASS));
+  document.querySelectorAll(`[${WINDOWS_MENU_REGION_ATTR}]`)
+    .forEach((node) => node.removeAttribute(WINDOWS_MENU_REGION_ATTR));
   if (previous?.appliedVars) {
     for (const name of previous.appliedVars) document.documentElement?.style.removeProperty(name);
   }

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -350,10 +350,8 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     const shellRow = menu?.nextElementSibling;
     const sidebar = shellRow?.querySelector(":scope > aside.app-shell-left-panel");
     const main = shellRow?.querySelector(":scope > main.main-surface");
-    // Reconcile from the unmodified layout so padding never accumulates and
-    // responsive/theme changes to the surfaces are picked up on every pass.
-    menu?.classList.remove(WINDOWS_MENU_CLASS);
     const menuBox = menu?.getBoundingClientRect();
+    const integrated = Boolean(menu?.classList.contains(WINDOWS_MENU_CLASS));
     const eligible = Boolean(
       menu && sidebar && main && main === shellMain &&
       menuBox && menuBox.width > 0 && menuBox.height > 0
@@ -369,9 +367,12 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
 
     const sidebarStyle = getComputedStyle(sidebar);
     const mainStyle = getComputedStyle(main);
+    const appliedOffset = integrated ? menuBox.height : 0;
+    const basePadding = (style) =>
+      `${Math.max(0, (Number.parseFloat(style.paddingTop) || 0) - appliedOffset)}px`;
     setVar("--cts-windows-menu-height", `${menuBox.height}px`);
-    setVar("--cts-windows-sidebar-padding-top", sidebarStyle.paddingTop);
-    setVar("--cts-windows-main-padding-top", mainStyle.paddingTop);
+    setVar("--cts-windows-sidebar-padding-top", basePadding(sidebarStyle));
+    setVar("--cts-windows-main-padding-top", basePadding(mainStyle));
     setClass(menu, WINDOWS_MENU_CLASS, true);
     setVar("--cts-windows-sidebar-foreground", sidebarStyle.color);
     setVar("--cts-windows-main-foreground", mainStyle.color);

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -348,7 +348,11 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     const shellRow = menu?.nextElementSibling;
     const sidebar = shellRow?.querySelector(":scope > aside.app-shell-left-panel");
     const main = shellRow?.querySelector(":scope > main.main-surface");
-    const eligible = Boolean(menu && sidebar && main && main === shellMain);
+    const menuBox = menu?.getBoundingClientRect();
+    const eligible = Boolean(
+      menu && sidebar && main && main === shellMain &&
+      menuBox && menuBox.width > 0 && menuBox.height > 0
+    );
 
     for (const stale of document.querySelectorAll(`.${WINDOWS_MENU_CLASS}`)) {
       if (!eligible || stale !== menu) stale.classList.remove(WINDOWS_MENU_CLASS);
@@ -358,8 +362,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     }
     if (!eligible) return;
 
-    const menuHeight = menu.getBoundingClientRect().height || 36;
-    setVar("--cts-windows-menu-height", `${menuHeight}px`);
+    setVar("--cts-windows-menu-height", `${menuBox.height}px`);
     setClass(menu, WINDOWS_MENU_CLASS, true);
     setVar("--cts-windows-sidebar-foreground", getComputedStyle(sidebar).color);
     setVar("--cts-windows-main-foreground", getComputedStyle(main).color);

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -23,9 +23,11 @@ html.codex-theme-studio .cts-windows-menu-bar {
   inset: 0 0 auto 0 !important;
   height: var(--cts-windows-menu-height, 36px) !important;
 }
-html.codex-theme-studio .cts-windows-menu-bar + * > aside.app-shell-left-panel,
+html.codex-theme-studio .cts-windows-menu-bar + * > aside.app-shell-left-panel {
+  padding-top: calc(var(--cts-windows-menu-height, 36px) + var(--cts-windows-sidebar-padding-top, 0px)) !important;
+}
 html.codex-theme-studio .cts-windows-menu-bar + * > main.main-surface {
-  padding-top: var(--cts-windows-menu-height, 36px) !important;
+  padding-top: calc(var(--cts-windows-menu-height, 36px) + var(--cts-windows-main-padding-top, 0px)) !important;
 }
 html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="sidebar"] {
   color: var(--cts-windows-sidebar-foreground) !important;
@@ -348,6 +350,9 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     const shellRow = menu?.nextElementSibling;
     const sidebar = shellRow?.querySelector(":scope > aside.app-shell-left-panel");
     const main = shellRow?.querySelector(":scope > main.main-surface");
+    // Reconcile from the unmodified layout so padding never accumulates and
+    // responsive/theme changes to the surfaces are picked up on every pass.
+    menu?.classList.remove(WINDOWS_MENU_CLASS);
     const menuBox = menu?.getBoundingClientRect();
     const eligible = Boolean(
       menu && sidebar && main && main === shellMain &&
@@ -362,10 +367,14 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     }
     if (!eligible) return;
 
+    const sidebarStyle = getComputedStyle(sidebar);
+    const mainStyle = getComputedStyle(main);
     setVar("--cts-windows-menu-height", `${menuBox.height}px`);
+    setVar("--cts-windows-sidebar-padding-top", sidebarStyle.paddingTop);
+    setVar("--cts-windows-main-padding-top", mainStyle.paddingTop);
     setClass(menu, WINDOWS_MENU_CLASS, true);
-    setVar("--cts-windows-sidebar-foreground", getComputedStyle(sidebar).color);
-    setVar("--cts-windows-main-foreground", getComputedStyle(main).color);
+    setVar("--cts-windows-sidebar-foreground", sidebarStyle.color);
+    setVar("--cts-windows-main-foreground", mainStyle.color);
 
     const sidebarRight = sidebar.getBoundingClientRect().right;
     for (const control of menu.querySelectorAll("button, [role=button]")) {

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -15,6 +15,26 @@
   const ROOT_CLASS = "codex-theme-studio";
   const THEME_ATTR = "data-cts-theme";
   const SHELL_ATTR = "data-cts-shell";
+  const WINDOWS_MENU_CLASS = "cts-windows-menu-bar";
+  const WINDOWS_MENU_REGION_ATTR = "data-cts-menu-region";
+  const RUNTIME_CSS = `
+html.codex-theme-studio .cts-windows-menu-bar {
+  position: absolute !important;
+  inset: 0 0 auto 0 !important;
+  height: var(--cts-windows-menu-height, 36px) !important;
+}
+html.codex-theme-studio .cts-windows-menu-bar + div > aside.app-shell-left-panel,
+html.codex-theme-studio .cts-windows-menu-bar + div > main.main-surface {
+  padding-top: var(--cts-windows-menu-height, 36px) !important;
+}
+html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="sidebar"] {
+  color: var(--cts-windows-sidebar-foreground) !important;
+  -webkit-text-fill-color: var(--cts-windows-sidebar-foreground) !important;
+}
+html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
+  color: var(--cts-windows-main-foreground) !important;
+  -webkit-text-fill-color: var(--cts-windows-main-foreground) !important;
+}`;
   const VERSION = __CTS_VERSION_JSON__;
   const STAMP = __CTS_STAMP_JSON__;
   const THEME = themeConfig && typeof themeConfig === "object" ? themeConfig : {};
@@ -314,6 +334,44 @@
     });
   };
 
+  // Codex 26.715+ renders the Windows application menu (File/Edit/View/Help)
+  // as a separate 36px flex item above the sidebar/main row. Theme CSS written
+  // for the older in-main toolbar cannot reach that strip, so the stock canvas
+  // shows through. Move only this structurally verified menu out of flex flow,
+  // then use equivalent top padding on the real sidebar/main surfaces: their
+  // own theme backgrounds extend behind the menu without cloning per-theme
+  // artwork or changing any content geometry.
+  const integrateWindowsMenu = (shellMain) => {
+    const menu = document.querySelector(
+      '.app-header-tint[class~="group/application-menu-top-bar"]'
+    );
+    const shellRow = menu?.nextElementSibling;
+    const sidebar = shellRow?.querySelector(":scope > aside.app-shell-left-panel");
+    const main = shellRow?.querySelector(":scope > main.main-surface");
+    const eligible = Boolean(menu && sidebar && main && main === shellMain);
+
+    for (const stale of document.querySelectorAll(`.${WINDOWS_MENU_CLASS}`)) {
+      if (!eligible || stale !== menu) stale.classList.remove(WINDOWS_MENU_CLASS);
+    }
+    for (const stale of document.querySelectorAll(`[${WINDOWS_MENU_REGION_ATTR}]`)) {
+      if (!eligible || !menu.contains(stale)) stale.removeAttribute(WINDOWS_MENU_REGION_ATTR);
+    }
+    if (!eligible) return;
+
+    const menuHeight = menu.getBoundingClientRect().height || 36;
+    setVar("--cts-windows-menu-height", `${menuHeight}px`);
+    setClass(menu, WINDOWS_MENU_CLASS, true);
+    setVar("--cts-windows-sidebar-foreground", getComputedStyle(sidebar).color);
+    setVar("--cts-windows-main-foreground", getComputedStyle(main).color);
+
+    const sidebarRight = sidebar.getBoundingClientRect().right;
+    for (const control of menu.querySelectorAll("button, [role=button]")) {
+      const box = control.getBoundingClientRect();
+      const region = box.left + box.width / 2 <= sidebarRight ? "sidebar" : "main";
+      setAttr(control, WINDOWS_MENU_REGION_ATTR, region);
+    }
+  };
+
   const ensure = () => {
     if (window[DISABLED_KEY]) return;
     const root = document.documentElement;
@@ -334,11 +392,12 @@
       (document.head || root).appendChild(style);
     }
     if (style.dataset.ctsStamp !== STAMP) {
-      style.textContent = cssText;
+      style.textContent = `${cssText}\n\n${RUNTIME_CSS}`;
       style.dataset.ctsStamp = STAMP;
     }
 
     const shellMain = document.querySelector("main.main-surface") || document.querySelector("main");
+    integrateWindowsMenu(shellMain);
     const home = findHome(state?.homeSticky);
     if (state) state.homeSticky = home;
     for (const candidate of document.querySelectorAll('[role="main"].cts-home')) {
@@ -443,6 +502,8 @@
     document.querySelectorAll("[data-cts-glyph]").forEach((node) => node.removeAttribute("data-cts-glyph"));
     document.querySelectorAll("[data-cts-icon]").forEach((node) => node.removeAttribute("data-cts-icon"));
     document.querySelectorAll("[data-cts-logo]").forEach((node) => node.removeAttribute("data-cts-logo"));
+    document.querySelectorAll(`.${WINDOWS_MENU_CLASS}`).forEach((node) => node.classList.remove(WINDOWS_MENU_CLASS));
+    document.querySelectorAll(`[${WINDOWS_MENU_REGION_ATTR}]`).forEach((node) => node.removeAttribute(WINDOWS_MENU_REGION_ATTR));
     document.getElementById(STYLE_ID)?.remove();
     document.getElementById(CHROME_ID)?.remove();
     document.getElementById(STAGE_ID)?.remove();


### PR DESCRIPTION
## Summary

- integrate the Windows File/Edit/View/Help DOM menu with themed sidebar/main surfaces
- preserve content geometry with measured menu-height padding
- select readable foreground colors from the surface beneath each menu control
- make cleanup and removal verification cover all Windows menu markers

## Root cause

Codex 26.715+ places its Windows application menu in a separate DOM flex row above the themed sidebar/main row. The engine's existing selectors therefore left the stock top strip visible even while the rest of the skin rendered correctly.

## Safety

The layout integration is guarded by the expected menu class plus direct sidebar/main structure. It is idempotent, resize-aware through the existing reconciler, and fully reversible.

Companion runtime/source-of-truth PR: https://github.com/Wangnov/awesome-codex-skins/pull/5

## Validation

- `cargo test` in `crates/codex-theme-engine`: 42 passed
- `cargo test` in `crates/codex-win-engine`: 98 passed
- Windows theme view test: passed
- runtime syntax check: passed
- local Tauri x64 NSIS build: passed
- live reversible layout prototype against Windows Codex 26.715