### PR TITLE
feat(themes): add CSP-safe motion video intros

### DIFF
--- a/crates/codex-theme-engine/src/import.rs
+++ b/crates/codex-theme-engine/src/import.rs
@@ -235,4 +235,37 @@ mod tests {
         assert!(import_codexskin(&bad, &root).is_err());
         assert!(!root.join("bad").exists());
     }
+
+    #[test]
+    fn imports_a_codexskin_with_motion() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("themes");
+        let skin = tmp.path().join("motion.codexskin");
+        // A package carrying an mp4 motion asset (plus its required static intro
+        // fallback) must import without any extra rejection path.
+        write_zip(
+            &skin,
+            &[
+                (
+                    "theme.json",
+                    br#"{"schemaVersion":2,"id":"motion-skin","name":"M","version":"1.0.0",
+                        "assets":{"intro":"assets/intro.webp"},
+                        "motionAssets":{"intro-video":"assets/intro-video.mp4"},
+                        "previews":["previews/home.webp"]}"# as &[u8],
+                ),
+                ("theme.css", b"html.codex-theme-studio {}\n"),
+                ("assets/intro.webp", b"RIFF\x01\x02"),
+                ("assets/intro-video.mp4", b"\x00\x00\x00\x18ftypisom"),
+                ("previews/home.webp", b"RIFF\x01\x02"),
+            ],
+        );
+
+        let summary = import_codexskin(&skin, &root).unwrap();
+        assert_eq!(summary.id, "motion-skin");
+        // The installed package validates and exposes the motion asset with its
+        // video mime — ready for the payload's dedicated motion data-URL map.
+        let installed = crate::theme::load_theme(&root.join("motion-skin")).unwrap();
+        assert!(installed.motion_assets.contains_key("intro-video"));
+        assert_eq!(installed.motion_assets["intro-video"].mime, "video/mp4");
+    }
 }

--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 
 use sha1::{Digest, Sha1};
 
-use crate::theme::{inline_assets, load_theme, LoadedTheme, ThemeConfig};
+use crate::theme::{
+    inline_assets, inline_motion_assets, load_theme, LoadedTheme, ThemeConfig,
+};
 use crate::{Result, ENGINE_VERSION};
 
 /// The injected renderer runtime — codex-theme-studio's file verbatim. It
@@ -47,20 +49,29 @@ pub struct BuiltPayload {
     pub asset_count: usize,
 }
 
-/// Build the `Runtime.evaluate` payload for a theme directory.
+/// Build the `Runtime.evaluate` payload for a theme directory. Still images
+/// become CSS data URLs; motion assets become a dedicated data-URL map consumed
+/// by the runtime's `<video>` element.
 pub fn build_payload(theme_dir: &Path) -> Result<BuiltPayload> {
     build_payload_from(load_theme(theme_dir)?)
 }
 
 pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
     let data_urls = inline_assets(&theme)?;
-    // Asset variables ride inside the stylesheet as data: URLs — immune to the
-    // blob revocation races that break late-loading images (border-image).
+    let motion_data_urls = inline_motion_assets(&theme)?;
+    // Still-image assets ride the stylesheet as --cts-asset-* data: URLs, immune
+    // to the blob revocation races that break late-loading images (border-image).
+    // Motion assets skip CSS entirely and ride their own JSON slot as data URLs;
+    // Codex already permits `media-src data:`, so playback needs no CSP bypass.
     let asset_variables = data_urls
         .iter()
         .map(|(key, url)| format!("  --cts-asset-{key}: url(\"{url}\");"))
         .collect::<Vec<_>>()
         .join("\n");
