### PR TITLE
fix(themes): harden composer scroll ownership

### DIFF
--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -14,6 +14,28 @@ use crate::{Result, ENGINE_VERSION};
 /// detection, icon annotation and cleanup contract; edit it in the studio,
 /// not here.
 const RUNTIME_TEMPLATE: &str = include_str!("runtime/theme-runtime.js");
+const COMPOSER_OVERFLOW_MODULE: &str = include_str!("runtime/composer-overflow.mjs");
+
+/// Runtime-owned Composer scroll contract. Theme art may extend beyond the
+/// shell without turning it into a scroll container; only the finite-height
+/// editor root may scroll vertically. Appended after theme CSS so old packages
+/// cannot reintroduce the shell-scroll bug.
+const RUNTIME_HARDENING_CSS: &str = r#"
+html.codex-theme-studio [data-cts-composer-overflow="shell"] {
+  overflow: clip !important;
+  overflow-clip-margin: 64px !important;
+}
+
+html.codex-theme-studio [data-cts-composer-overflow="lane"] {
+  overflow: visible !important;
+}
+
+html.codex-theme-studio [data-cts-composer-overflow="editor"] {
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+  overscroll-behavior: contain !important;
+}
+"#;
 
 #[derive(Debug, Clone)]
 pub struct BuiltPayload {
@@ -40,7 +62,7 @@ pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
         .collect::<Vec<_>>()
         .join("\n");
     let css_with_assets = format!(
-        ":root.codex-theme-studio {{\n{asset_variables}\n}}\n\n{}",
+        ":root.codex-theme-studio {{\n{asset_variables}\n}}\n\n{}\n\n{RUNTIME_HARDENING_CSS}",
         theme.css
     );
     let config_json = serde_json::to_string(&theme.config)
@@ -50,15 +72,19 @@ pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
     // Fingerprint the executable packed payload, including the renderer
     // runtime. Without the runtime template, renderer-only bug fixes share the
     // old stamp and the daemon cannot distinguish them from an installed copy.
+    let runtime_template = RUNTIME_TEMPLATE.replace(
+        "__CTS_COMPOSER_OVERFLOW_HELPERS__",
+        &composer_overflow_helpers_expression(),
+    );
     let short = fingerprint(
-        RUNTIME_TEMPLATE,
+        &runtime_template,
         &css_with_assets,
         chrome_html.as_deref().unwrap_or(""),
         &config_json,
     );
     let stamp = format!("{ENGINE_VERSION}:{}:{short}", theme.config.id);
 
-    let payload = RUNTIME_TEMPLATE
+    let payload = runtime_template
         .replace("__CTS_CSS_JSON__", &js_json(&css_with_assets)?)
         .replace("__CTS_THEME_JSON__", &config_json)
         .replace(
@@ -76,6 +102,13 @@ pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
         stamp,
         payload,
     })
+}
+
+fn composer_overflow_helpers_expression() -> String {
+    let module = COMPOSER_OVERFLOW_MODULE.replace("export function ", "function ");
+    format!(
+        "(() => {{\n{module}\nreturn {{ createComposerOverflowAnnotator, selectComposerSurfaces }};\n}})()"
+    )
 }
 
 fn js_json(value: &str) -> Result<String> {
@@ -111,6 +144,8 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
   });
   document.querySelectorAll('.cts-windows-menu-bar').forEach((node) => node.classList.remove('cts-windows-menu-bar'));
   document.querySelectorAll('[data-cts-menu-region]').forEach((node) => node.removeAttribute('data-cts-menu-region'));
+  document.querySelectorAll('[data-cts-composer-overflow]').forEach((node) => node.removeAttribute('data-cts-composer-overflow'));
+  document.querySelectorAll('[data-cts-composer-mode]').forEach((node) => node.removeAttribute('data-cts-composer-mode'));
   document.documentElement?.style.removeProperty('--cts-windows-menu-height');
   document.documentElement?.style.removeProperty('--cts-windows-sidebar-padding-top');
   document.documentElement?.style.removeProperty('--cts-windows-main-padding-top');
