### PR TITLE
fix(themes): support Codex 26.727 main surface

### DIFF
--- a/crates/codex-theme-engine/src/cdp.rs
+++ b/crates/codex-theme-engine/src/cdp.rs
@@ -379,7 +379,7 @@ pub async fn cdp_http_ready(port: u16) -> bool {
 /// unmounts — an `app://` page whose title still identifies Codex.
 pub const PROBE_EXPRESSION: &str = r#"(() => {
     const markers = {
-      shell: Boolean(document.querySelector('main.main-surface')),
+      shell: Boolean(document.querySelector('main[data-app-shell-main-surface], main.main-surface')),
       sidebar: Boolean(document.querySelector('.app-shell-left-panel')),
       composer: Boolean(document.querySelector('.composer-surface-chrome')),
       main: Boolean(document.querySelector('[role="main"]')),
@@ -514,5 +514,16 @@ mod tests {
             candidate.url = url.into();
             assert!(!is_theme_excluded_target(&candidate), "unexpected exclusion: {url}");
         }
+    }
+
+    #[test]
+    fn shell_probe_accepts_current_and_legacy_main_surfaces() {
+        let current = PROBE_EXPRESSION
+            .find("main[data-app-shell-main-surface]")
+            .expect("current main-surface selector");
+        let legacy = PROBE_EXPRESSION
+            .find("main.main-surface")
+            .expect("legacy main-surface selector");
+        assert!(current < legacy, "current semantic marker must be probed first");
     }
 }

--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -105,6 +105,10 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
   document.documentElement?.classList.remove('codex-theme-studio');
   document.documentElement?.removeAttribute('data-cts-theme');
   document.documentElement?.removeAttribute('data-cts-shell');
+  document.querySelectorAll('[data-cts-main-surface-compat]').forEach((node) => {
+    node.classList.remove('main-surface');
+    node.removeAttribute('data-cts-main-surface-compat');
+  });
   document.querySelectorAll('.cts-windows-menu-bar').forEach((node) => node.classList.remove('cts-windows-menu-bar'));
   document.querySelectorAll('[data-cts-menu-region]').forEach((node) => node.removeAttribute('data-cts-menu-region'));
   document.documentElement?.style.removeProperty('--cts-windows-menu-height');
@@ -133,6 +137,7 @@ pub const VERIFY_REMOVED_EXPRESSION: &str = r#"(() =>
   !document.getElementById('cts-chrome') &&
   !document.getElementById('cts-stage') &&
   !document.getElementById('cts-intro') &&
+  !document.querySelector('[data-cts-main-surface-compat]') &&
   !window.__CODEX_THEME_STUDIO__
 )()"#;
 
@@ -157,6 +162,9 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
       }};
     }};
     const chrome = document.getElementById('cts-chrome');
+    const stage = document.getElementById('cts-stage');
+    const mainSurfaceNode = document.querySelector('main[data-app-shell-main-surface], main.main-surface');
+    const mainSurface = box(mainSurfaceNode);
     const state = window.__CODEX_THEME_STUDIO__;
     const composer = box(document.querySelector('.composer-surface-chrome'));
     const sidebar = box(document.querySelector('aside.app-shell-left-panel'));
@@ -167,6 +175,10 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
       stylePresent: Boolean(document.getElementById('cts-style')),
       chromePresent: Boolean(chrome),
       chromePointerEvents: chrome ? getComputedStyle(chrome).pointerEvents : null,
+      mainSurface,
+      mainSurfaceMode: mainSurfaceNode?.hasAttribute('data-app-shell-main-surface') ? 'current' : (mainSurfaceNode ? 'legacy' : null),
+      mainSurfaceCompatible: Boolean(mainSurfaceNode?.classList.contains('main-surface')),
+      stageAttachedToMainSurface: !stage || stage.parentElement === mainSurfaceNode,
       composer,
       sidebar,
       viewport: {{ width: innerWidth, height: innerHeight }},
@@ -180,6 +192,9 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
       result.version === {version_json} &&
       result.stylePresent &&
       (!result.chromePresent || result.chromePointerEvents === 'none') &&
+      Boolean(result.mainSurface?.visible) &&
+      result.mainSurfaceCompatible &&
+      result.stageAttachedToMainSurface &&
       Boolean(result.composer?.visible) &&
       Boolean(result.sidebar?.visible) &&
       !result.documentOverflow.x
@@ -224,6 +239,8 @@ mod tests {
         // The CSS rides as a JSON string literal, so quotes appear escaped.
         assert!(built.payload.contains("--cts-asset-wall: url(\\\"data:image/png;base64,"));
         assert!(built.payload.contains("data-cts-layer"));
+        assert!(built.payload.contains("main[data-app-shell-main-surface]"));
+        assert!(built.payload.contains("data-cts-main-surface-compat"));
         assert_eq!(built.asset_count, 1);
         assert!(built.stamp.starts_with(&format!("{ENGINE_VERSION}:fixture:")));
     }