+    // A JSON object literal injected directly as the runtime's `motionAssets`
+    // argument — NOT wrapped as a string like the chrome fragment.
+    let motion_json = serde_json::to_string(&motion_data_urls)
+        .map_err(|e| crate::ThemeEngineError::Theme(format!("motion serialize: {e}")))?;
     let css_with_assets = format!(
         ":root.codex-theme-studio {{\n{asset_variables}\n}}\n\n{}\n\n{RUNTIME_HARDENING_CSS}",
         theme.css
@@ -69,9 +80,8 @@ pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
         .map_err(|e| crate::ThemeEngineError::Theme(format!("config serialize: {e}")))?;
     let chrome_html = theme.chrome_html.clone();
 
-    // Fingerprint the executable packed payload, including the renderer
-    // runtime. Without the runtime template, renderer-only bug fixes share the
-    // old stamp and the daemon cannot distinguish them from an installed copy.
+    // Fingerprint the executable packed payload, including the renderer runtime
+    // and motion bytes. A video-only change must re-inject and replay the intro.
     let runtime_template = RUNTIME_TEMPLATE.replace(
         "__CTS_COMPOSER_OVERFLOW_HELPERS__",
         &composer_overflow_helpers_expression(),
@@ -81,6 +91,7 @@ pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
         &css_with_assets,
         chrome_html.as_deref().unwrap_or(""),
         &config_json,
+        &motion_json,
     );
     let stamp = format!("{ENGINE_VERSION}:{}:{short}", theme.config.id);
 
@@ -92,12 +103,13 @@ pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
             &serde_json::to_string(&chrome_html)
                 .map_err(|e| crate::ThemeEngineError::Theme(format!("chrome serialize: {e}")))?,
         )
+        .replace("__CTS_MOTION_JSON__", &motion_json)
         .replace("__CTS_VERSION_JSON__", &js_json(ENGINE_VERSION)?)
         .replace("__CTS_STAMP_JSON__", &js_json(&stamp)?);
 
     Ok(BuiltPayload {
         payload_bytes: payload.len(),
-        asset_count: data_urls.len(),
+        asset_count: data_urls.len() + motion_data_urls.len(),
         theme: theme.config,
         stamp,
         payload,
@@ -120,12 +132,13 @@ fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
-fn fingerprint(runtime: &str, css: &str, chrome: &str, config: &str) -> String {
+fn fingerprint(runtime: &str, css: &str, chrome: &str, config: &str, motion: &str) -> String {
     let mut hasher = Sha1::new();
     hasher.update(runtime.as_bytes());
     hasher.update(css.as_bytes());
     hasher.update(chrome.as_bytes());
     hasher.update(config.as_bytes());
+    hasher.update(motion.as_bytes());
     let digest = hasher.finalize();
     hex(&digest)[..12].to_string()
 }
@@ -356,10 +369,79 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_tracks_runtime_changes() {
-        let first = fingerprint("runtime-a", "css", "chrome", "config");
-        let second = fingerprint("runtime-b", "css", "chrome", "config");
-        assert_ne!(first, second, "runtime change must re-stamp");
+    fn fingerprint_tracks_runtime_and_motion_changes() {
+        let base = fingerprint("runtime-a", "css", "chrome", "config", "{}");
+        assert_ne!(
+            base,
+            fingerprint("runtime-b", "css", "chrome", "config", "{}"),
+            "runtime change must re-stamp"
+        );
+        assert_ne!(
+            base,
+            fingerprint(
+                "runtime-a",
+                "css",
+                "chrome",
+                "config",
+                r#"{"intro-video":"data:video/mp4;base64,AAAA"}"#
+            ),
+            "motion change must re-stamp"
+        );
+    }
+
+    fn motion_fixture(tmp: &Path) -> std::path::PathBuf {
+        let dir = tmp.join("ning-hongye");
+        std::fs::create_dir_all(dir.join("assets")).unwrap();
+        std::fs::write(
+            dir.join("theme.json"),
+            r##"{
+              "schemaVersion": 2,
+              "id": "ning-hongye",
+              "name": "Ning",
+              "assets": { "intro": "assets/intro.webp" },
+              "motionAssets": { "intro-video": "assets/intro-video.mp4" }
+            }"##,
+        )
+        .unwrap();
+        std::fs::write(dir.join("theme.css"), "html.codex-theme-studio {}\n").unwrap();
+        std::fs::write(dir.join("assets/intro.webp"), [0x52, 0x49, 0x46, 0x46, 1, 2]).unwrap();
+        // A "video" far larger than the 1.4 MB CSS-image cap. It is valid in
+        // the dedicated motion slot because it never becomes a CSS URL.
+        std::fs::write(dir.join("assets/intro-video.mp4"), vec![7u8; 2_000_000]).unwrap();
+        dir
+    }
+
+    #[test]
+    fn motion_uses_dedicated_data_url_without_touching_css_or_csp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = motion_fixture(tmp.path());
+        let built = build_payload(&dir).unwrap();
+        assert!(built.payload.contains("data:video/mp4;base64,"));
+        assert!(!built.payload.contains("http://127.0.0.1"));
+        assert!(!built.payload.contains("Page.setBypassCSP"));
+        assert!(built.payload.len() > 2_500_000, "video bytes must enter motion JSON");
+        // The still image still rides the stylesheet as a data: URL.
+        assert!(built.payload.contains("--cts-asset-intro: url("));
+        assert!(!built.payload.contains("--cts-asset-intro-video"));
+        assert_eq!(built.asset_count, 2);
+    }
+
+    #[test]
+    fn payload_without_motion_substitutes_an_empty_map() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = build_payload(&fixture_theme(tmp.path())).unwrap();
+        assert!(!built.payload.contains("__CTS_MOTION_JSON__"));
+        assert!(built.payload.trim_end().ends_with(", {})"));
+    }
+
+    #[test]
+    fn swapped_video_bytes_restamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = motion_fixture(tmp.path());
+        let first = build_payload(&dir).unwrap().stamp;
+        std::fs::write(dir.join("assets/intro-video.mp4"), vec![9u8; 3_000_000]).unwrap();
+        let second = build_payload(&dir).unwrap().stamp;
+        assert_ne!(first, second, "a swapped video must re-stamp");
     }
 
     #[test]