@@ -128,6 +163,8 @@ pub const VERIFY_REMOVED_EXPRESSION: &str = r#"(() =>
   !document.documentElement.classList.contains('codex-theme-studio') &&
   !document.querySelector('.cts-windows-menu-bar') &&
   !document.querySelector('[data-cts-menu-region]') &&
+  !document.querySelector('[data-cts-composer-overflow]') &&
+  !document.querySelector('[data-cts-composer-mode]') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-menu-height') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-sidebar-padding-top') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-main-padding-top') &&
@@ -149,6 +186,7 @@ pub const CURRENT_STAMP_EXPRESSION: &str =
 /// Structural verification of an applied theme (port of `verifyExpression`).
 pub fn verify_expression(expected_version: &str) -> Result<String> {
     let version_json = js_json(expected_version)?;
+    let composer_helpers = composer_overflow_helpers_expression();
     Ok(format!(
         r#"(() => {{
     const box = (node) => {{
@@ -166,12 +204,62 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
     const mainSurfaceNode = document.querySelector('main[data-app-shell-main-surface], main.main-surface');
     const mainSurface = box(mainSurfaceNode);
     const state = window.__CODEX_THEME_STUDIO__;
-    const composer = box(document.querySelector('.composer-surface-chrome'));
+    const hostVersion = (() => {{
+      try {{
+        const value = window.electronBridge?.getSentryInitOptions?.()?.appVersion;
+        return typeof value === 'string' && /^\d+\./.test(value) ? value : null;
+      }} catch {{
+        return null;
+      }}
+    }})();
+    const hostCompatibility = hostVersion === '26.715.31251'
+      ? {{ audited: true, profile: 'composer-three-layer', composerLanePolicy: 'required' }}
+      : hostVersion === '26.715.31925'
+        ? {{ audited: true, profile: 'composer-two-or-three-layer', composerLanePolicy: 'optional' }}
+        : hostVersion === '26.727.51351'
+          ? {{ audited: true, profile: 'composer-current-multiline', composerLanePolicy: 'required' }}
+          : {{ audited: false, profile: 'capability-adaptive', composerLanePolicy: 'optional' }};
+    const {{ selectComposerSurfaces }} = {composer_helpers};
+    const composerNodes = selectComposerSurfaces(document);
+    const composerNode = composerNodes.find((node) => {{
+      const r = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return r.width > 0 && r.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+    }}) ?? composerNodes[0] ?? null;
+    const composer = box(composerNode);
+    const composerEditor = composerNode?.querySelector('[data-cts-composer-overflow="editor"]') ?? null;
+    const composerLanes = composerNode
+      ? [...composerNode.querySelectorAll('[data-cts-composer-overflow="lane"]')]
+      : [];
+    const composerMode = composerNode?.getAttribute('data-cts-composer-mode') ?? null;
+    const composerOverflow = composerNode ? {{
+      shellRole: composerNode.getAttribute('data-cts-composer-overflow'),
+      mode: composerMode,
+      shellOverflowY: getComputedStyle(composerNode).overflowY,
+      laneCount: composerLanes.length,
+      laneOverflowYs: composerLanes.map((node) => getComputedStyle(node).overflowY),
+      lanesValid: composerLanes.every((node) => getComputedStyle(node).overflowY === 'visible'),
+      lanePolicyValid: hostCompatibility.composerLanePolicy !== 'required' ||
+        composerMode === 'single-line' || composerLanes.length >= 1,
+      editorCount: composerNode.querySelectorAll('[data-cts-composer-overflow="editor"]').length,
+      editorOverflowY: composerEditor ? getComputedStyle(composerEditor).overflowY : null,
+    }} : null;
+    if (composerOverflow) {{
+      composerOverflow.modeValid = composerOverflow.mode === 'single-line' ||
+        composerOverflow.mode === 'scrolling';
+      composerOverflow.editorValid = composerOverflow.mode === 'single-line'
+        ? composerOverflow.editorCount === 0
+        : composerOverflow.mode === 'scrolling' &&
+          composerOverflow.editorCount === 1 &&
+          composerOverflow.editorOverflowY === 'auto';
+    }}
     const sidebar = box(document.querySelector('aside.app-shell-left-panel'));
     const result = {{
       installed: document.documentElement.classList.contains('codex-theme-studio'),
       themeId: document.documentElement.getAttribute('data-cts-theme'),
       version: state?.version ?? null,
+      hostVersion,
+      hostCompatibility,
       stylePresent: Boolean(document.getElementById('cts-style')),
       chromePresent: Boolean(chrome),
       chromePointerEvents: chrome ? getComputedStyle(chrome).pointerEvents : null,
@@ -180,6 +268,7 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
       mainSurfaceCompatible: Boolean(mainSurfaceNode?.classList.contains('main-surface')),
       stageAttachedToMainSurface: !stage || stage.parentElement === mainSurfaceNode,
       composer,
+      composerOverflow,
       sidebar,
       viewport: {{ width: innerWidth, height: innerHeight }},
       documentOverflow: {{
@@ -196,6 +285,12 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
       result.mainSurfaceCompatible &&
       result.stageAttachedToMainSurface &&
       Boolean(result.composer?.visible) &&
+      result.composerOverflow?.shellRole === 'shell' &&
+      result.composerOverflow?.shellOverflowY === 'clip' &&
+      result.composerOverflow?.lanesValid === true &&
+      result.composerOverflow?.lanePolicyValid === true &&
+      result.composerOverflow?.modeValid === true &&
+      result.composerOverflow?.editorValid === true &&
       Boolean(result.sidebar?.visible) &&
       !result.documentOverflow.x
     );
@@ -241,6 +336,9 @@ mod tests {
         assert!(built.payload.contains("data-cts-layer"));
         assert!(built.payload.contains("main[data-app-shell-main-surface]"));
         assert!(built.payload.contains("data-cts-main-surface-compat"));
+        assert!(built.payload.contains("createComposerOverflowAnnotator"));
+        assert!(built.payload.contains("data-cts-composer-overflow=\\\"shell\\\""));
+        assert!(built.payload.contains("overflow: clip !important"));
         assert_eq!(built.asset_count, 1);
         assert!(built.stamp.starts_with(&format!("{ENGINE_VERSION}:fixture:")));
     }
@@ -276,6 +374,8 @@ mod tests {
             "data-cts-main-surface-compat",
             "cts-windows-menu-bar",
             "data-cts-menu-region",
+            "data-cts-composer-overflow",
+            "data-cts-composer-mode",
             "--cts-windows-menu-height",
             "--cts-windows-sidebar-padding-top",
             "--cts-windows-main-padding-top",
@@ -315,5 +415,9 @@ mod tests {
         assert!(expr.contains("mainSurfaceMode"));
         assert!(expr.contains("mainSurfaceCompatible"));
         assert!(expr.contains("stageAttachedToMainSurface"));
+        assert!(expr.contains("composerOverflow"));
+        assert!(expr.contains("modeValid"));
+        assert!(expr.contains("editorValid"));
+        assert!(expr.contains("26.727.51351"));
     }
 }

--- a/crates/codex-theme-engine/src/runtime/composer-overflow.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-overflow.mjs
@@ -1,0 +1,167 @@
+// Shared Composer capability detection. These functions are serialized into
+// the renderer payload, so keep them self-contained (no module-scope reads).
+
+export function selectComposerSurfaces(root) {
+  const unique = (nodes) => [...new Set(nodes.filter(Boolean))];
+  const marked = unique(
+    [...root.querySelectorAll("[data-codex-composer]")]
+      .map((node) => node.closest?.(".composer-surface-chrome")),
+  );
+  const rooted = unique([
+    ...root.querySelectorAll("[data-codex-composer-root] .composer-surface-chrome"),
+  ]);
+  const preferred = unique([...marked, ...rooted]);
+  if (preferred.length) return preferred;
+
+  // Older renderers may not expose the stable Composer markers. Retain a
+  // capability fallback, but exclude static surfaces that contain no editor.
+  return [...root.querySelectorAll(".composer-surface-chrome")].filter((surface) =>
+    surface.querySelector(
+      '.ProseMirror[contenteditable="true"], [contenteditable="true"], textarea',
+    ));
+}
+
+export function createComposerOverflowAnnotator({
+  overflowAttribute,
+  modeAttribute,
+  readStyle,
+  viewportSignature,
+}) {
+  const cache = new WeakMap();
+  const annotatedNodes = new Set();
+  const modeNodes = new Set();
+
+  const setAttribute = (node, name, value) => {
+    if (node.getAttribute(name) !== value) node.setAttribute(name, value);
+  };
+
+  const pathMatches = (left, right) =>
+    left.length === right.length && left.every((node, index) => node === right[index]);
+
+  const declaresScrollableOverflow = (node) => {
+    const className = typeof node.className === "string" ? node.className : "";
+    return className.split(/\s+/).some((token) =>
+      /^!?overflow-y-(?:auto|scroll)$/.test(token));
+  };
+
+  const nodeSignature = (node) => {
+    const className = typeof node.className === "string" ? node.className : "";
+    return `${node.tagName || ""}\u0000${className}\u0000${node.getAttribute("style") || ""}`;
+  };
+
+  const classify = (composer, path, signature) => {
+    // Runtime roles change computed overflow through the hardening stylesheet.
+    // Clear them only when the structural signature changes, measure native
+    // capabilities, then restore before applying the guarded final diff.
+    const previousRoles = new Map();
+    for (const node of annotatedNodes) {
+      if (node === composer || composer.contains(node)) {
+        const role = node.getAttribute(overflowAttribute);
+        if (role !== null) previousRoles.set(node, role);
+        node.removeAttribute(overflowAttribute);
+      }
+    }
+    const previousMode = composer.getAttribute(modeAttribute);
+    if (previousMode !== null) composer.removeAttribute(modeAttribute);
+
+    let fallback = null;
+    let editorScrollRoot = null;
+    const nativeOverflow = new Map();
+    for (const node of path) {
+      const style = readStyle(node);
+      const scrollable = /^(auto|scroll)$/.test(style.overflowY);
+      const maxHeight = Number.parseFloat(style.maxHeight);
+      const finiteHeight = style.maxHeight !== "none" &&
+        Number.isFinite(maxHeight) && maxHeight > 0;
+      nativeOverflow.set(node, style.overflowY);
+      if (scrollable && !fallback) fallback = node;
+      if (scrollable && finiteHeight) {
+        editorScrollRoot = node;
+        break;
+      }
+    }
+    editorScrollRoot ??= fallback;
+
+    const roles = new Map([[composer, "shell"]]);
+    if (editorScrollRoot) {
+      roles.set(editorScrollRoot, "editor");
+      for (let node = editorScrollRoot.parentElement;
+        node && node !== composer;
+        node = node.parentElement) {
+        const overflowY = nativeOverflow.has(node)
+          ? nativeOverflow.get(node)
+          : readStyle(node).overflowY;
+        // A skin can mask the app's lane overflow before we measure it. Keep
+        // the app's explicit utility class as a structural signal, without
+        // treating unrelated intermediate layout wrappers as lanes.
+        if (/^(auto|scroll)$/.test(overflowY) || declaresScrollableOverflow(node)) {
+          roles.set(node, "lane");
+        }
+      }
+    }
+
+    for (const [node, role] of previousRoles) setAttribute(node, overflowAttribute, role);
+    if (previousMode !== null) setAttribute(composer, modeAttribute, previousMode);
+
+    const value = {
+      path,
+      signature,
+      roles,
+      mode: editorScrollRoot ? "scrolling" : "single-line",
+    };
+    cache.set(composer, value);
+    return value;
+  };
+
+  return (composers) => {
+    const desiredRoles = new Map();
+    const desiredModes = new Map();
+
+    for (const composer of composers) {
+      const editable = composer.querySelector(
+        '[data-codex-composer], .ProseMirror[contenteditable="true"], ' +
+        '[contenteditable="true"], textarea',
+      );
+      if (!editable) continue;
+
+      const path = [];
+      for (let node = editable; node && node !== composer; node = node.parentElement) {
+        path.push(node);
+      }
+      if (!path.length || path.at(-1)?.parentElement !== composer) continue;
+
+      const signature = `${viewportSignature()}\u0001${[composer, ...path]
+        .map(nodeSignature).join("\u0002")}`;
+      const previous = cache.get(composer);
+      const classification = previous && previous.signature === signature &&
+        pathMatches(previous.path, path)
+        ? previous
+        : classify(composer, path, signature);
+
+      for (const [node, role] of classification.roles) desiredRoles.set(node, role);
+      desiredModes.set(composer, classification.mode);
+    }
+
+    for (const node of annotatedNodes) {
+      if (!desiredRoles.has(node)) {
+        node.removeAttribute(overflowAttribute);
+        annotatedNodes.delete(node);
+      }
+    }
+    for (const [node, role] of desiredRoles) {
+      setAttribute(node, overflowAttribute, role);
+      annotatedNodes.add(node);
+    }
+
+    for (const node of modeNodes) {
+      if (!desiredModes.has(node)) {
+        node.removeAttribute(modeAttribute);
+        modeNodes.delete(node);
+      }
+    }
+    for (const [node, mode] of desiredModes) {
+      setAttribute(node, modeAttribute, mode);
+      modeNodes.add(node);
+    }
+  };
+}

--- a/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+import {
+  createComposerOverflowAnnotator,
+  selectComposerSurfaces,
+} from "./composer-overflow.mjs";
+
+const OVERFLOW_ATTR = "data-cts-composer-overflow";
+const MODE_ATTR = "data-cts-composer-mode";
+
+class FakeNode {
+  constructor(tagName, { className = "", attributes = {}, nativeStyle = {} } = {}) {
+    this.tagName = tagName.toUpperCase();
+    this.className = className;
+    this.attributes = new Map(Object.entries(attributes));
+    this.nativeStyle = { overflowY: "visible", maxHeight: "none", ...nativeStyle };
+    this.children = [];
+    this.parentElement = null;
+  }
+
+  append(child) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
+  contains(candidate) {
+    for (let node = candidate; node; node = node.parentElement) {
+      if (node === this) return true;
+    }
+    return false;
+  }
+
+  querySelector(selector) {
+    const descendants = [];
+    const visit = (node) => {
+      for (const child of node.children) {
+        descendants.push(child);
+        visit(child);
+      }
+    };
+    visit(this);
+    if (selector.includes("[data-codex-composer]")) {
+      const marked = descendants.find((node) => node.getAttribute("data-codex-composer") !== null);
+      if (marked) return marked;
+    }
+    return descendants.find((node) =>
+      node.className.split(/\s+/).includes("ProseMirror") ||
+      node.getAttribute("contenteditable") === "true" ||
+      node.tagName === "TEXTAREA") ?? null;
+  }
+}
+
+test("surface selection prefers the marked primary Composer over static cards", () => {
+  const staticCard = { querySelector: () => null };
+  const primaryComposer = { querySelector: () => ({}) };
+  const marker = { closest: () => primaryComposer };
+  const root = {
+    querySelectorAll(selector) {
+      if (selector === "[data-codex-composer]") return [marker];
+      if (selector === "[data-codex-composer-root] .composer-surface-chrome") return [];
+      if (selector === ".composer-surface-chrome") return [staticCard, primaryComposer];
+      return [];
+    },
+  };
+
+  assert.deepEqual(selectComposerSurfaces(root), [primaryComposer]);
+});
+
+test("surface selection fallback excludes surfaces without an editor", () => {
+  const staticSurface = { querySelector: () => null };
+  const editableSurface = { querySelector: () => ({}) };
+  const root = {
+    querySelectorAll(selector) {
+      if (selector === ".composer-surface-chrome") return [staticSurface, editableSurface];
+      return [];
+    },
+  };
+
+  assert.deepEqual(selectComposerSurfaces(root), [editableSurface]);
+});
+
+test("multiline roles are cleared when React reuses the nodes for single-line layout", () => {
+  const shell = new FakeNode("div", {
+    className: "composer-surface-chrome multiline",
+    nativeStyle: { overflowY: "auto" },
+  });
+  const lane = shell.append(new FakeNode("div", {
+    className: "lane multiline",
+    nativeStyle: { overflowY: "auto" },
+  }));
+  const editor = lane.append(new FakeNode("div", {
+    className: "editor multiline",
+    nativeStyle: { overflowY: "auto", maxHeight: "160px" },
+  }));
+  editor.append(new FakeNode("div", {
+    className: "ProseMirror",
+    attributes: { contenteditable: "true", "data-codex-composer": "true" },
+  }));
+
+  const readStyle = (node) => {
+    const role = node.getAttribute(OVERFLOW_ATTR);
+    if (role === "shell") return { ...node.nativeStyle, overflowY: "clip" };
+    if (role === "lane") return { ...node.nativeStyle, overflowY: "visible" };
+    if (role === "editor") return { ...node.nativeStyle, overflowY: "auto" };
+    return node.nativeStyle;
+  };
+  const annotate = createComposerOverflowAnnotator({
+    overflowAttribute: OVERFLOW_ATTR,
+    modeAttribute: MODE_ATTR,
+    readStyle,
+    viewportSignature: () => "1280x800",
+  });
+
+  annotate([shell]);
+  assert.equal(shell.getAttribute(OVERFLOW_ATTR), "shell");
+  assert.equal(shell.getAttribute(MODE_ATTR), "scrolling");
+  assert.equal(lane.getAttribute(OVERFLOW_ATTR), "lane");
+  assert.equal(editor.getAttribute(OVERFLOW_ATTR), "editor");
+
+  shell.className = "composer-surface-chrome single-line";
+  lane.className = "lane single-line";
+  editor.className = "editor single-line";
+  shell.nativeStyle = { overflowY: "visible", maxHeight: "none" };
+  lane.nativeStyle = { overflowY: "visible", maxHeight: "none" };
+  editor.nativeStyle = { overflowY: "hidden", maxHeight: "none" };
+
+  annotate([shell]);
+  assert.equal(shell.getAttribute(OVERFLOW_ATTR), "shell");
+  assert.equal(shell.getAttribute(MODE_ATTR), "single-line");
+  assert.equal(lane.getAttribute(OVERFLOW_ATTR), null);
+  assert.equal(editor.getAttribute(OVERFLOW_ATTR), null);
+  assert.equal(readStyle(editor).overflowY, "hidden");
+});
+
+test("26.727 multiline lanes remain detectable when a skin masks native overflow", () => {
+  for (const overflowY of ["visible", "hidden", "clip"]) {
+    const shell = new FakeNode("div", { className: "composer-surface-chrome" });
+    const wrapper = shell.append(new FakeNode("div", {
+      className: "grid overflow-hidden",
+      nativeStyle: { overflowY: "hidden" },
+    }));
+    const lane = wrapper.append(new FakeNode("div", {
+      className: "mb-1 flex-grow overflow-y-auto",
+      nativeStyle: { overflowY },
+    }));
+    const editor = lane.append(new FakeNode("div", {
+      className: "max-h-[25dvh] overflow-y-auto",
+      nativeStyle: { overflowY: "auto", maxHeight: "160px" },
+    }));
+    editor.append(new FakeNode("div", {
+      className: "ProseMirror",
+      attributes: { contenteditable: "true", "data-codex-composer": "true" },
+    }));
+
+    const readStyle = (node) => {
+      const role = node.getAttribute(OVERFLOW_ATTR);
+      if (role === "shell") return { ...node.nativeStyle, overflowY: "clip" };
+      if (role === "lane") return { ...node.nativeStyle, overflowY: "visible" };
+      if (role === "editor") return { ...node.nativeStyle, overflowY: "auto" };
+      return node.nativeStyle;
+    };
+    const annotate = createComposerOverflowAnnotator({
+      overflowAttribute: OVERFLOW_ATTR,
+      modeAttribute: MODE_ATTR,
+      readStyle,
+      viewportSignature: () => "1280x800",
+    });
+
+    annotate([shell]);
+    assert.equal(shell.getAttribute(MODE_ATTR), "scrolling");
+    assert.equal(lane.getAttribute(OVERFLOW_ATTR), "lane", overflowY);
+    assert.equal(readStyle(lane).overflowY, "visible", overflowY);
+    assert.equal(editor.getAttribute(OVERFLOW_ATTR), "editor", overflowY);
+    assert.equal(wrapper.getAttribute(OVERFLOW_ATTR), null, overflowY);
+  }
+});
+
+test("unchanged layout reuses its classification without remeasuring hardened styles", () => {
+  const shell = new FakeNode("div", { className: "composer-surface-chrome" });
+  const editor = shell.append(new FakeNode("div", {
+    className: "editor",
+    nativeStyle: { overflowY: "auto", maxHeight: "120px" },
+  }));
+  editor.append(new FakeNode("div", {
+    className: "ProseMirror",
+    attributes: { "data-codex-composer": "true" },
+  }));
+  let reads = 0;
+  const annotate = createComposerOverflowAnnotator({
+    overflowAttribute: OVERFLOW_ATTR,
+    modeAttribute: MODE_ATTR,
+    readStyle: (node) => {
+      reads += 1;
+      return node.nativeStyle;
+    },
+    viewportSignature: () => "1280x800",
+  });
+
+  annotate([shell]);
+  const initialReads = reads;
+  annotate([shell]);
+  assert.equal(reads, initialReads);
+});

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -19,6 +19,12 @@
   const LEGACY_SHELL_MAIN_CLASS = "main-surface";
   const WINDOWS_MENU_CLASS = "cts-windows-menu-bar";
   const WINDOWS_MENU_REGION_ATTR = "data-cts-menu-region";
+  const COMPOSER_OVERFLOW_ATTR = "data-cts-composer-overflow";
+  const COMPOSER_MODE_ATTR = "data-cts-composer-mode";
+  const {
+    createComposerOverflowAnnotator,
+    selectComposerSurfaces,
+  } = __CTS_COMPOSER_OVERFLOW_HELPERS__;
   const RUNTIME_CSS = `
 html.codex-theme-studio .cts-windows-menu-bar {
   position: absolute !important;
@@ -70,6 +76,10 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
   document.querySelectorAll("[data-cts-glyph]").forEach((node) => node.removeAttribute("data-cts-glyph"));
   document.querySelectorAll("[data-cts-icon]").forEach((node) => node.removeAttribute("data-cts-icon"));
   document.querySelectorAll("[data-cts-logo]").forEach((node) => node.removeAttribute("data-cts-logo"));
+  document.querySelectorAll(`[${COMPOSER_OVERFLOW_ATTR}]`)
+    .forEach((node) => node.removeAttribute(COMPOSER_OVERFLOW_ATTR));
+  document.querySelectorAll(`[${COMPOSER_MODE_ATTR}]`)
+    .forEach((node) => node.removeAttribute(COMPOSER_MODE_ATTR));
 
   // Split the chrome fragment into its layers: "overlay" floats above the UI
   // (fixed, z31), "stage" is scenery mounted inside main UNDER the content.
@@ -155,6 +165,16 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
   };
 
   const chromeRectCache = { left: NaN, top: NaN, width: NaN, height: NaN };
+
+  // Codex 26.715+ can reuse the same Composer nodes across single-line and
+  // multiline layouts. Measure the current native scroll capabilities without
+  // letting our own hardening roles contaminate the next classification.
+  const annotateComposerOverflow = createComposerOverflowAnnotator({
+    overflowAttribute: COMPOSER_OVERFLOW_ATTR,
+    modeAttribute: COMPOSER_MODE_ATTR,
+    readStyle: (node) => getComputedStyle(node),
+    viewportSignature: () => `${innerWidth}x${innerHeight}`,
+  });
 
   // Semantic icon annotation: CSS cannot match by text, so tag well-known
   // controls with data-cts-icon and let theme CSS attach bitmap icons.
@@ -453,6 +473,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     if (shellMain) setClass(shellMain, "cts-home-shell", Boolean(home));
 
     annotateIcons();
+    annotateComposerOverflow(selectComposerSurfaces(document));
 
     const fillTexts = (rootNode) => {
       for (const node of rootNode.querySelectorAll("[data-cts-text]")) {
@@ -551,6 +572,10 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     document.querySelectorAll(`[${SHELL_MAIN_COMPAT_ATTR}]`).forEach(releaseShellMainCompat);
     document.querySelectorAll(`.${WINDOWS_MENU_CLASS}`).forEach((node) => node.classList.remove(WINDOWS_MENU_CLASS));
     document.querySelectorAll(`[${WINDOWS_MENU_REGION_ATTR}]`).forEach((node) => node.removeAttribute(WINDOWS_MENU_REGION_ATTR));
+    document.querySelectorAll(`[${COMPOSER_OVERFLOW_ATTR}]`)
+      .forEach((node) => node.removeAttribute(COMPOSER_OVERFLOW_ATTR));
+    document.querySelectorAll(`[${COMPOSER_MODE_ATTR}]`)
+      .forEach((node) => node.removeAttribute(COMPOSER_MODE_ATTR));
     document.getElementById(STYLE_ID)?.remove();
     document.getElementById(CHROME_ID)?.remove();
     document.getElementById(STAGE_ID)?.remove();


### PR DESCRIPTION
## Summary

- port the mature capability-based Composer overflow classifier into the Manager renderer payload
- keep the decorative shell clipped, intermediate lanes visible, and the finite-height editor as the sole vertical scroll owner
- make hot-switch cleanup and structural verification cover current Codex 26.727 plus the audited 26.715 layouts
- add focused regressions for primary-surface selection, React node reuse, masked overflow utility classes, and cached re-annotation

## Root cause

Codex 26.727 can expose nested overflow-y-auto containers around the Composer. Theme ornaments make the outer shell a spurious scroll owner even when its content only exceeds the client height by a few pixels. The old local hardening prototype was version-shaped and had no direct behavior tests.

## Validation

- npm run check
- npm run lint
- npm test (289 passed)
- npm run build
- cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml --workspace (128 passed)
- cargo test --manifest-path crates/codex-theme-engine/Cargo.toml --all-targets (44 passed)
- cargo test --manifest-path crates/codex-mac-engine/Cargo.toml --all-targets (24 passed)
- cargo test --manifest-path crates/codex-win-engine/Cargo.toml --all-targets (82 passed)
- codex review --uncommitted: no actionable findings