### PR TITLE
chore(release): bump version to 0.5.2

### DIFF
--- a/docs/releases/v0.5.2.md
+++ b/docs/releases/v0.5.2.md
@@ -1,0 +1,55 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 新增从 GitHub Release 选择历史 Codex 版本，以及对 DMG、ZIP、MSIX 离线安装包的原生校验与降级安装。
+> Adds historical Codex selection from GitHub Releases plus native verification and downgrade installs for offline DMG, ZIP, and MSIX packages.
+
+## ✨ 亮点 · Highlights
+
+- **选择安装版本**：直接读取 `Wangnov/codex-app-mirror` 的分页 GitHub Release 历史，按当前平台与架构列出可安装版本；确认页会明确展示版本、安装包、来源与更新策略，再执行升级、降级或全新安装。
+  Choose an install version: browse the paginated `Wangnov/codex-app-mirror` GitHub Release history filtered for the current platform and architecture, then confirm the exact version, asset, source, and update policy before upgrading, downgrading, or installing fresh.
+
+- **安装离线 Release 包**：可以选择已经从 GitHub Release 下载到本机的 macOS `.dmg` / `.zip` 或 Windows `.msix`。离线路径不请求 GitHub，也不使用 Sparkle；管理器会锁定确认时的 SHA-256，并在安装前再次核对同一文件，同时验证平台签名、包身份、架构与版本。
+  Install offline Release packages: select a macOS `.dmg` / `.zip` or Windows `.msix` already downloaded from GitHub Releases. The offline path makes no GitHub request and does not use Sparkle; the manager pins the SHA-256 shown at confirmation, rechecks the same file before installation, and verifies its platform signature, package identity, architecture, and version.
+
+- **真实降级与更新控制**：历史安装可同时选择是否阻止 Codex 自更新。macOS 通过原子替换与健康检查完成安装，失败自动回滚；Windows 支持 MSIX 强制降级，并在系统无法部署 MSIX 时使用已验证的便携安装回退。
+  Real downgrades with update control: historical installs can also keep Codex self-updates blocked. macOS uses an atomic swap with health checks and automatic rollback, while Windows supports forced MSIX downgrades and a verified portable fallback when MSIX deployment is unavailable.
+
+## 🐛 修复 · Fixes
+
+- **安装中断后可安全恢复**：安装事务会在破坏性重命名和回滚前持久记录状态，并把所选自更新策略与最终安装结果一起恢复，避免崩溃或断电后误判已安装版本、丢失回滚材料或留下错误策略。
+  Recover safely after interruption: install transactions now persist state before destructive renames and rollback, and recover the selected self-update policy from the final on-disk verdict, avoiding false success, lost rollback material, or the wrong policy after a crash or power loss.
+
+- **暂停下载锁定原目标**：恢复普通更新或历史版本下载时会继续用户最初确认的精确版本、构建、安装路径和 Windows 安装方式；即使后台版本列表已刷新，也不会静默改装成新的最新版。
+  Paused downloads retain the confirmed target: resuming either a normal update or a historical install keeps the exact version, build, install path, and Windows route originally approved, even if the latest catalog changes in the meantime.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64 0.23.0",
  "codex-mac-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.5.1"
+version = "0.5.2"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump Codex App Manager from 0.5.1 to 0.5.2 across all required manifests and lockfiles
- add bilingual release notes for historical GitHub Release selection and offline DMG, ZIP, and MSIX installs
- preserve the template installation, signing, privacy, checksum, Homebrew, and mirror guidance

## Validation

- npm run check
- npm run lint
- npm test (31 files, 325 tests)
- npm run build
- cargo test --locked --manifest-path src-tauri/Cargo.toml --lib (163 tests)
- version-position and fixed release-note section checks
- git diff --check

Feature implementation: #257