--- a/crates/codex-theme-engine/src/runtime/theme-runtime-motion.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime-motion.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { JSDOM } from "jsdom";
+import { test } from "vitest";
+
+const TEMPLATE_PATH = path.join(
+  process.cwd(),
+  "crates/codex-theme-engine/src/runtime/theme-runtime.js",
+);
+const HELPERS = `({
+  createComposerOverflowAnnotator: () => {
+    const annotate = () => {};
+    annotate.invalidate = () => {};
+    return annotate;
+  },
+  selectComposerSurfaces: () => [],
+})`;
+const CSS = `
+html.codex-theme-studio {
+  --cts-asset-intro: url("data:image/webp;base64,UklGRg==");
+  --cts-intro-duration: 10s;
+}`;
+
+async function runtimeExpression({ stamp, themeId, videoSrc }) {
+  const template = await fs.readFile(TEMPLATE_PATH, "utf8");
+  return template
+    .replace("__CTS_COMPOSER_OVERFLOW_HELPERS__", HELPERS)
+    .replace("__CTS_CSS_JSON__", JSON.stringify(CSS))
+    .replace("__CTS_THEME_JSON__", JSON.stringify({ id: themeId, colors: {}, strings: {} }))
+    .replace("__CTS_CHROME_JSON__", "null")
+    .replace("__CTS_MOTION_JSON__", JSON.stringify({ "intro-video": videoSrc }))
+    .replace("__CTS_VERSION_JSON__", JSON.stringify("test"))
+    .replace("__CTS_STAMP_JSON__", JSON.stringify(stamp));
+}
+
+function createDom() {
+  const dom = new JSDOM(
+    "<!doctype html><html><head></head><body><main data-app-shell-main-surface></main></body></html>",
+    { pretendToBeVisual: true, runScripts: "outside-only" },
+  );
+  dom.window.matchMedia = () => ({
+    matches: false,
+    addEventListener() {},
+    removeEventListener() {},
+  });
+  Object.defineProperty(dom.window.HTMLMediaElement.prototype, "play", {
+    configurable: true,
+    value: () => Promise.resolve(),
+  });
+  return dom;
+}
+
+test("hot switching replaces the previous theme's video and ignores its stale callback", async () => {
+  const dom = createDom();
+  try {
+    dom.window.eval(await runtimeExpression({
+      stamp: "theme-a:1",
+      themeId: "theme-a",
+      videoSrc: "data:video/mp4;base64,QQ==",
+    }));
+    const oldIntro = dom.window.document.getElementById("cts-intro");
+    const oldVideo = oldIntro?.querySelector("video");
+    assert.ok(oldIntro && oldVideo);
+
+    dom.window.eval(await runtimeExpression({
+      stamp: "theme-b:1",
+      themeId: "theme-b",
+      videoSrc: "data:video/mp4;base64,Qg==",
+    }));
+    const currentIntro = dom.window.document.getElementById("cts-intro");
+    const currentVideo = currentIntro?.querySelector("video");
+    assert.ok(currentIntro && currentVideo);
+    assert.notEqual(currentIntro, oldIntro);
+    assert.equal(currentVideo.getAttribute("src"), "data:video/mp4;base64,Qg==");
+
+    oldVideo.dispatchEvent(new dom.window.Event("error"));
+    assert.equal(dom.window.document.getElementById("cts-intro"), currentIntro);
+    assert.equal(currentIntro.querySelector("video"), currentVideo);
+  } finally {
+    dom.window.close();
+  }
+});
+
+test("a failed video remounts a fresh static intro", async () => {
+  const dom = createDom();
+  try {
+    dom.window.eval(await runtimeExpression({
+      stamp: "theme-a:1",
+      themeId: "theme-a",
+      videoSrc: "data:video/mp4;base64,QQ==",
+    }));
+    const videoIntro = dom.window.document.getElementById("cts-intro");
+    const video = videoIntro?.querySelector("video");
+    assert.ok(videoIntro && video);
+
+    video.dispatchEvent(new dom.window.Event("error"));
+    const fallback = dom.window.document.getElementById("cts-intro");
+    assert.ok(fallback);
+    assert.notEqual(fallback, videoIntro);
+    assert.equal(fallback.querySelector("video"), null);
+    assert.equal(fallback.dataset.ctsVideoError, "media error");
+  } finally {
+    dom.window.close();
+  }
+});

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -5,7 +5,7 @@
 // here must be guarded by a value comparison — writing the same value to
 // style/class/attributes still dirties style state in Chromium and causes
 // visible repaint flashes (e.g. whenever a dropdown portal mounts).
