### PR TITLE
chore(release): bump version to 0.5.3

### DIFF
--- a/docs/releases/v0.5.3.md
+++ b/docs/releases/v0.5.3.md
@@ -1,0 +1,49 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 修复新版本 Codex 的皮肤试穿，在首页直接提醒 Codex App Manager 更新，并收紧自定义更新源的安全边界。
+> Restores skin try-on on newer Codex builds, surfaces Manager updates on the home screen, and tightens security boundaries for custom update sources.
+
+## ✨ 亮点 · Highlights
+
+- **首页直接提醒管理器更新**：启用“启动时自动检查更新”时，macOS 与 Windows 首页发现 Codex App Manager 新版本会显示横幅和“更新”按钮；确认后沿用现有的签名校验、安装与重启流程，无更新或检查失败时保持安静。
+  Manager updates on the home screen: when “Check for updates on startup” is enabled, macOS and Windows now show a banner and Update button for a newer Codex App Manager release. Confirmation continues through the existing signature verification, install, and relaunch flow, while no-update and failed checks stay quiet.
+
+- **更安全的自定义更新源**：macOS 自定义源会拒绝本机、内网、元数据服务或其他不可公网路由的目标，也不会跟随未验证的重定向；仅代理网络仍可通过经过验证的公共 DoH 解析继续更新。
+  Safer custom update sources: macOS now rejects loopback, private, metadata-service, and other non-public destinations, and will not follow unvalidated redirects. Proxy-only networks can still update through validated public DoH resolution.
+
+## 🐛 修复 · Fixes
+
+- **新版本 Codex 可再次试穿皮肤**：Codex `26.831.21537` 起设置模块的压缩标识符发生变化，之前会报 `settings module not found`；现在从该版本起使用新版适配器，并继续兼容此前的 Codex 版本。
+  Skin try-on works on newer Codex builds again: Codex `26.831.21537` changed a minified identifier in its settings module, previously causing `settings module not found`. A version-aware adapter now handles that build and later releases while retaining compatibility with older Codex versions.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64 0.23.1",
  "codex-mac-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.5.2"
+version = "0.5.3"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump Codex App Manager from 0.5.2 to 0.5.3 across all six release version declarations
- add bilingual v0.5.3 release notes for Codex 26.831.21537+ theme try-on compatibility and the Home update banner
- document the custom-source security hardening and current unsigned Windows installer status

## Validation

- `node scripts/check-release-version.mjs source v0.5.3 .`
- `npm run test:release` (56 passed)
- `npm run check`
- `npm run lint`
- `npm test` (337 passed)
- `npm run build`
- Rust tests: 330 passed (4 ignored)
- `git diff --check`
- `codex review --uncommitted` — no findings