### PR TITLE
fix(themes): invalidate composer overflow cache

### DIFF
--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -337,6 +337,7 @@ mod tests {
         assert!(built.payload.contains("main[data-app-shell-main-surface]"));
         assert!(built.payload.contains("data-cts-main-surface-compat"));
         assert!(built.payload.contains("createComposerOverflowAnnotator"));
+        assert!(built.payload.contains("annotateComposerOverflow.invalidate()"));
         assert!(built.payload.contains("data-cts-composer-overflow=\\\"shell\\\""));
         assert!(built.payload.contains("overflow: clip !important"));
         assert_eq!(built.asset_count, 1);

--- a/crates/codex-theme-engine/src/runtime/composer-overflow.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-overflow.mjs
@@ -27,7 +27,7 @@ export function createComposerOverflowAnnotator({
   readStyle,
   viewportSignature,
 }) {
-  const cache = new WeakMap();
+  let cache = new WeakMap();
   const annotatedNodes = new Set();
   const modeNodes = new Set();
 
@@ -113,7 +113,7 @@ export function createComposerOverflowAnnotator({
     return value;
   };
 
-  return (composers) => {
+  const annotate = (composers) => {
     const desiredRoles = new Map();
     const desiredModes = new Map();
 
@@ -164,4 +164,14 @@ export function createComposerOverflowAnnotator({
       modeNodes.add(node);
     }
   };
+
+  // Computed overflow can change without altering any node in the Composer
+  // path (for example through an ancestor class, stylesheet, or media query).
+  // Let the runtime discard structural classifications when those external
+  // style inputs change while retaining the cache for ordinary ensure passes.
+  annotate.invalidate = () => {
+    cache = new WeakMap();
+  };
+
+  return annotate;
 }

--- a/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
@@ -216,3 +216,42 @@ test("unchanged layout reuses its classification without remeasuring hardened st
   annotate([shell]);
   assert.equal(reads, initialReads);
 });
+
+test("external style invalidation remeasures an unchanged Composer path", () => {
+  const shell = new FakeNode("div", { className: "composer-surface-chrome" });
+  const editor = shell.append(new FakeNode("div", {
+    className: "editor",
+    nativeStyle: { overflowY: "visible", maxHeight: "none" },
+  }));
+  editor.append(new FakeNode("div", {
+    className: "ProseMirror",
+    attributes: { "data-codex-composer": "true" },
+  }));
+  let reads = 0;
+  const annotate = createComposerOverflowAnnotator({
+    overflowAttribute: OVERFLOW_ATTR,
+    modeAttribute: MODE_ATTR,
+    readStyle: (node) => {
+      reads += 1;
+      return node.nativeStyle;
+    },
+    viewportSignature: () => "1280x800",
+  });
+
+  annotate([shell]);
+  assert.equal(shell.getAttribute(MODE_ATTR), "single-line");
+  const initialReads = reads;
+
+  // Simulate a stylesheet or ancestor change: computed style changes while
+  // the Composer path, viewport, classes, and inline styles remain identical.
+  editor.nativeStyle = { overflowY: "auto", maxHeight: "160px" };
+  annotate([shell]);
+  assert.equal(reads, initialReads);
+  assert.equal(shell.getAttribute(MODE_ATTR), "single-line");
+
+  annotate.invalidate();
+  annotate([shell]);
+  assert.ok(reads > initialReads);
+  assert.equal(shell.getAttribute(MODE_ATTR), "scrolling");
+  assert.equal(editor.getAttribute(OVERFLOW_ATTR), "editor");
+});

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -604,16 +604,37 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
   // Ignore mutations we caused ourselves (chrome text/position, clock ticks,
   // root inline vars) — they must never re-trigger ensure().
   const chromeNode = () => document.getElementById(CHROME_ID);
+  const externalRootStyleSignature = () => Array.from(document.documentElement.style)
+    .filter((name) => !appliedVars.includes(name))
+    .sort()
+    .map((name) => `${name}:${document.documentElement.style.getPropertyValue(name)}!${
+      document.documentElement.style.getPropertyPriority(name)}`)
+    .join(";");
+  const styleMutationTouchesComposer = (target) => Boolean(
+    target.closest?.(".composer-surface-chrome") ||
+    target.querySelector?.(
+      '[data-codex-composer], .ProseMirror[contenteditable="true"], ' +
+      '[contenteditable="true"], textarea',
+    )
+  );
+  let rootStyleSignature = externalRootStyleSignature();
   const observer = new MutationObserver((mutations) => {
     const chrome = chromeNode();
     for (const mutation of mutations) {
       const target = mutation.target;
       if (chrome && (target === chrome || chrome.contains(target))) continue;
-      if (target === document.documentElement && mutation.type === "attributes" && mutation.attributeName === "style") continue;
+      if (target === document.documentElement && mutation.type === "attributes" && mutation.attributeName === "style") {
+        const nextRootStyleSignature = externalRootStyleSignature();
+        if (nextRootStyleSignature === rootStyleSignature) continue;
+        rootStyleSignature = nextRootStyleSignature;
+      }
+      if (mutation.type === "attributes" && mutation.attributeName === "style" &&
+        target !== document.documentElement && !styleMutationTouchesComposer(target)) continue;
       if (mutation.type === "childList") {
         repairProjectGlyphs(target);
         for (const added of mutation.addedNodes) repairProjectGlyphs(added);
       }
+      annotateComposerOverflow.invalidate();
       scheduleEnsure();
       return;
     }
@@ -622,9 +643,12 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     childList: true,
     subtree: true,
     attributes: true,
-    attributeFilter: ["class", "data-theme", "data-appearance", "data-color-mode"],
+    attributeFilter: ["class", "style", "data-theme", "data-appearance", "data-color-mode"],
   });
-  const timer = setInterval(ensure, 4000);
+  const timer = setInterval(() => {
+    annotateComposerOverflow.invalidate();
+    ensure();
+  }, 4000);
   const resizeHandler = scheduleEnsure;
   window.addEventListener("resize", resizeHandler, { passive: true });
 
@@ -643,7 +667,10 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
   let mediaHandler = null;
   try {
     mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    mediaHandler = () => scheduleEnsure();
+    mediaHandler = () => {
+      annotateComposerOverflow.invalidate();
+      scheduleEnsure();
+    };
     mediaQuery.addEventListener("change", mediaHandler);
   } catch {}
 


### PR DESCRIPTION
## Summary

- add explicit Composer overflow classification cache invalidation
- invalidate for relevant DOM and inline-style mutations, external root style changes, appearance media changes, and periodic CSSOM fallback checks
- add a regression test for computed-style changes with an otherwise unchanged Composer path

Follow-up to the Codex review on #248: https://github.com/Wangnov/Codex-App-Manager/pull/248#discussion_r3698037239

## Validation

- `npm run check`
- `npm run lint`
- `npm test` (290 passed)
- `npm run build`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace` (128 passed)
- `cargo test --manifest-path crates/codex-theme-engine/Cargo.toml --all-targets` (44 passed, 4 ignored live-only tests)
- `cargo test --manifest-path crates/codex-mac-engine/Cargo.toml --all-targets` (24 passed)
- `cargo test --manifest-path crates/codex-win-engine/Cargo.toml --all-targets` (82 passed)
- `codex review --uncommitted` (no actionable findings)