-((cssText, themeConfig, chromeHtml) => {
+((cssText, themeConfig, chromeHtml, motionAssets) => {
   const STATE_KEY = "__CODEX_THEME_STUDIO__";
   const DISABLED_KEY = "__CODEX_THEME_STUDIO_DISABLED__";
   const STYLE_ID = "cts-style";
@@ -48,6 +48,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
   const VERSION = __CTS_VERSION_JSON__;
   const STAMP = __CTS_STAMP_JSON__;
   const THEME = themeConfig && typeof themeConfig === "object" ? themeConfig : {};
+  const MOTION = motionAssets && typeof motionAssets === "object" ? motionAssets : {};
 
   window[DISABLED_KEY] = false;
 
@@ -70,6 +71,11 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
   if (previous?.appliedVars) {
     for (const name of previous.appliedVars) document.documentElement?.style.removeProperty(name);
   }
+  // A different stamp means a different theme (or payload): a still-playing
+  // intro from the previous theme must not outlive it, and its stale node
+  // would also make the new theme's playIntro() bail out. Same-stamp
+  // re-ensures leave the intro alone — reconciliation must never cut it.
+  if (previous && previous.stamp !== STAMP) document.getElementById(INTRO_ID)?.remove();
   // A hot theme switch reuses the live DOM. Clear semantic annotations from
   // the previous payload before the new theme decides which glyphs it can
   // actually render; otherwise partial icon sets inherit stale hidden paths.
@@ -692,19 +698,76 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
       if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
       if (document.getElementById(INTRO_ID) || !document.body) return;
       // Theme-agnostic convention: themes register their intro art as the
-      // asset key "intro"; --cts-asset-tiga-punch is the legacy fallback.
+      // asset key "intro"; --cts-asset-tiga-punch is the legacy fallback. An
+      // optional "intro-video" motion asset takes priority while the static
+      // art remains its poster/fallback when playback is unavailable.
       const styles = getComputedStyle(document.documentElement);
       const art = styles.getPropertyValue("--cts-asset-intro") || styles.getPropertyValue("--cts-asset-tiga-punch");
-      if (!art || !art.trim()) return;
-      const intro = document.createElement("div");
-      intro.id = INTRO_ID;
-      intro.setAttribute("aria-hidden", "true");
-      intro.innerHTML = '<i class="cts-intro-rays"></i><b class="cts-intro-figure"></b><u class="cts-intro-flash"></u>';
-      document.body.appendChild(intro);
-      setTimeout(() => intro.remove(), 2500);
+      const videoSrc = typeof MOTION["intro-video"] === "string" ? MOTION["intro-video"] : "";
+      if ((!art || !art.trim()) && !videoSrc) return;
+      const durationValue = styles.getPropertyValue("--cts-intro-duration").trim();
+      const durationMatch = durationValue.match(/^(\d+(?:\.\d+)?)(ms|s)$/i);
+      const durationMs = durationMatch
+        ? Math.min(15000, Math.max(1000, Number(durationMatch[1]) * (durationMatch[2].toLowerCase() === "s" ? 1000 : 1)))
+        : 2500;
+      const mountIntro = (videoError) => {
+        document.getElementById(INTRO_ID)?.remove();
+        const intro = document.createElement("div");
+        intro.id = INTRO_ID;
+        intro.setAttribute("aria-hidden", "true");
+        if (videoError) intro.dataset.ctsVideoError = videoError;
+        intro.innerHTML = '<i class="cts-intro-rays"></i><b class="cts-intro-figure"></b><u class="cts-intro-flash"></u>';
+        document.body.appendChild(intro);
+        setTimeout(() => intro.remove(), durationMs + 120);
+        return intro;
+      };
+      const intro = mountIntro();
+      // A video that fails mid-play must not strand the fallback inside a
+      // parent whose animation timeline already ran out: remount the intro
+      // from scratch so the static art restarts cleanly (or clear it when the
+      // theme ships no static intro at all). The callbacks are async — after
+      // a hot switch or `off`, the removed video rejects play() with
+      // AbortError and this closure fires against a world it no longer owns,
+      // so it must verify the intro is still ours (and only fall back once:
+      // the error event and the play rejection often arrive together).
+      let fellBack = false;
+      const fallbackToStatic = (reason) => {
+        if (fellBack || window[DISABLED_KEY]) return;
+        if (document.getElementById(INTRO_ID) !== intro) return;
+        fellBack = true;
+        if (art && art.trim()) mountIntro(reason);
+        else intro.remove();
+      };
+      if (videoSrc) {
+        const video = document.createElement("video");
+        video.className = "cts-intro-video";
+        video.src = videoSrc;
+        video.autoplay = true;
+        video.muted = true;
+        video.defaultMuted = true;
+        video.playsInline = true;
+        video.preload = "auto";
+        video.controls = false;
+        video.disablePictureInPicture = true;
+        video.setAttribute("muted", "");
+        video.setAttribute("playsinline", "");
+        video.addEventListener("error", () => {
+          const mediaError = video.error;
+          fallbackToStatic(mediaError
+            ? `${mediaError.code}:${mediaError.message || "media error"}`
+            : "media error");
+        }, { once: true });
+        intro.prepend(video);
+        try {
+          const playing = video.play();
+          playing?.catch?.((error) => fallbackToStatic(`${error?.name || "play"}:${error?.message || "rejected"}`));
+        } catch (error) {
+          fallbackToStatic(`${error?.name || "play"}:${error?.message || "failed"}`);
+        }
+      }
     } catch { /* cosmetic only */ }
   };
   if (previous?.stamp !== STAMP) playIntro();
 
   return { installed: true, version: VERSION, themeId: THEME.id || "custom" };
-})(__CTS_CSS_JSON__, __CTS_THEME_JSON__, __CTS_CHROME_JSON__)
+})(__CTS_CSS_JSON__, __CTS_THEME_JSON__, __CTS_CHROME_JSON__, __CTS_MOTION_JSON__)