@@ -256,6 +273,7 @@ mod tests {
             );
         }
         for marker in [
+            "data-cts-main-surface-compat",
             "cts-windows-menu-bar",
             "data-cts-menu-region",
             "--cts-windows-menu-height",
@@ -276,9 +294,26 @@ mod tests {
     }
 
     #[test]
+    fn runtime_supports_current_and_legacy_main_surfaces() {
+        let current = RUNTIME_TEMPLATE
+            .find("main[data-app-shell-main-surface]")
+            .expect("current main-surface selector");
+        let legacy = RUNTIME_TEMPLATE
+            .find("main.${LEGACY_SHELL_MAIN_CLASS}")
+            .expect("legacy main-surface selector");
+        assert!(current < legacy, "current semantic marker must win");
+        assert!(!RUNTIME_TEMPLATE.contains(
+            "document.querySelector(\"main.main-surface\") || document.querySelector(\"main\")"
+        ));
+    }
+
+    #[test]
     fn verify_expression_embeds_version() {
         let expr = verify_expression("9.9.9").unwrap();
         assert!(expr.contains("\"9.9.9\""));
         assert!(expr.contains("result.pass"));
+        assert!(expr.contains("mainSurfaceMode"));
+        assert!(expr.contains("mainSurfaceCompatible"));
+        assert!(expr.contains("stageAttachedToMainSurface"));
     }
 }

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -15,6 +15,8 @@
   const ROOT_CLASS = "codex-theme-studio";
   const THEME_ATTR = "data-cts-theme";
   const SHELL_ATTR = "data-cts-shell";
+  const SHELL_MAIN_COMPAT_ATTR = "data-cts-main-surface-compat";
+  const LEGACY_SHELL_MAIN_CLASS = "main-surface";
   const WINDOWS_MENU_CLASS = "cts-windows-menu-bar";
   const WINDOWS_MENU_REGION_ATTR = "data-cts-menu-region";
   const RUNTIME_CSS = `
@@ -96,6 +98,31 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
 
   const setClass = (node, name, on) => {
     if (node.classList.contains(name) !== on) node.classList.toggle(name, on);
+  };
+
+  // Codex <= 26.715 exposed the content surface as `main.main-surface`.
+  // Codex 26.727 replaced that class with the stable
+  // `data-app-shell-main-surface` attribute and also introduced an unrelated
+  // full-window <main> before it. Prefer the current semantic marker, keep the
+  // legacy selector for old clients, and add the legacy class only as a
+  // runtime-owned compatibility shim so existing theme packages keep working.
+  const releaseShellMainCompat = (node) => {
+    if (!node?.hasAttribute(SHELL_MAIN_COMPAT_ATTR)) return;
+    node.classList.remove(LEGACY_SHELL_MAIN_CLASS);
+    node.removeAttribute(SHELL_MAIN_COMPAT_ATTR);
+  };
+
+  const resolveShellMain = () => {
+    const shellMain = document.querySelector("main[data-app-shell-main-surface]") ||
+      document.querySelector(`main.${LEGACY_SHELL_MAIN_CLASS}`);
+    for (const candidate of document.querySelectorAll(`[${SHELL_MAIN_COMPAT_ATTR}]`)) {
+      if (candidate !== shellMain) releaseShellMainCompat(candidate);
+    }
+    if (shellMain && !shellMain.classList.contains(LEGACY_SHELL_MAIN_CLASS)) {
+      shellMain.classList.add(LEGACY_SHELL_MAIN_CLASS);
+      shellMain.setAttribute(SHELL_MAIN_COMPAT_ATTR, "true");
+    }
+    return shellMain;
   };
 
   const detectShellMode = () => {
@@ -415,7 +442,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
       style.dataset.ctsStamp = STAMP;
     }
 
-    const shellMain = document.querySelector("main.main-surface") || document.querySelector("main");
+    const shellMain = resolveShellMain();
     integrateWindowsMenu(shellMain);
     const home = findHome(state?.homeSticky);
     if (state) state.homeSticky = home;
@@ -521,6 +548,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     document.querySelectorAll("[data-cts-glyph]").forEach((node) => node.removeAttribute("data-cts-glyph"));
     document.querySelectorAll("[data-cts-icon]").forEach((node) => node.removeAttribute("data-cts-icon"));
     document.querySelectorAll("[data-cts-logo]").forEach((node) => node.removeAttribute("data-cts-logo"));
+    document.querySelectorAll(`[${SHELL_MAIN_COMPAT_ATTR}]`).forEach(releaseShellMainCompat);
     document.querySelectorAll(`.${WINDOWS_MENU_CLASS}`).forEach((node) => node.classList.remove(WINDOWS_MENU_CLASS));
     document.querySelectorAll(`[${WINDOWS_MENU_REGION_ATTR}]`).forEach((node) => node.removeAttribute(WINDOWS_MENU_REGION_ATTR));
     document.getElementById(STYLE_ID)?.remove();


### PR DESCRIPTION
## Summary

- Prefer the Codex 26.727 semantic main-surface marker and retain the legacy selector as fallback.
- Add a runtime-owned compatibility class so existing theme packages continue to match unchanged CSS.
- Verify stage placement, cleanup, and CDP probing for both current and legacy shell structures.

## Validation

- npm run build
- npm test (284 passed)
- npm run lint
- cargo test --manifest-path crates/codex-theme-engine/Cargo.toml (44 passed)
- cargo test --manifest-path src-tauri/Cargo.toml --workspace (128 passed)
- Theme Studio npm run check (50 themes, current + legacy shell contracts)
