### PR TITLE
fix: restore latest Codex theme try-on and surface updates

### DIFF
--- a/crates/codex-theme-engine/src/native_hot.rs
+++ b/crates/codex-theme-engine/src/native_hot.rs
@@ -12,10 +12,12 @@
 //! dedupes into the live module graph) and cache the functions on `window`.
 //!
 //! Discovery is version-adapted: 26.707 keeps the eager loaded-chunk scan,
-//! while 26.715 follows the Vite dependency manifest to its lazy
-//! `setting-storage-*` chunk. A version hint only controls probe order; every
-//! adapter still proves the module structurally before it is used, so a stale
-//! installed-version cache cannot select an incompatible implementation.
+//! 26.715 follows the Vite dependency manifest to its lazy
+//! `setting-storage-*` chunk, and 26.831.21537+ accepts the full ASCII
+//! JavaScript identifier shape after Rolldown first minified the write wrapper
+//! to `$D`. A version hint only controls probe order; every adapter still proves
+//! the module structurally before it is used, so a stale installed-version
+//! cache cannot select an incompatible implementation.
 
 use serde_json::Value;
 
@@ -42,6 +44,7 @@ pub const SETTING_KEYS: [&str; 5] = [
 enum SettingsAdapter {
     V26_707,
     V26_715,
+    V26_831_21537,
 }
 
 impl SettingsAdapter {
@@ -49,17 +52,30 @@ impl SettingsAdapter {
         match self {
             Self::V26_707 => "26.707",
             Self::V26_715 => "26.715",
+            Self::V26_831_21537 => "26.831.21537+",
         }
     }
 }
 
+// Mirror package comparison pins the boundary: 26.831.20005 still emitted
+// `nO`/`tO`, while the next published build, 26.831.21537, emitted `$D`/`QD`.
+const FULL_JS_IDENTIFIER_MIN_VERSION: [u32; 3] = [26, 831, 21537];
+
+fn version_triplet(version: &str) -> Option<[u32; 3]> {
+    let mut parts = version.trim().split('.');
+    Some([
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+    ])
+}
+
 fn preferred_adapter(version_hint: Option<&str>) -> Option<SettingsAdapter> {
-    let train = version_hint?
-        .trim()
-        .split('.')
-        .nth(1)?
-        .parse::<u32>()
-        .ok()?;
+    let version = version_triplet(version_hint?)?;
+    if version >= FULL_JS_IDENTIFIER_MIN_VERSION {
+        return Some(SettingsAdapter::V26_831_21537);
+    }
+    let train = version[1];
     match train {
         707..=714 => Some(SettingsAdapter::V26_707),
         715.. => Some(SettingsAdapter::V26_715),
@@ -67,12 +83,23 @@ fn preferred_adapter(version_hint: Option<&str>) -> Option<SettingsAdapter> {
     }
 }
 
-fn adapter_order(version_hint: Option<&str>) -> [SettingsAdapter; 2] {
+fn adapter_order(version_hint: Option<&str>) -> [SettingsAdapter; 3] {
     match preferred_adapter(version_hint) {
-        Some(SettingsAdapter::V26_707) => [SettingsAdapter::V26_707, SettingsAdapter::V26_715],
-        Some(SettingsAdapter::V26_715) | None => {
-            [SettingsAdapter::V26_715, SettingsAdapter::V26_707]
-        }
+        Some(SettingsAdapter::V26_707) => [
+            SettingsAdapter::V26_707,
+            SettingsAdapter::V26_715,
+            SettingsAdapter::V26_831_21537,
+        ],
+        Some(SettingsAdapter::V26_715) => [
+            SettingsAdapter::V26_715,
+            SettingsAdapter::V26_707,
+            SettingsAdapter::V26_831_21537,
+        ],
+        Some(SettingsAdapter::V26_831_21537) | None => [
+            SettingsAdapter::V26_831_21537,
+            SettingsAdapter::V26_715,
+            SettingsAdapter::V26_707,
+        ],
     }
 }
 
@@ -92,15 +119,20 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
   }
   const preferred = "__CAM_PREFERRED_ADAPTER__";
   const adapters = preferred === "26.707"
-    ? ["26.707", "26.715"]
-    : ["26.715", "26.707"];
+    ? ["26.707", "26.715", "26.831.21537+"]
+    : preferred === "26.715"
+      ? ["26.715", "26.707", "26.831.21537+"]
+      : ["26.831.21537+", "26.715", "26.707"];
   const loadedUrls = [...new Set([
     ...performance.getEntriesByType("resource").map((r) => r.name),
     ...[...document.querySelectorAll("script[src]")].map((el) => el.src),
     ...[...document.querySelectorAll('link[rel="modulepreload"]')].map((el) => el.href),
   ])].filter((u) => u.includes(".js"));
-  const writeRe = /async function (\w+)\(e,t\)\{await (\w+)\([`'"]set-setting[`'"],\{params:\{key:e\.key,value:t\}\}\)\}/;
-  const readRe = /async function (\w+)\(e\)\{return\(await (\w+)\([`'"]get-setting[`'"],\{params:\{key:e\.key\}\}\)\)\.value\?\?e\.default\}/;
+  const legacyWriteRe = /async function (\w+)\(e,t\)\{await (\w+)\([`'"]set-setting[`'"],\{params:\{key:e\.key,value:t\}\}\)\}/;
+  const legacyReadRe = /async function (\w+)\(e\)\{return\(await (\w+)\([`'"]get-setting[`'"],\{params:\{key:e\.key\}\}\)\)\.value\?\?e\.default\}/;
+  const modernWriteRe = /async function ([$A-Za-z_][$A-Za-z0-9_]*)\(e,t\)\{await ([$A-Za-z_][$A-Za-z0-9_]*)\([`'"]set-setting[`'"],\{params:\{key:e\.key,value:t\}\}\)\}/;
+  const modernReadRe = /async function ([$A-Za-z_][$A-Za-z0-9_]*)\(e\)\{return\(await ([$A-Za-z_][$A-Za-z0-9_]*)\([`'"]get-setting[`'"],\{params:\{key:e\.key\}\}\)\)\.value\?\?e\.default\}/;
+  const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const fetched = new Map();
   const checked = new Set();
   const fetchText = async (url) => {
@@ -132,6 +164,10 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
     return [...candidates];
   };
   const resolveModule = async (adapter, candidates) => {
+    const modern = adapter === "26.831.21537+";
+    const writeRe = modern ? modernWriteRe : legacyWriteRe;
+    const readRe = modern ? modernReadRe : legacyReadRe;
+    const exportIdentifier = modern ? "[$A-Za-z_][$A-Za-z0-9_]*" : "\\w+";
     for (const url of candidates) {
       const text = await fetchText(url);
       if (text == null || !text.includes("set-setting")) continue;
@@ -139,7 +175,10 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
       const readMatch = text.match(readRe);
       if (!writeMatch || !readMatch) continue;
       const aliasOf = (name) => {
-        const match = text.match(new RegExp("\\b" + name + " as (\\w+)"));
+        const match = text.match(new RegExp(
+          "(?:^|[^$A-Za-z0-9_])" + escapeRegExp(name) +
+            " as (" + exportIdentifier + ")"
+        ));
         return match ? match[1] : null;
       };
       const writeAlias = aliasOf(writeMatch[1]);
@@ -403,15 +442,19 @@ mod tests {
 
     #[test]
     fn discovery_script_carries_the_known_minified_shapes() {
-        // The wrapper shapes measured in Codex 26.707.91948. The regexes live
-        // in page-side JS; here we pin the load-bearing fragments so an
-        // accidental edit of ENSURE_API_JS fails loudly.
+        // The legacy wrapper shape was measured in Codex 26.707.91948. The
+        // modern identifier shape was first observed in 26.831.21537, whose
+        // write wrapper is `$D` and export alias is `ezt`. The regexes live in
+        // page-side JS; pin the load-bearing fragments so an accidental edit
+        // of ENSURE_API_JS fails loudly.
         for fragment in [
             r"async function (\w+)\(e,t\)\{await (\w+)\(",
+            r"async function ([$A-Za-z_][$A-Za-z0-9_]*)\(e,t\)",
             "set-setting",
             "get-setting",
             "__camThemeSettingsV1",
             "modulepreload",
+            "escapeRegExp(name)",
             "await import(url)",
         ] {
             assert!(
@@ -425,27 +468,65 @@ mod tests {
     fn adapter_order_tracks_supported_codex_trains() {
         assert_eq!(
             adapter_order(Some("26.707.9981.0")),
-            [SettingsAdapter::V26_707, SettingsAdapter::V26_715]
+            [
+                SettingsAdapter::V26_707,
+                SettingsAdapter::V26_715,
+                SettingsAdapter::V26_831_21537,
+            ]
         );
         assert_eq!(
             adapter_order(Some("26.715.2305.0")),
-            [SettingsAdapter::V26_715, SettingsAdapter::V26_707]
+            [
+                SettingsAdapter::V26_715,
+                SettingsAdapter::V26_707,
+                SettingsAdapter::V26_831_21537,
+            ]
         );
+    }
+
+    #[test]
+    fn full_identifier_adapter_starts_at_first_observed_codex_build() {
+        for previous in ["26.831.11858", "26.831.20005"] {
+            assert_eq!(
+                preferred_adapter(Some(previous)),
+                Some(SettingsAdapter::V26_715),
+                "{previous} must stay on the pre-boundary adapter"
+            );
+        }
+        for current_or_newer in ["26.831.21537", "26.831.21537.0", "26.832.1"] {
+            assert_eq!(
+                preferred_adapter(Some(current_or_newer)),
+                Some(SettingsAdapter::V26_831_21537),
+                "{current_or_newer} must accept full JS identifiers"
+            );
+        }
     }
 
     #[test]
     fn unknown_or_new_version_probes_latest_adapter_first() {
         assert_eq!(
             adapter_order(Some("unexpected")),
-            [SettingsAdapter::V26_715, SettingsAdapter::V26_707]
+            [
+                SettingsAdapter::V26_831_21537,
+                SettingsAdapter::V26_715,
+                SettingsAdapter::V26_707,
+            ]
         );
         assert_eq!(
             adapter_order(Some("26.706.1")),
-            [SettingsAdapter::V26_715, SettingsAdapter::V26_707]
+            [
+                SettingsAdapter::V26_831_21537,
+                SettingsAdapter::V26_715,
+                SettingsAdapter::V26_707,
+            ]
         );
         assert_eq!(
             adapter_order(None),
-            [SettingsAdapter::V26_715, SettingsAdapter::V26_707]
+            [
+                SettingsAdapter::V26_831_21537,
+                SettingsAdapter::V26_715,
+                SettingsAdapter::V26_707,
+            ]
         );
     }
 
@@ -453,10 +534,13 @@ mod tests {
     fn discovery_script_embeds_versioned_probe_order_and_lazy_715_chunk() {
         let legacy = ensure_api_expression(Some("26.707.9981.0"));
         let current = ensure_api_expression(Some("26.715.2305.0"));
+        let modern = ensure_api_expression(Some("26.831.21537"));
         assert!(legacy.contains(r#"const preferred = "26.707""#));
         assert!(current.contains(r#"const preferred = "26.715""#));
+        assert!(modern.contains(r#"const preferred = "26.831.21537+""#));
         assert!(current.contains("setting-storage-"));
-        assert!(current.contains(r#"["26.715", "26.707"]"#));
+        assert!(current.contains(r#"["26.715", "26.707", "26.831.21537+"]"#));
+        assert!(modern.contains(r#"["26.831.21537+", "26.715", "26.707"]"#));
         assert!(!current.contains("response.ok"));
     }
 }

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,6 +1,6 @@
 # Privacy policy · 隐私政策
 
-Effective date / 生效日期：2026-07-14
+Effective date / 生效日期：2026-09-02
 
 This policy applies to Codex App Manager, its public website, and the download
 router maintained by this repository. Third-party services selected or contacted
@@ -31,9 +31,11 @@ by the user remain subject to their own privacy policies.
 Network requests provide update, download, and verification features; they are
 not used for telemetry:
 
-- **Manager self-update:** the current version checks only when the user selects
-  “Check for manager updates” on the About screen. Download, installation, and
-  restart require a separate user confirmation.
+- **Manager self-update:** when “Check for updates on startup” is enabled (the
+  default), the Manager checks its signed updater feed once after Home loads and
+  shows an in-app banner only when a newer Manager release is available. Users
+  can disable this startup request in Settings or check manually from About.
+  Download, installation, and restart require a separate user confirmation.
 - **Codex update checks:** by default, the Manager checks Codex on the Home
   screen at startup and periodically while the Manager remains open. Users can
   independently disable startup and periodic checks and adjust the interval.
@@ -48,8 +50,9 @@ not used for telemetry:
 
 网络请求只用于更新、下载与校验，不用于遥测：
 
-- **Manager 自身更新：**当前版本只有在用户进入“关于”并点击“检查管理器更新”时才会检查；
-  下载、安装与重启还需要用户再次确认。
+- **Manager 自身更新：**启用“启动时自动检查更新”（默认开启）时，Manager 会在主界面加载后
+  检查一次签名更新源，并且只在存在新版 Manager 时显示应用内横幅。用户可在设置中关闭这次
+  启动请求，也可从“关于”手动检查；下载、安装与重启仍需要用户再次确认。
 - **Codex 更新检查：**默认在主界面启动时检查，并在 Manager 保持打开时按设置周期检查。
   用户可以分别关闭启动检查和定时检查，也可调整间隔。
 - **安装、更新与校验：**用户主动发起操作后，应用会访问所选镜像、OpenAI 官方源、GitHub
@@ -127,13 +130,13 @@ scope.
 
 ## Contact and user choices · 联系方式与用户选择
 
-Users can disable Codex startup/periodic checks, choose an update source and
-proxy, and decide whether to install a Manager update. Report privacy or
+Users can disable startup and periodic update checks, choose an update source
+and proxy, and decide whether to install a Manager update. Report privacy or
 security concerns through [GitHub Issues](https://github.com/Wangnov/Codex-App-Manager/issues).
 Never post tokens, passwords, private keys, complete presigned URLs, or other
 secrets publicly.
 
-用户可以关闭 Codex 启动/定时检查、选择更新源与代理，并决定是否安装 Manager 更新。
+用户可以关闭启动/定时更新检查、选择更新源与代理，并决定是否安装 Manager 更新。
 隐私或安全问题请通过 [GitHub Issues](https://github.com/Wangnov/Codex-App-Manager/issues)
 报告；请勿公开粘贴 token、密码、私钥、完整预签名 URL 或其他秘密。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2209,9 +2209,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
-      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2243,9 +2243,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2263,11 +2263,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -2648,9 +2648,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.394",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz",
-      "integrity": "sha512-Wmt2Gm0o8JWBuGgmc4XZ0u9s1RaCRqhxP47phplmfg04+qypTUurpeJGP45A7Fhv7jdrrVH44PLlR9qXo37cVQ==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4606,9 +4606,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5743,9 +5743,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,7 @@ use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_updater::UpdaterExt;
 
 use crate::app::atomic_file;
-use crate::app::config_health::ConfigHealth;
+use crate::app::config_health::{ConfigHealth, ConfigStatus, StoreLoadHealth};
 use crate::app::diagnostics::Diagnostics;
 use crate::app::disk::available_space;
 use crate::app::install_tx::SelfUpdatePolicyTransition;
@@ -445,6 +445,12 @@ fn manager_update_matches_confirmation(
     latest_version == expected_version.trim() && current_version == expected_current_version.trim()
 }
 
+fn manager_update_or_stale<T>(update: Option<T>) -> Result<T, AppError> {
+    update.ok_or_else(|| {
+        AppError::StaleExpectation("管理器更新已不可用，请重新检查后再确认。".to_string())
+    })
+}
+
 #[tauri::command]
 pub async fn manager_check_update(
     app: AppHandle,
@@ -472,11 +478,12 @@ pub async fn manager_install_update(
     let updater = manager_updater_builder(&app)?
         .build()
         .map_err(|e| AppError::Engine(format!("build manager updater: {e}")))?;
-    let update = updater
-        .check()
-        .await
-        .map_err(|e| AppError::Engine(format!("check manager update before install: {e}")))?
-        .ok_or_else(|| AppError::Engine("No manager update is available.".to_string()))?;
+    let update = manager_update_or_stale(
+        updater
+            .check()
+            .await
+            .map_err(|e| AppError::Engine(format!("check manager update before install: {e}")))?,
+    )?;
     if !manager_update_matches_confirmation(
         &update.version,
         &update.current_version,
@@ -1676,6 +1683,37 @@ pub async fn win_stage_update(
 #[tauri::command]
 pub fn get_settings(state: State<'_, ManagerState>) -> Result<PersistedAppSettings, CommandError> {
     let mut settings = PersistedAppSettings::load();
+    normalize_settings_for_target(&mut settings, &state.target);
+    Ok(settings)
+}
+
+fn settings_or_strict_error(
+    settings: PersistedAppSettings,
+    health: StoreLoadHealth,
+) -> Result<PersistedAppSettings, AppError> {
+    // `detail` also carries forward-schema warnings. In that case fields which
+    // controlled automatic networking may have defaulted during downgrade, so
+    // a syntactically readable file is still not authoritative.
+    if health.status != ConfigStatus::Ok
+        || health.detail.is_some()
+        || health.unknown_source.is_some()
+    {
+        return Err(AppError::Internal(format!(
+            "无法可靠读取自动更新设置：{}",
+            health.detail.as_deref().unwrap_or("设置存储状态异常")
+        )));
+    }
+    Ok(settings)
+}
+
+/// Read settings for an automatic network check. Unlike `get_settings`, this
+/// refuses recovered/default values when the on-disk preference is uncertain.
+#[tauri::command]
+pub fn get_settings_strict(
+    state: State<'_, ManagerState>,
+) -> Result<PersistedAppSettings, CommandError> {
+    let (settings, health) = PersistedAppSettings::load_with_health();
+    let mut settings = settings_or_strict_error(settings, health)?;
     normalize_settings_for_target(&mut settings, &state.target);
     Ok(settings)
 }
@@ -3202,12 +3240,14 @@ pub async fn win_uninstall(
 mod tests {
     use super::{
         install_root_from_picked_dir, invalidate_retained_pause_if_stale,
-        manager_update_matches_confirmation, normalize_windows_source_base,
-        record_macos_policy_install_state, record_windows_policy_install_state,
+        manager_update_matches_confirmation, manager_update_or_stale,
+        normalize_windows_source_base, record_macos_policy_install_state,
+        record_windows_policy_install_state, settings_or_strict_error,
         validate_historical_architecture_with_compatibility, validate_install_root_path,
         validated_custom_proxy_for_settings, HistoricalPolicyInstallState,
         INSTALL_LOCATION_PROBE_PREFIX,
     };
+    use crate::app::config_health::StoreLoadHealth;
     use crate::app::mac_update::HistoricalMacEvidence;
     use crate::app::op_phase::OperationPhase;
     use crate::app::oplock::{OperationKind, OperationManager};
@@ -3412,6 +3452,29 @@ mod tests {
         assert!(!manager_update_matches_confirmation(
             "0.2.1", "0.2.1", "0.2.1", "0.2.0"
         ));
+        assert!(matches!(
+            manager_update_or_stale::<()>(None),
+            Err(AppError::StaleExpectation(_))
+        ));
+    }
+
+    #[test]
+    fn automatic_manager_check_rejects_uncertain_settings() {
+        let settings = crate::app::settings_store::AppSettings::default();
+        assert!(settings_or_strict_error(settings.clone(), StoreLoadHealth::ok()).is_ok());
+        assert!(settings_or_strict_error(
+            settings.clone(),
+            StoreLoadHealth::corrupt("settings.json unavailable".to_string())
+        )
+        .is_err());
+
+        let mut newer_schema = StoreLoadHealth::ok();
+        newer_schema.detail = Some("settings schema is newer than supported".to_string());
+        assert!(settings_or_strict_error(settings.clone(), newer_schema).is_err());
+
+        let mut unknown_source = StoreLoadHealth::ok();
+        unknown_source.unknown_source = Some("future-source".to_string());
+        assert!(settings_or_strict_error(settings, unknown_source).is_err());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -754,6 +754,7 @@ pub fn run() {
             commands::manager_check_update,
             commands::manager_install_update,
             commands::get_settings,
+            commands::get_settings_strict,
             commands::set_settings,
             commands::get_config_health,
             commands::restore_config_backup,

--- a/src/app/ManagerUpdatePrompt.test.tsx
+++ b/src/app/ManagerUpdatePrompt.test.tsx
@@ -1,0 +1,268 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  managerApi,
+  type ManagerUpdateAvailable,
+  type ManagerUpdateCheck,
+} from "../services/managerApi";
+import { DEFAULT_SETTINGS } from "../shared/types";
+import { I18nProvider } from "./i18n";
+import {
+  ManagerUpdatePrompt,
+  useManagerUpdatePrompt,
+} from "./ManagerUpdatePrompt";
+
+vi.mock("../services/managerApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../services/managerApi")>();
+  return {
+    ...actual,
+    managerApi: {
+      getSettingsStrict: vi.fn(),
+      checkManagerUpdate: vi.fn(),
+    },
+  };
+});
+
+const api = vi.mocked(managerApi);
+
+function available(
+  overrides: Partial<ManagerUpdateAvailable> = {},
+): ManagerUpdateAvailable {
+  return {
+    kind: "available",
+    version: "0.5.3",
+    currentVersion: "0.5.2",
+    installAndRelaunch: vi.fn().mockResolvedValue(undefined),
+    discard: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function PromptHost({ visible = true }: { visible?: boolean }) {
+  const controller = useManagerUpdatePrompt();
+  return visible ? <ManagerUpdatePrompt {...controller} /> : null;
+}
+
+function promptTree(visible = true) {
+  return (
+    <I18nProvider>
+      <PromptHost visible={visible} />
+    </I18nProvider>
+  );
+}
+
+function renderPrompt() {
+  return render(promptTree());
+}
+
+describe("ManagerUpdatePrompt", () => {
+  beforeEach(() => {
+    localStorage.setItem("cam.lang", "zh-CN");
+    api.getSettingsStrict.mockReset();
+    api.getSettingsStrict.mockResolvedValue(DEFAULT_SETTINGS);
+    api.checkManagerUpdate.mockReset();
+  });
+
+  it("quietly checks on startup and stays hidden when no update is available", async () => {
+    api.checkManagerUpdate.mockResolvedValue({ kind: "none" });
+
+    const { container } = renderPrompt();
+
+    await waitFor(() =>
+      expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1),
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does not contact the updater feed when startup checks are disabled", async () => {
+    api.getSettingsStrict.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      checkOnStartup: false,
+    });
+
+    const { container } = renderPrompt();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(api.getSettingsStrict).toHaveBeenCalledTimes(1);
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("fails closed when the startup preference cannot be read", async () => {
+    api.getSettingsStrict.mockRejectedValue(new Error("settings unavailable"));
+
+    const { container } = renderPrompt();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(api.getSettingsStrict).toHaveBeenCalledTimes(1);
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each<ManagerUpdateCheck>([
+    { kind: "development" },
+    { kind: "unavailable" },
+  ])("does not turn routine $kind checks into a warning", async (result) => {
+    api.checkManagerUpdate.mockResolvedValue(result);
+
+    const { container } = renderPrompt();
+
+    await waitFor(() =>
+      expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1),
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("keeps the startup checker mounted while operation screens hide the prompt", async () => {
+    api.checkManagerUpdate.mockResolvedValue({ kind: "none" });
+    const { rerender } = renderPrompt();
+    await waitFor(() =>
+      expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1),
+    );
+
+    rerender(promptTree(false));
+    rerender(promptTree(true));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(api.getSettingsStrict).toHaveBeenCalledTimes(1);
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the home banner and installs after an explicit confirmation", async () => {
+    const user = userEvent.setup();
+    const update = available();
+    api.checkManagerUpdate.mockResolvedValue(update);
+
+    renderPrompt();
+
+    const message = await screen.findByText("发现管理器新版本 0.5.3");
+    const banner = message.closest(".banner");
+    expect(banner).not.toBeNull();
+    await user.click(
+      within(banner as HTMLElement).getByRole("button", { name: "更新" }),
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "更新到 0.5.3?" });
+    expect(
+      within(dialog).getByText("将下载并安装管理器更新,完成后自动重启管理器。"),
+    ).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "更新" }));
+
+    await waitFor(() =>
+      expect(update.installAndRelaunch).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it("rechecks stale metadata and requires confirmation for the fresh version", async () => {
+    const user = userEvent.setup();
+    const stale = available({
+      installAndRelaunch: vi.fn().mockRejectedValue({
+        code: "stale_expectation",
+        message: "release changed",
+      }),
+    });
+    const fresh = available({ version: "0.5.4" });
+    api.checkManagerUpdate
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(fresh);
+
+    renderPrompt();
+
+    const oldMessage = await screen.findByText("发现管理器新版本 0.5.3");
+    await user.click(
+      within(oldMessage.closest(".banner") as HTMLElement).getByRole("button", {
+        name: "更新",
+      }),
+    );
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "更新" }),
+    );
+
+    expect(
+      await screen.findByText("发现管理器新版本 0.5.4"),
+    ).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    expect(stale.discard).toHaveBeenCalledTimes(1);
+    await waitFor(
+      () => expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      { timeout: 600 },
+    );
+
+    const freshMessage = screen.getByText("发现管理器新版本 0.5.4");
+    await user.click(
+      within(freshMessage.closest(".banner") as HTMLElement).getByRole(
+        "button",
+        { name: "更新" },
+      ),
+    );
+    expect(
+      screen.getByRole("dialog", { name: "更新到 0.5.4?" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clears stale metadata when the advertised update disappears", async () => {
+    const user = userEvent.setup();
+    const stale = available({
+      installAndRelaunch: vi.fn().mockRejectedValue({
+        code: "stale_expectation",
+        message: "release disappeared",
+      }),
+    });
+    api.checkManagerUpdate
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce({ kind: "none" });
+
+    renderPrompt();
+
+    const message = await screen.findByText("发现管理器新版本 0.5.3");
+    await user.click(
+      within(message.closest(".banner") as HTMLElement).getByRole("button", {
+        name: "更新",
+      }),
+    );
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "更新" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("发现管理器新版本 0.5.3"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    expect(stale.discard).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the confirmation actionable after an install failure", async () => {
+    const user = userEvent.setup();
+    const installAndRelaunch = vi
+      .fn()
+      .mockRejectedValue(new Error("network down"));
+    api.checkManagerUpdate.mockResolvedValue(available({ installAndRelaunch }));
+
+    renderPrompt();
+
+    const message = await screen.findByText("发现管理器新版本 0.5.3");
+    await user.click(
+      within(message.closest(".banner") as HTMLElement).getByRole("button", {
+        name: "更新",
+      }),
+    );
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "更新" }));
+
+    await screen.findByRole("alert");
+    expect(within(dialog).getByRole("button", { name: "更新" })).toBeEnabled();
+  });
+});

--- a/src/app/ManagerUpdatePrompt.tsx
+++ b/src/app/ManagerUpdatePrompt.tsx
@@ -1,0 +1,198 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  errorCode,
+  managerApi,
+  type ManagerUpdateAvailable,
+} from "../services/managerApi";
+import { StatusBanner, Ring } from "./components";
+import { userErrorMessage } from "./errorCopy";
+import { useI18n } from "./i18n";
+import { Sheet } from "./Sheet";
+
+export interface ManagerUpdatePromptController {
+  update: ManagerUpdateAvailable | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Owns the one-per-session startup check. Home calls this hook at its stable
+ * platform-dispatch layer, so Codex progress/finished screens can hide the
+ * prompt without remounting the checker and contacting the feed again.
+ */
+export function useManagerUpdatePrompt(): ManagerUpdatePromptController {
+  const [update, setUpdate] = useState<ManagerUpdateAvailable | null>(null);
+  const updateRef = useRef<ManagerUpdateAvailable | null>(null);
+  const mountedRef = useRef(false);
+  const checkingRef = useRef<Promise<void> | null>(null);
+
+  const replaceUpdate = useCallback((next: ManagerUpdateAvailable | null) => {
+    const previous = updateRef.current;
+    updateRef.current = next;
+    if (mountedRef.current) setUpdate(next);
+    if (previous && previous !== next) void previous.discard();
+  }, []);
+
+  const check = useCallback((): Promise<void> => {
+    if (checkingRef.current) return checkingRef.current;
+
+    const pending = managerApi
+      .checkManagerUpdate()
+      .then((result) => {
+        if (result.kind === "available") {
+          if (mountedRef.current) replaceUpdate(result);
+          else void result.discard();
+          return;
+        }
+        if (mountedRef.current) replaceUpdate(null);
+      })
+      .catch(() => {
+        // Startup checks are deliberately quiet. About keeps the explicit
+        // check path and its localized failure message for troubleshooting.
+      })
+      .finally(() => {
+        if (checkingRef.current === pending) checkingRef.current = null;
+      });
+    checkingRef.current = pending;
+    return pending;
+  }, [replaceUpdate]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    let active = true;
+
+    // Fail closed when local settings cannot be read: an uncertain preference
+    // must not become an unsolicited network request.
+    void managerApi
+      .getSettingsStrict()
+      .then((settings) => {
+        if (active && settings.checkOnStartup) void check();
+      })
+      .catch(() => undefined);
+
+    return () => {
+      active = false;
+      mountedRef.current = false;
+      const retained = updateRef.current;
+      updateRef.current = null;
+      void retained?.discard();
+    };
+  }, [check]);
+
+  const refresh = useCallback(async () => {
+    // A stale expectation can never succeed on retry. Remove it before asking
+    // the signed feed for fresh metadata and requiring a new confirmation.
+    replaceUpdate(null);
+    await check();
+  }, [check, replaceUpdate]);
+
+  return useMemo(() => ({ update, refresh }), [refresh, update]);
+}
+
+/**
+ * Reuses the existing home status banner and signed updater confirmation.
+ * Routine offline/feed failures stay quiet; the About page remains the manual
+ * diagnostics path.
+ */
+export function ManagerUpdatePrompt({
+  update,
+  refresh,
+}: ManagerUpdatePromptController) {
+  const { t } = useI18n();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  const titleId = useId();
+  const bodyId = useId();
+
+  const closeConfirm = useCallback(() => {
+    if (installing) return;
+    setConfirmOpen(false);
+    setFailure(null);
+  }, [installing]);
+
+  const installUpdate = useCallback(async () => {
+    if (!update || installing) return;
+    setInstalling(true);
+    setFailure(null);
+    try {
+      await update.installAndRelaunch();
+    } catch (cause) {
+      if (errorCode(cause) === "stale_expectation") {
+        setConfirmOpen(false);
+        await refresh();
+      } else {
+        setFailure(userErrorMessage(cause, t));
+      }
+    } finally {
+      setInstalling(false);
+    }
+  }, [installing, refresh, t, update]);
+
+  if (!update) return null;
+
+  return (
+    <>
+      <div className="manager-update-prompt">
+        <StatusBanner
+          tone="info"
+          icon="arrowUp"
+          action={
+            <button
+              type="button"
+              className="btn primary sm"
+              onClick={() => {
+                setFailure(null);
+                setConfirmOpen(true);
+              }}
+              disabled={installing}
+            >
+              {t("confirm.ok")}
+            </button>
+          }
+        >
+          {t("about.mgrFound", { version: update.version })}
+        </StatusBanner>
+      </div>
+
+      <Sheet
+        open={confirmOpen}
+        onDismiss={closeConfirm}
+        dismissable={!installing}
+        labelledBy={titleId}
+        describedBy={bodyId}
+        initialFocus="dismiss"
+      >
+        <Ring icon="arrowUp" />
+        <h3 id={titleId}>{t("confirm.title", { version: update.version })}</h3>
+        <p id={bodyId}>{t("about.mgrConfirmBody")}</p>
+        {failure ? <StatusBanner tone="err">{failure}</StatusBanner> : null}
+        <div className="row2 sheet-actions">
+          <button
+            type="button"
+            className="btn ghost"
+            onClick={closeConfirm}
+            disabled={installing}
+          >
+            {t("confirm.cancel")}
+          </button>
+          <button
+            type="button"
+            className="btn primary"
+            onClick={() => void installUpdate()}
+            disabled={installing}
+          >
+            {installing ? t("progress.installing") : t("confirm.ok")}
+          </button>
+        </div>
+      </Sheet>
+    </>
+  );
+}

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2675,6 +2675,27 @@ button.row.danger:hover {
   font-variant-numeric: tabular-nums;
 }
 
+/* Signed Manager update notice: stable Home owns the quiet startup check, and
+   this slot keeps the reusable banner above the scrolling content so the
+   update action is immediately discoverable. */
+.manager-update-prompt {
+  flex: 0 0 auto;
+  padding: var(--space-xs) var(--space-md) 0;
+}
+.manager-update-prompt .banner {
+  width: 100%;
+  max-width: 640px;
+  margin-inline: auto;
+  animation: risein 0.28s var(--ease-out) both;
+}
+.manager-update-prompt .banner > span {
+  flex: 1;
+  min-width: 0;
+}
+.manager-update-prompt .banner .btn {
+  flex-shrink: 0;
+}
+
 /* ── Banner / note ───────────────────────────────────────────────────────── */
 .banner {
   display: flex;
@@ -4035,6 +4056,7 @@ button.row.danger:hover {
   .ring.spin svg,
   .spinicon,
   .cam-icon *,
+  .manager-update-prompt .banner,
   .view > * {
     animation: none !important;
   }

--- a/src/app/views/About.test.tsx
+++ b/src/app/views/About.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  managerApi,
+  type ManagerUpdateAvailable,
+} from "../../services/managerApi";
+import { I18nProvider } from "../i18n";
+import { ThemeProvider } from "../theme";
+import { About } from "./About";
+
+vi.mock("../../services/managerApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../services/managerApi")>();
+  return {
+    ...actual,
+    managerApi: {
+      checkManagerUpdate: vi.fn(),
+      openUrl: vi.fn(),
+      openLogsDir: vi.fn(),
+      getDiagnostics: vi.fn(),
+    },
+  };
+});
+
+const api = vi.mocked(managerApi);
+
+function available(
+  version: string,
+  installAndRelaunch = vi.fn().mockResolvedValue(undefined),
+): ManagerUpdateAvailable {
+  return {
+    kind: "available",
+    version,
+    currentVersion: "0.5.2",
+    installAndRelaunch,
+    discard: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function renderAbout() {
+  return render(
+    <ThemeProvider>
+      <I18nProvider>
+        <About onBack={vi.fn()} />
+      </I18nProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("About manager update", () => {
+  beforeEach(() => {
+    localStorage.setItem("cam.lang", "zh-CN");
+    api.checkManagerUpdate.mockReset();
+  });
+
+  it("really rechecks stale metadata and requires a fresh confirmation", async () => {
+    const user = userEvent.setup();
+    const staleInstall = vi.fn().mockRejectedValue({
+      code: "stale_expectation",
+      message: "release changed",
+    });
+    const stale = available("0.5.3", staleInstall);
+    const fresh = available("0.5.4");
+    api.checkManagerUpdate
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(fresh);
+
+    renderAbout();
+    await user.click(
+      screen.getByRole("button", { name: /检查管理器更新/ }),
+    );
+
+    const staleDialog = await screen.findByRole("dialog", {
+      name: "更新到 0.5.3?",
+    });
+    await user.click(
+      within(staleDialog).getByRole("button", { name: "更新" }),
+    );
+
+    const freshDialog = await screen.findByRole("dialog", {
+      name: "更新到 0.5.4?",
+    });
+    expect(freshDialog).toBeInTheDocument();
+    expect(staleInstall).toHaveBeenCalledTimes(1);
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    expect(stale.discard).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(
+        within(freshDialog).getByRole("button", { name: "更新" }),
+      ).toBeEnabled(),
+    );
+  });
+});

--- a/src/app/views/About.tsx
+++ b/src/app/views/About.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useId, useState } from "react";
 
-import { managerApi, type ManagerUpdateAvailable } from "../../services/managerApi";
+import {
+  errorCode,
+  managerApi,
+  type ManagerUpdateAvailable,
+} from "../../services/managerApi";
 import { userErrorMessage } from "../errorCopy";
 import { Icon, CodexMark } from "../icons";
 import { useI18n } from "../i18n";
@@ -58,12 +62,19 @@ export function About({ onBack }: { onBack: () => void }) {
     try {
       await pendingUpdate.installAndRelaunch();
     } catch (cause) {
-      setMgrMsg(userErrorMessage(cause, t));
-      setPendingUpdate(null);
+      if (errorCode(cause) === "stale_expectation") {
+        // The feed changed after confirmation. Re-read it now so the localized
+        // "rechecked" contract is true and any replacement version requires a
+        // fresh confirmation.
+        await checkManager();
+      } else {
+        setMgrMsg(userErrorMessage(cause, t));
+        setPendingUpdate(null);
+      }
     } finally {
       setMgrBusy(false);
     }
-  }, [pendingUpdate, t]);
+  }, [checkManager, pendingUpdate, t]);
 
   const openLogsDir = useCallback(async () => {
     setMgrMsg(null);

--- a/src/app/views/Home.test.tsx
+++ b/src/app/views/Home.test.tsx
@@ -32,7 +32,9 @@ vi.mock("../../services/managerApi", async (importOriginal) => {
     managerApi: {
       beginTrackedOperation: vi.fn(),
       armDestructive: vi.fn(),
+      checkManagerUpdate: vi.fn(),
       getSettings: vi.fn(),
+      getSettingsStrict: vi.fn(),
       getHostArchitecture: vi.fn(),
       setSettings: vi.fn(),
       getOperationSnapshot: vi.fn(() => Promise.resolve(null)),
@@ -159,6 +161,7 @@ describe("MacHome state machine", () => {
     localStorage.setItem("cam.lang", "zh-CN");
     setPlatform("MacIntel");
     api.getSettings.mockResolvedValue(settings());
+    api.getSettingsStrict.mockResolvedValue(settings());
     api.macStatus.mockResolvedValue(STATUS_MANAGED);
     api.macPlanUpdate.mockResolvedValue(REPORT_UPDATE);
     api.macPerformUpdate.mockResolvedValue(PERFORM_OK);
@@ -170,6 +173,7 @@ describe("MacHome state machine", () => {
     api.getOperationCompletion.mockResolvedValue(null);
     api.beginTrackedOperation.mockResolvedValue("test-install-operation");
     api.armDestructive.mockResolvedValue("test-operation");
+    api.checkManagerUpdate.mockResolvedValue({ kind: "none" });
     api.getHostArchitecture.mockResolvedValue("aarch64");
     api.historicalReleaseCatalog.mockImplementation((platform, architecture) =>
       Promise.resolve({

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -43,6 +43,11 @@ import { currentPlatform } from "../platform";
 import { WinHome } from "./WinHome";
 import { mib, fmtDateTime } from "../format";
 import { useHomeMotion } from "../motion";
+import {
+  ManagerUpdatePrompt,
+  useManagerUpdatePrompt,
+  type ManagerUpdatePromptController,
+} from "../ManagerUpdatePrompt";
 import { Sheet } from "../Sheet";
 import {
   macSkippedUpdateCandidate,
@@ -77,6 +82,7 @@ type MacOrdinaryExpectation = Extract<
 /** Platform dispatcher — the backend command surface differs per OS. */
 export function Home(props: { onOpenSettings: () => void }) {
   const [hostArchitecture, setHostArchitecture] = useState<string | null>(null);
+  const managerUpdatePrompt = useManagerUpdatePrompt();
   useEffect(() => {
     let active = true;
     void managerApi
@@ -92,18 +98,28 @@ export function Home(props: { onOpenSettings: () => void }) {
     };
   }, []);
   return currentPlatform() === "windows" ? (
-    <WinHome {...props} hostArchitecture={hostArchitecture} />
+    <WinHome
+      {...props}
+      hostArchitecture={hostArchitecture}
+      managerUpdatePrompt={managerUpdatePrompt}
+    />
   ) : (
-    <MacHome {...props} hostArchitecture={hostArchitecture} />
+    <MacHome
+      {...props}
+      hostArchitecture={hostArchitecture}
+      managerUpdatePrompt={managerUpdatePrompt}
+    />
   );
 }
 
 function MacHome({
   onOpenSettings,
   hostArchitecture,
+  managerUpdatePrompt,
 }: {
   onOpenSettings: () => void;
   hostArchitecture: string | null;
+  managerUpdatePrompt: ManagerUpdatePromptController;
 }) {
   const { t, lang } = useI18n();
   const [report, setReport] = useState<MacUpdateReport | null>(null);
@@ -1020,6 +1036,7 @@ function MacHome({
           <Icon name="gear" />
         </button>
       </TopBar>
+      <ManagerUpdatePrompt {...managerUpdatePrompt} />
 
       <div
         className="scroll"

--- a/src/app/views/WinHome.test.tsx
+++ b/src/app/views/WinHome.test.tsx
@@ -33,7 +33,9 @@ vi.mock("../../services/managerApi", async (importOriginal) => {
     managerApi: {
       beginTrackedOperation: vi.fn(),
       armDestructive: vi.fn(),
+      checkManagerUpdate: vi.fn(),
       getSettings: vi.fn(),
+      getSettingsStrict: vi.fn(),
       setSettings: vi.fn(),
       getOperationSnapshot: vi.fn(() => Promise.resolve(null)),
       getPausedOperationSnapshot: vi.fn(() => Promise.resolve(null)),
@@ -203,6 +205,7 @@ describe("WinHome state machine", () => {
     sessionStorage.clear();
     api.beginTrackedOperation.mockResolvedValue("win-install-op-1");
     api.armDestructive.mockResolvedValue("win-op-1");
+    api.checkManagerUpdate.mockResolvedValue({ kind: "none" });
     api.getOperationCompletion.mockResolvedValue(null);
     api.getSettings.mockResolvedValue(settings());
     api.winDefaultInstallRoot.mockResolvedValue(DEFAULT_SETTINGS.installRoot);

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -43,6 +43,10 @@ import {
 import { mib, fmtDateTime } from "../format";
 import { samePath, normalizePath } from "../paths";
 import { useHomeMotion } from "../motion";
+import {
+  ManagerUpdatePrompt,
+  type ManagerUpdatePromptController,
+} from "../ManagerUpdatePrompt";
 import { Sheet } from "../Sheet";
 import {
   skippedUpdateMatches,
@@ -122,9 +126,11 @@ function storeProvenanceRecovery(value: ProvenanceRecovery | null) {
 export function WinHome({
   onOpenSettings,
   hostArchitecture,
+  managerUpdatePrompt,
 }: {
   onOpenSettings: () => void;
   hostArchitecture?: string | null;
+  managerUpdatePrompt?: ManagerUpdatePromptController;
 }) {
   const { t, lang } = useI18n();
   const [report, setReport] = useState<WinUpdateReport | null>(null);
@@ -1384,6 +1390,9 @@ export function WinHome({
           <Icon name="gear" />
         </button>
       </TopBar>
+      {managerUpdatePrompt ? (
+        <ManagerUpdatePrompt {...managerUpdatePrompt} />
+      ) : null}
 
       <div
         className="scroll"

--- a/src/services/managerApi.test.ts
+++ b/src/services/managerApi.test.ts
@@ -103,6 +103,19 @@ describe("settings API", () => {
     );
   });
 
+  it("lets automatic network callers fail closed on native settings errors", async () => {
+    vi.stubGlobal("window", {
+      open: vi.fn(),
+      __TAURI_INTERNALS__: {},
+    });
+    invokeMock.mockRejectedValue(new Error("settings unavailable"));
+
+    await expect(managerApi.getSettingsStrict()).rejects.toThrow(
+      "settings unavailable",
+    );
+    expect(invokeMock).toHaveBeenCalledWith("get_settings_strict");
+  });
+
   it("coerces empty custom source and proxy modes to real defaults", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", {

--- a/src/services/managerApi.ts
+++ b/src/services/managerApi.ts
@@ -1123,6 +1123,17 @@ export const managerApi = {
       return localSettings();
     }
   },
+  /**
+   * Read settings without converting a native storage failure into defaults.
+   * Automatic network callers use this so an unknown preference fails closed;
+   * ordinary UI callers can keep using getSettings's local fallback.
+   */
+  async getSettingsStrict(): Promise<AppSettings> {
+    if (!hasTauriRuntime()) {
+      return localSettings();
+    }
+    return normalizeSettings(await invoke<AppSettings>("get_settings_strict"));
+  },
   async setSettings(next: AppSettings): Promise<AppSettings> {
     const safe = normalizeSettings(next);
     if (!hasTauriRuntime()) {


### PR DESCRIPTION
## Summary

- restore native hot theme try-on for Codex 26.831.21537 and later by recognizing dollar-prefixed JavaScript identifiers while preserving the legacy adapters
- pin the compatibility boundary to the first published affected build: 26.831.21537; 26.831.20005 still uses the legacy identifier shape
- reuse the existing status banner on both macOS and Windows homes to announce a newer Codex App Manager release and offer the existing signed update flow
- fail closed when startup-update preferences cannot be read safely, refresh stale release expectations before install, and document the automatic feed check

## Root cause

CDP remains reachable. Codex 26.831.21537 changed the minified settings writer identifier from the legacy word-only form to a dollar-prefixed JavaScript identifier. The old locator therefore failed before importing the settings module.

## Verification

- `codex review --uncommitted`: no findings after iteration
- `npm test`: 337 passed
- `npm run check`
- `npm run lint`
- `npm run build`
- `cargo test --manifest-path crates/codex-theme-engine/Cargo.toml`: 51 passed, 4 ignored
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`: 168 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- ignored live round-trip test against local Codex 26.831.21537: settings read and same-value write succeeded with no state change
- rendered desktop and 400 px layouts: banner, confirmation sheet, and cancel path verified; final install was not triggered during visual QA