--- a/crates/codex-theme-engine/src/theme.rs
+++ b/crates/codex-theme-engine/src/theme.rs
@@ -6,6 +6,7 @@
 //!   theme.css     required — selectors scoped to html.codex-theme-studio
 //!   chrome.html   optional — decorative overlay fragment (pointer-events: none)
 //!   assets/*.webp bitmap assets referenced by theme.json "assets"
+//!   assets/*.mp4  optional motion assets referenced by "motionAssets"
 //! ```
 //!
 //! Everything is validated and inlined; nothing is fetched at runtime.
@@ -29,6 +30,11 @@ pub const MAX_ASSET_BYTES: u64 = 1_400_000;
 /// text message to `Runtime.evaluate`; 24 MB raw ≈ 32 MB payload, safely
 /// under tungstenite's 64 MB default message cap.
 pub const MAX_TOTAL_ASSET_BYTES: u64 = 24 * 1024 * 1024;
+/// Per motion-asset ceiling. Motion (mp4/webm) rides a dedicated data-URL map,
+/// not a CSS variable, so Chromium's ~2 MB CSS data-URL behavior does not apply.
+/// It still counts toward [`MAX_TOTAL_ASSET_BYTES`] because the whole payload is
+/// sent in one CDP message (SPEC: ≤ 24 MB raw, ≤ 8 MB recommended).
+pub const MAX_MOTION_ASSET_BYTES: u64 = 24 * 1024 * 1024;
 
 const NAME_MAX: usize = 64;
 
@@ -119,6 +125,10 @@ pub struct LoadedTheme {
     pub css: String,
     pub chrome_html: Option<String>,
     pub assets: BTreeMap<String, AssetRef>,
+    /// Motion assets (mp4/webm) placed in the runtime's dedicated data-URL map,
+    /// never CSS variables. Additive schemaVersion-2 extension; packages
+    /// without them stay fully static.
+    pub motion_assets: BTreeMap<String, AssetRef>,
     /// Optional native Codex appearance block, applied to ~/.codex/config.toml
     /// while Codex is stopped. Passed through as-is (validated on apply).
     pub codex_theme: Option<serde_json::Value>,
@@ -172,6 +182,8 @@ fn mime_for(path: &Path) -> Option<&'static str> {
         "png" => Some("image/png"),
         "jpg" | "jpeg" => Some("image/jpeg"),
         "webp" => Some("image/webp"),
+        "mp4" => Some("video/mp4"),
+        "webm" => Some("video/webm"),
         _ => None,
     }
 }
@@ -224,8 +236,8 @@ fn extract_meta(raw: &serde_json::Value, dir: &Path) -> ThemeMeta {
                 .filter_map(|v| v.as_str())
                 .filter_map(|rel| {
                     let path = resolve_inside(dir, rel, "preview").ok()?;
-                    let mime = mime_for(&path)?;
-                    let _ = mime;
+                    // Previews are screenshots — image mimes only, never motion.
+                    mime_for(&path).filter(|m| m.starts_with("image/"))?;
                     let meta = std::fs::metadata(&path).ok()?;
                     (meta.is_file() && meta.len() >= 1 && meta.len() <= MAX_PREVIEW_BYTES)
                         .then(|| rel.to_string())
@@ -327,7 +339,11 @@ pub fn load_theme(theme_dir: &Path) -> Result<LoadedTheme> {
                 .as_str()
                 .ok_or_else(|| err(format!("asset {key} path must be a string")))?;
             let asset_path = resolve_inside(&dir, rel, &format!("asset {key}"))?;
+            // Still-image assets only: they ride CSS `url()` variables, so a
+            // video mime here would smuggle a >2 MB data: URL into a background.
+            // Motion (mp4/webm) is declared separately under `motionAssets`.
             let mime = mime_for(&asset_path)
+                .filter(|m| m.starts_with("image/"))
                 .ok_or_else(|| err(format!("unsupported asset format for {key}: {rel}")))?;
             let meta = std::fs::metadata(&asset_path)
                 .map_err(|e| err(format!("asset {key} unreadable: {e}")))?;
@@ -352,6 +368,54 @@ pub fn load_theme(theme_dir: &Path) -> Result<LoadedTheme> {
         }
     }
 
+    // Motion assets (mp4/webm) are an additive extension. They ride a dedicated
+    // data-URL map instead of CSS variables, so the image-only 1.4 MB ceiling
+    // does not apply. They still share the combined CDP message budget with
+    // static art. Unknown key, collision, wrong format or oversize fails load,
+    // matching the Manager runtime and Studio pack contracts.
+    let mut motion_assets = BTreeMap::new();
+    if let Some(map) = raw.get("motionAssets").and_then(|v| v.as_object()) {
+        for (key, value) in map {
+            if !name_pattern(key) {
+                return Err(err(format!("invalid motion asset key: {key}")));
+            }
+            if key != "intro-video" {
+                return Err(err(format!("unsupported motion asset key: {key}")));
+            }
+            if assets.contains_key(key) {
+                return Err(err(format!(
+                    "motion asset {key} collides with a static asset of the same name"
+                )));
+            }
+            let rel = value
+                .as_str()
+                .ok_or_else(|| err(format!("motion asset {key} path must be a string")))?;
+            let asset_path = resolve_inside(&dir, rel, &format!("motion asset {key}"))?;
+            let mime = mime_for(&asset_path)
+                .filter(|m| m.starts_with("video/"))
+                .ok_or_else(|| err(format!("unsupported motion asset format for {key}: {rel}")))?;
+            let meta = std::fs::metadata(&asset_path)
+                .map_err(|e| err(format!("motion asset {key} unreadable: {e}")))?;
+            if !meta.is_file() || meta.len() < 1 || meta.len() > MAX_MOTION_ASSET_BYTES {
+                return Err(err(format!(
+                    "motion asset {key} must be a non-empty file up to {MAX_MOTION_ASSET_BYTES} bytes"
+                )));
+            }
+            total_bytes += meta.len();
+            if total_bytes > MAX_TOTAL_ASSET_BYTES {
+                return Err(err("combined theme assets exceed the size budget"));
+            }
+            motion_assets.insert(
+                key.clone(),
+                AssetRef {
+                    path: asset_path,
+                    mime,
+                    bytes: meta.len(),
+                },
+            );
+        }
+    }
+
     let codex_theme = raw.get("codexTheme").filter(|v| v.is_object()).cloned();
     let meta = extract_meta(&raw, &dir);
 
@@ -362,6 +426,7 @@ pub fn load_theme(theme_dir: &Path) -> Result<LoadedTheme> {
         css,
         chrome_html,
         assets,
+        motion_assets,
         codex_theme,
     })
 }
@@ -373,6 +438,20 @@ pub fn inline_assets(theme: &LoadedTheme) -> Result<BTreeMap<String, String>> {
     for (key, asset) in &theme.assets {
         let bytes = std::fs::read(&asset.path)
             .map_err(|e| err(format!("asset {key} unreadable: {e}")))?;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        data_urls.insert(key.clone(), format!("data:{};base64,{}", asset.mime, encoded));
+    }
+    Ok(data_urls)
+}
+
+/// Inline motion assets into the runtime's dedicated JSON map. Video data URLs
+/// never enter CSS, so they avoid CSS image limits while remaining inside the
+/// page's existing `media-src data:` policy.
+pub fn inline_motion_assets(theme: &LoadedTheme) -> Result<BTreeMap<String, String>> {
+    let mut data_urls = BTreeMap::new();
+    for (key, asset) in &theme.motion_assets {
+        let bytes = std::fs::read(&asset.path)
+            .map_err(|e| err(format!("motion asset {key} unreadable: {e}")))?;
         let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
         data_urls.insert(key.clone(), format!("data:{};base64,{}", asset.mime, encoded));
     }
@@ -492,6 +571,78 @@ mod tests {
         std::fs::write(dir.join("theme.css"), "").unwrap();
         let error = load_theme(&dir).unwrap_err().to_string();
         assert!(error.contains("inside the theme directory"), "{error}");
+    }
+
+    #[test]
+    fn loads_motion_assets_and_rejects_unknown_keys_and_static_collisions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("motion");
+        std::fs::create_dir_all(dir.join("assets")).unwrap();
+        std::fs::write(
+            dir.join("theme.json"),
+            r##"{
+              "schemaVersion": 2,
+              "id": "motion",
+              "assets": { "intro": "assets/intro.webp" },
+              "motionAssets": { "intro-video": "assets/intro.mp4" }
+            }"##,
+        )
+        .unwrap();
+        std::fs::write(dir.join("theme.css"), "").unwrap();
+        std::fs::write(dir.join("assets/intro.webp"), b"RIFF").unwrap();
+        std::fs::write(dir.join("assets/intro.mp4"), b"video").unwrap();
+
+        let theme = load_theme(&dir).unwrap();
+        assert_eq!(theme.motion_assets["intro-video"].mime, "video/mp4");
+
+        std::fs::write(
+            dir.join("theme.json"),
+            r##"{
+              "schemaVersion": 2,
+              "id": "motion",
+              "assets": { "intro-video": "assets/intro.webp" },
+              "motionAssets": { "intro-video": "assets/intro.mp4" }
+            }"##,
+        )
+        .unwrap();
+        let error = load_theme(&dir).unwrap_err().to_string();
+        assert!(error.contains("collides with a static asset"), "{error}");
+
+        std::fs::write(
+            dir.join("theme.json"),
+            r##"{
+              "schemaVersion": 2,
+              "id": "motion",
+              "motionAssets": { "outro-video": "assets/intro.mp4" }
+            }"##,
+        )
+        .unwrap();
+        let error = load_theme(&dir).unwrap_err().to_string();
+        assert!(error.contains("unsupported motion asset key"), "{error}");
+    }
+
+    #[test]
+    fn motion_shares_the_combined_payload_budget() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("motion-budget");
+        std::fs::create_dir_all(dir.join("assets")).unwrap();
+        std::fs::write(
+            dir.join("theme.json"),
+            r##"{
+              "schemaVersion": 2,
+              "id": "motion-budget",
+              "assets": { "intro": "assets/intro.webp" },
+              "motionAssets": { "intro-video": "assets/intro.mp4" }
+            }"##,
+        )
+        .unwrap();
+        std::fs::write(dir.join("theme.css"), "").unwrap();
+        std::fs::write(dir.join("assets/intro.webp"), b"RIFF").unwrap();
+        let video = std::fs::File::create(dir.join("assets/intro.mp4")).unwrap();
+        video.set_len(MAX_MOTION_ASSET_BYTES).unwrap();
+
+        let error = load_theme(&dir).unwrap_err().to_string();
+        assert!(error.contains("combined theme assets exceed"), "{error}");
     }
 
     #[test]

--- a/crates/codex-theme-engine/tests/real_packages.rs
+++ b/crates/codex-theme-engine/tests/real_packages.rs
@@ -5,14 +5,25 @@
 use std::path::PathBuf;
 
 fn studio_themes() -> Option<PathBuf> {
-    let root = PathBuf::from(std::env::var("HOME").ok()?).join("codex-theme-studio/themes");
-    root.is_dir().then_some(root)
+    if let Ok(configured) = std::env::var("CODEX_THEME_STUDIO_THEMES") {
+        let root = PathBuf::from(configured);
+        if root.is_dir() {
+            return Some(root);
+        }
+    }
+    let home = PathBuf::from(std::env::var("HOME").ok()?);
+    [
+        home.join("awesome-codex-skins/skins"),
+        home.join("codex-theme-studio/themes"),
+    ]
+    .into_iter()
+    .find(|root| root.is_dir())
 }
 
 #[test]
 #[ignore = "requires ~/codex-theme-studio (developer machine only)"]
 fn studio_packages_load_and_build() {
-    let root = studio_themes().expect("~/codex-theme-studio/themes not found");
+    let root = studio_themes().expect("Studio skins directory not found");
     let listed = codex_theme_engine::theme::list_themes(&root);
     let ids: Vec<&str> = listed.iter().map(|t| t.id.as_str()).collect();
     assert!(ids.contains(&"guts-terminal"), "listed: {ids:?}");
@@ -64,7 +75,7 @@ fn studio_packages_load_and_build() {
 #[test]
 #[ignore = "requires a running Codex with --remote-debugging-port=9345"]
 fn live_inject_verify_revert_when_stock() {
-    let root = studio_themes().expect("~/codex-theme-studio/themes not found");
+    let root = studio_themes().expect("Studio skins directory not found");
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
## Summary

- add `motionAssets.intro-video` support for MP4/WebM theme intros
- inline video bytes in a dedicated JSON/data-URL channel already allowed by Codex's `media-src data:` policy
- preserve static intro fallback, reduced-motion behavior, hot switching, and full theme removal
- reject unsupported motion keys, static/motion key collisions, invalid formats, and payloads over the shared 24 MB raw-asset budget

This supersedes the original loopback-server design. It does not start a media server and does not call `Page.setBypassCSP`, so enabling a motion theme cannot weaken the renderer's CSP.

## Verification

- `codex review --uncommitted`: no findings after addressing the unknown-key/dead-payload review comment
- `npm run lint`, `npm run check`, `npm test`, and `npm run build`
- `cargo test --locked --manifest-path src-tauri/Cargo.toml --workspace --all-targets`
- `cargo test --locked --manifest-path crates/codex-theme-engine/Cargo.toml`
- `cargo check --locked --manifest-path crates/codex-theme-engine/Cargo.toml --target x86_64-pc-windows-msvc`
- all 50 current Studio themes load and build, including the 16.1 MB Ning Hongye motion payload
- real Chromium smoke: the 6.04 s MP4 data URL reaches `readyState=4` with no media error

The runtime regression tests cover video failure fallback and stale async callbacks during hot theme switches.
