### PR TITLE
chore(release): bump version to 0.5.4

### DIFF
--- a/crates/codex-theme-engine/src/native_hot.rs
+++ b/crates/codex-theme-engine/src/native_hot.rs
@@ -7,9 +7,9 @@
 //! backdrops and the settings query invalidates across views) and persists
 //! through Codex's own store. This module locates those wrappers at runtime —
 //! the chunk file names and minified export aliases change per Codex build,
-//! so discovery is structural: scan the loaded chunks for the wrappers' exact
-//! minified shape, resolve their export aliases, `import()` the chunk (which
-//! dedupes into the live module graph) and cache the functions on `window`.
+//! so discovery is structural: scan candidate chunks, resolve the exported
+//! wrappers, `import()` the chunk (which dedupes into the live module graph)
+//! and cache the functions on `window`.
 //!
 //! Discovery is version-adapted: 26.707 keeps the eager loaded-chunk scan,
 //! 26.715 follows the Vite dependency manifest to its lazy
@@ -18,6 +18,9 @@
 //! to `$D`. A version hint only controls probe order; every adapter still proves
 //! the module structurally before it is used, so a stale installed-version
 //! cache cannot select an incompatible implementation.
+//! 26.901.20858 added native app-host settings branches. Its adapter inspects
+//! exported wrappers' parameter/payload contracts instead of matching their
+//! entire bodies, retaining Codex's own native/legacy dispatch and defaults.
 
 use serde_json::Value;
 
@@ -45,6 +48,7 @@ enum SettingsAdapter {
     V26_707,
     V26_715,
     V26_831_21537,
+    V26_901_20858,
 }
 
 impl SettingsAdapter {
@@ -53,6 +57,7 @@ impl SettingsAdapter {
             Self::V26_707 => "26.707",
             Self::V26_715 => "26.715",
             Self::V26_831_21537 => "26.831.21537+",
+            Self::V26_901_20858 => "26.901.20858+",
         }
     }
 }
@@ -60,6 +65,9 @@ impl SettingsAdapter {
 // Mirror package comparison pins the boundary: 26.831.20005 still emitted
 // `nO`/`tO`, while the next published build, 26.831.21537, emitted `$D`/`QD`.
 const FULL_JS_IDENTIFIER_MIN_VERSION: [u32; 3] = [26, 831, 21537];
+// Mirror's adjacent macOS packages: 26.831.21537 has direct RPC wrappers;
+// 26.901.20858 (build 7658) first adds app-host settings.read/write branches.
+const NATIVE_SETTINGS_BRIDGE_MIN_VERSION: [u32; 3] = [26, 901, 20858];
 
 fn version_triplet(version: &str) -> Option<[u32; 3]> {
     let mut parts = version.trim().split('.');
@@ -72,6 +80,9 @@ fn version_triplet(version: &str) -> Option<[u32; 3]> {
 
 fn preferred_adapter(version_hint: Option<&str>) -> Option<SettingsAdapter> {
     let version = version_triplet(version_hint?)?;
+    if version >= NATIVE_SETTINGS_BRIDGE_MIN_VERSION {
+        return Some(SettingsAdapter::V26_901_20858);
+    }
     if version >= FULL_JS_IDENTIFIER_MIN_VERSION {
         return Some(SettingsAdapter::V26_831_21537);
     }
@@ -83,19 +94,28 @@ fn preferred_adapter(version_hint: Option<&str>) -> Option<SettingsAdapter> {
     }
 }
 
-fn adapter_order(version_hint: Option<&str>) -> [SettingsAdapter; 3] {
+fn adapter_order(version_hint: Option<&str>) -> [SettingsAdapter; 4] {
     match preferred_adapter(version_hint) {
         Some(SettingsAdapter::V26_707) => [
             SettingsAdapter::V26_707,
             SettingsAdapter::V26_715,
             SettingsAdapter::V26_831_21537,
+            SettingsAdapter::V26_901_20858,
         ],
         Some(SettingsAdapter::V26_715) => [
             SettingsAdapter::V26_715,
             SettingsAdapter::V26_707,
             SettingsAdapter::V26_831_21537,
+            SettingsAdapter::V26_901_20858,
         ],
-        Some(SettingsAdapter::V26_831_21537) | None => [
+        Some(SettingsAdapter::V26_831_21537) => [
+            SettingsAdapter::V26_831_21537,
+            SettingsAdapter::V26_715,
+            SettingsAdapter::V26_707,
+            SettingsAdapter::V26_901_20858,
+        ],
+        Some(SettingsAdapter::V26_901_20858) | None => [
+            SettingsAdapter::V26_901_20858,
             SettingsAdapter::V26_831_21537,
             SettingsAdapter::V26_715,
             SettingsAdapter::V26_707,
@@ -105,7 +125,7 @@ fn adapter_order(version_hint: Option<&str>) -> [SettingsAdapter; 3] {
 
 /// Locate + cache the renderer's settings API (idempotent). The cache lives on
 /// `window.__camThemeSettingsV1`, so repeated ops skip the chunk scan.
-const PREFERRED_ADAPTER_TOKEN: &str = "__CAM_PREFERRED_ADAPTER__";
+const ADAPTERS_TOKEN: &str = "__CAM_ADAPTERS__";
 
 const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
   const w = window;
@@ -117,12 +137,7 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
       url: w.__camThemeSettingsV1.url,
     };
   }
-  const preferred = "__CAM_PREFERRED_ADAPTER__";
-  const adapters = preferred === "26.707"
-    ? ["26.707", "26.715", "26.831.21537+"]
-    : preferred === "26.715"
-      ? ["26.715", "26.707", "26.831.21537+"]
-      : ["26.831.21537+", "26.715", "26.707"];
+  const adapters = __CAM_ADAPTERS__;
   const loadedUrls = [...new Set([
     ...performance.getEntriesByType("resource").map((r) => r.name),
     ...[...document.querySelectorAll("script[src]")].map((el) => el.src),
@@ -133,6 +148,49 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
   const modernWriteRe = /async function ([$A-Za-z_][$A-Za-z0-9_]*)\(e,t\)\{await ([$A-Za-z_][$A-Za-z0-9_]*)\([`'"]set-setting[`'"],\{params:\{key:e\.key,value:t\}\}\)\}/;
   const modernReadRe = /async function ([$A-Za-z_][$A-Za-z0-9_]*)\(e\)\{return\(await ([$A-Za-z_][$A-Za-z0-9_]*)\([`'"]get-setting[`'"],\{params:\{key:e\.key\}\}\)\)\.value\?\?e\.default\}/;
   const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Resolve the real exported functions, not hard-coded/minified export names.
+  // Inspect but never invoke candidates during discovery. The two wrappers
+  // must use their own key/value parameters and the same RPC fallback. Native
+  // bridge branches, guards and whitespace around that contract may vary.
+  const exportedSettingsWrappers = (mod) => {
+    const id = "[$A-Za-z_][$A-Za-z0-9_]*";
+    const paramsRe = new RegExp(
+      "^async\\s+function(?:\\s+" + id + ")?\\s*\\(\\s*(" + id +
+      ")(?:\\s*,\\s*(" + id + "))?\\s*\\)\\s*\\{"
+    );
+    const reads = [];
+    const writes = [];
+    for (const fn of new Set(Object.values(mod))) {
+      if (typeof fn !== "function") continue;
+      let source;
+      // Codex's instrumentation wraps Function#toString; some unrelated
+      // exports cannot be inspected through it. Skip those, not the module.
+      try { source = Function.prototype.toString.call(fn); } catch { continue; }
+      const params = source.match(paramsRe);
+      if (!params) continue;
+      const key = escapeRegExp(params[1]) + "\\s*\\.\\s*key";
+      if (params[2] == null) {
+        const readRe = new RegExp(
+          "\\(\\s*await\\s+(" + id + ")\\s*\\(\\s*[`'\"]get-setting[`'\"]\\s*,\\s*" +
+          "\\{\\s*params\\s*:\\s*\\{\\s*key\\s*:\\s*" + key + "\\s*\\}\\s*\\}\\s*\\)\\s*\\)" +
+          "\\s*\\.\\s*value\\s*\\?\\?\\s*" + escapeRegExp(params[1]) + "\\s*\\.\\s*default"
+        );
+        const match = source.match(readRe);
+        if (match) reads.push({ fn, rpc: match[1] });
+      } else {
+        const writeRe = new RegExp(
+          "\\bawait\\s+(" + id + ")\\s*\\(\\s*[`'\"]set-setting[`'\"]\\s*,\\s*" +
+          "\\{\\s*params\\s*:\\s*\\{\\s*key\\s*:\\s*" + key + "\\s*,\\s*value\\s*:\\s*" +
+          escapeRegExp(params[2]) + "\\s*\\}\\s*\\}\\s*\\)"
+        );
+        const match = source.match(writeRe);
+        if (match) writes.push({ fn, rpc: match[1] });
+      }
+    }
+    // Do not guess when a module exposes several different settings APIs.
+    if (reads.length !== 1 || writes.length !== 1 || reads[0].rpc !== writes[0].rpc) return null;
+    return { read: reads[0].fn, write: writes[0].fn };
+  };
   const fetched = new Map();
   const checked = new Set();
   const fetchText = async (url) => {
@@ -171,6 +229,16 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
     for (const url of candidates) {
       const text = await fetchText(url);
       if (text == null || !text.includes("set-setting")) continue;
+      if (adapter === "26.901.20858+") {
+        // Only import an app settings candidate, never every loaded chunk.
+        if (!text.includes("get-setting") || !text.includes("async function")) continue;
+        let mod;
+        try { mod = await import(url); } catch { continue; }
+        const api = exportedSettingsWrappers(mod);
+        if (!api) continue;
+        w.__camThemeSettingsV1 = { ...api, url, adapter };
+        return { ok: true, cached: false, adapter, url, checked: checked.size };
+      }
       const writeMatch = text.match(writeRe);
       const readMatch = text.match(readRe);
       if (!writeMatch || !readMatch) continue;
@@ -198,6 +266,10 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
     const candidates = adapter === "26.715" ? await lazy715Candidates() : loadedUrls;
     const outcome = await resolveModule(adapter, candidates);
     if (outcome != null) return outcome;
+    if (adapter === "26.901.20858+") {
+      const lazyOutcome = await resolveModule(adapter, await lazy715Candidates());
+      if (lazyOutcome != null) return lazyOutcome;
+    }
   }
   return {
     ok: false,
@@ -207,8 +279,11 @@ const ENSURE_API_JS_TEMPLATE: &str = r#"(async () => {
 })()"#;
 
 fn ensure_api_expression(version_hint: Option<&str>) -> String {
-    let preferred = adapter_order(version_hint)[0].id();
-    ENSURE_API_JS_TEMPLATE.replace(PREFERRED_ADAPTER_TOKEN, preferred)
+    let adapters = adapter_order(version_hint).map(SettingsAdapter::id);
+    ENSURE_API_JS_TEMPLATE.replace(
+        ADAPTERS_TOKEN,
+        &serde_json::to_string(&adapters).expect("static adapter IDs"),
+    )
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -226,8 +301,8 @@ struct JsOutcome {
 
 async fn run_js(session: &CdpSession, expression: &str, what: &str) -> Result<JsOutcome> {
     let value = session.evaluate(expression).await?;
-    let outcome: JsOutcome = serde_json::from_value(value)
-        .map_err(|e| err(format!("{what}: 结果解析失败: {e}")))?;
+    let outcome: JsOutcome =
+        serde_json::from_value(value).map_err(|e| err(format!("{what}: 结果解析失败: {e}")))?;
     if !outcome.ok {
         return Err(err(format!(
             "hot-import-unsupported: {what}: {}",
@@ -300,8 +375,8 @@ pub async fn write_values(
         .iter()
         .map(|(key, value)| serde_json::json!([key, value]))
         .collect();
-    let payload_json = serde_json::to_string(&payload)
-        .map_err(|e| err(format!("写入负载序列化失败: {e}")))?;
+    let payload_json =
+        serde_json::to_string(&payload).map_err(|e| err(format!("写入负载序列化失败: {e}")))?;
     let expression = format!(
         r#"(async () => {{
   const api = window.__camThemeSettingsV1;
@@ -317,7 +392,9 @@ pub async fn write_values(
   return {{ ok: true }};
 }})()"#
     );
-    run_js(session, &expression, "写入外观设置").await.map(|_| ())
+    run_js(session, &expression, "写入外观设置")
+        .await
+        .map(|_| ())
 }
 
 /// The write set for a typed theme: both ChromeThemes, both code theme ids
@@ -456,6 +533,8 @@ mod tests {
             "modulepreload",
             "escapeRegExp(name)",
             "await import(url)",
+            "Function.prototype.toString.call(fn)",
+            "reads[0].rpc !== writes[0].rpc",
         ] {
             assert!(
                 ENSURE_API_JS_TEMPLATE.contains(fragment),
@@ -472,6 +551,7 @@ mod tests {
                 SettingsAdapter::V26_707,
                 SettingsAdapter::V26_715,
                 SettingsAdapter::V26_831_21537,
+                SettingsAdapter::V26_901_20858,
             ]
         );
         assert_eq!(
@@ -480,6 +560,7 @@ mod tests {
                 SettingsAdapter::V26_715,
                 SettingsAdapter::V26_707,
                 SettingsAdapter::V26_831_21537,
+                SettingsAdapter::V26_901_20858,
             ]
         );
     }
@@ -507,6 +588,7 @@ mod tests {
         assert_eq!(
             adapter_order(Some("unexpected")),
             [
+                SettingsAdapter::V26_901_20858,
                 SettingsAdapter::V26_831_21537,
                 SettingsAdapter::V26_715,
                 SettingsAdapter::V26_707,
@@ -515,6 +597,7 @@ mod tests {
         assert_eq!(
             adapter_order(Some("26.706.1")),
             [
+                SettingsAdapter::V26_901_20858,
                 SettingsAdapter::V26_831_21537,
                 SettingsAdapter::V26_715,
                 SettingsAdapter::V26_707,
@@ -523,6 +606,7 @@ mod tests {
         assert_eq!(
             adapter_order(None),
             [
+                SettingsAdapter::V26_901_20858,
                 SettingsAdapter::V26_831_21537,
                 SettingsAdapter::V26_715,
                 SettingsAdapter::V26_707,
@@ -531,16 +615,41 @@ mod tests {
     }
 
     #[test]
+    fn native_bridge_adapter_starts_at_first_observed_codex_build() {
+        for previous in ["26.831.21537", "26.901.20857"] {
+            assert_eq!(
+                preferred_adapter(Some(previous)),
+                Some(SettingsAdapter::V26_831_21537),
+                "{previous} must stay on the pre-bridge adapter"
+            );
+        }
+        for current_or_newer in ["26.901.20858", "26.901.20858.0", "26.901.22334", "27.1.1"] {
+            assert_eq!(
+                preferred_adapter(Some(current_or_newer)),
+                Some(SettingsAdapter::V26_901_20858),
+                "{current_or_newer} must accept native bridge branches"
+            );
+        }
+    }
+
+    #[test]
     fn discovery_script_embeds_versioned_probe_order_and_lazy_715_chunk() {
         let legacy = ensure_api_expression(Some("26.707.9981.0"));
         let current = ensure_api_expression(Some("26.715.2305.0"));
         let modern = ensure_api_expression(Some("26.831.21537"));
-        assert!(legacy.contains(r#"const preferred = "26.707""#));
-        assert!(current.contains(r#"const preferred = "26.715""#));
-        assert!(modern.contains(r#"const preferred = "26.831.21537+""#));
+        let native = ensure_api_expression(Some("26.901.20858"));
+        assert!(legacy
+            .contains(r#"const adapters = ["26.707","26.715","26.831.21537+","26.901.20858+"]"#));
+        assert!(current
+            .contains(r#"const adapters = ["26.715","26.707","26.831.21537+","26.901.20858+"]"#));
+        assert!(modern
+            .contains(r#"const adapters = ["26.831.21537+","26.715","26.707","26.901.20858+"]"#));
+        assert!(native
+            .contains(r#"const adapters = ["26.901.20858+","26.831.21537+","26.715","26.707"]"#));
         assert!(current.contains("setting-storage-"));
-        assert!(current.contains(r#"["26.715", "26.707", "26.831.21537+"]"#));
-        assert!(modern.contains(r#"["26.831.21537+", "26.715", "26.707"]"#));
         assert!(!current.contains("response.ok"));
+        for script in [legacy, current, modern, native] {
+            assert!(!script.contains(ADAPTERS_TOKEN));
+        }
     }
 }

--- a/crates/codex-theme-engine/src/runtime/native-hot-discovery.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/native-hot-discovery.test.mjs
@@ -1,0 +1,214 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { compileFunction, constants } from "node:vm";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+// Execute the production Rust-embedded expression, including real ESM imports.
+// Only the renderer's resource inventory and custom-protocol fetch are mocked.
+const rust = await readFile(join(process.cwd(), "crates/codex-theme-engine/src/native_hot.rs"), "utf8");
+const template = rust.match(/const ENSURE_API_JS_TEMPLATE: &str = r#"([\s\S]*?)"#;/)[1];
+const newest = ["26.901.20858+", "26.831.21537+", "26.715", "26.707"];
+const roots = [];
+// Bypass Vitest's transformed module loader: production import() and fixtures
+// must share Node's real ESM cache, just as they share Chromium's in Codex.
+const nativeImport = compileFunction("return import(url)", ["url"], {
+  importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+});
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+// These small wrapper excerpts preserve the shapes measured in real packages;
+// the RPC/native service implementations below are isolated test doubles.
+const wrappers = {
+  legacy: 'async function rd(e){return(await rpc(`get-setting`,{params:{key:e.key}})).value??e.default}\nasync function wr(e,t){await rpc(`set-setting`,{params:{key:e.key,value:t}})}\nexport {rd as r,wr as w};',
+  "26.831.21537": 'async function QD(e){return(await KD(`get-setting`,{params:{key:e.key}})).value??e.default}\nasync function $D(e,t){await KD(`set-setting`,{params:{key:e.key,value:t}})}\nexport {QD as JRt,$D as ezt};',
+  "26.901.20858": 'async function xO(e){return bX?.settings==null?(await DD(`get-setting`,{params:{key:e.key}})).value??e.default:(await bX.settings.read(e.key)).effective}\nasync function SO(e,t){if(bX?.settings!=null){await bX.settings.write(e.key,t);return}await DD(`set-setting`,{params:{key:e.key,value:t}})}\nexport {xO as r,SO as w};',
+  "26.901.22334": 'async function bO(e){return bX?.settings==null?(await ED(`get-setting`,{params:{key:e.key}})).value??e.default:(await bX.settings.read(e.key)).effective}\nasync function xO(e,t){if(bX?.settings!=null){await bX.settings.write(e.key,t);return}await ED(`set-setting`,{params:{key:e.key,value:t}})}\nexport {bO as fUt,xO as vUt};',
+};
+
+function moduleSource(shape, native = true) {
+  return `
+export const calls = [];
+const values = new Map([["appearanceTheme", "dark"]]);
+async function rpc(method, {params}) {
+  calls.push([method, params.key, params.value]);
+  if (method === "get-setting") return {value: values.get(params.key)};
+  values.set(params.key, params.value);
+}
+const KD = rpc, DD = rpc, ED = rpc, $rpc = rpc;
+const bX = ${native ? `{
+  settings: {
+    async read(key) {calls.push(["native-read", key]); return {effective: values.get(key)};},
+    async write(key, value) {calls.push(["native-write", key, value]); values.set(key, value);},
+  },
+}` : "null"};
+${shape}
+`;
+}
+
+async function renderer(files, { loaded = Object.keys(files), adapters = newest, failures = [], inspection = Function } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "cam-native-hot-"));
+  roots.push(root);
+  await writeFile(join(root, "package.json"), '{"type":"module"}');
+  const urls = Object.fromEntries(Object.keys(files).map((name) => [name, pathToFileURL(join(root, name)).href]));
+  await Promise.all(Object.entries(files).map(([name, source]) => writeFile(join(root, name), source)));
+  const fetched = [];
+  const window = {};
+  const fetch = async (url) => {
+    fetched.push(url);
+    if (failures.includes(url) || failures.some((name) => urls[name] === url)) throw new Error("unreadable");
+    return { ok: false, text: () => readFile(fileURLToPath(url), "utf8") };
+  };
+  const entries = loaded.map((name) => ({ name: urls[name] }));
+  const document = {
+    querySelectorAll: (selector) => selector === "script[src]"
+      ? entries.map(({ name }) => ({ src: name }))
+      : entries.map(({ name }) => ({ href: name })),
+  };
+  const script = template.replace("__CAM_ADAPTERS__", JSON.stringify(adapters));
+  const run = compileFunction(`return ${script}`, ["window", "document", "performance", "fetch", "Function"], {
+    importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+  });
+  return {
+    run: () => run(window, document, { getEntriesByType: () => entries }, fetch, inspection),
+    window,
+    fetched,
+    urls,
+    module: (name) => nativeImport(urls[name]),
+  };
+}
+
+async function assertRoundTrip(page, adapter, route) {
+  expect(await page.run()).toMatchObject({ ok: true, cached: false, adapter });
+  const mod = await page.module(Object.keys(page.urls).find((name) => page.urls[name] === page.window.__camThemeSettingsV1.url));
+  expect(mod.calls).toEqual([]); // Discovery must never write, or even call read.
+  const api = page.window.__camThemeSettingsV1;
+  const before = await api.read({ key: "appearanceTheme" });
+  expect(before).toBe("dark");
+  await api.write({ key: "appearanceTheme" }, "light");
+  expect(await api.read({ key: "appearanceTheme" })).toBe("light");
+  await api.write({ key: "appearanceTheme" }, before);
+  expect(await api.read({ key: "appearanceTheme" })).toBe("dark");
+  expect(mod.calls.map((call) => call[0])).toEqual([
+    route === "native" ? "native-read" : "get-setting",
+    route === "native" ? "native-write" : "set-setting",
+    route === "native" ? "native-read" : "get-setting",
+    route === "native" ? "native-write" : "set-setting",
+    route === "native" ? "native-read" : "get-setting",
+  ]);
+  const fetchedBefore = page.fetched.length;
+  expect(await page.run()).toMatchObject({ ok: true, cached: true, adapter });
+  expect(page.fetched).toHaveLength(fetchedBefore);
+  expect(new Set(page.fetched).size).toBe(page.fetched.length);
+}
+
+describe("native hot settings discovery executes across Codex versions", () => {
+  it("keeps the 26.707 eager adapter", async () => {
+    const page = await renderer({ "index-707.js": moduleSource(wrappers.legacy) }, {
+      adapters: ["26.707", "26.715", "26.831.21537+", "26.901.20858+"],
+    });
+    await assertRoundTrip(page, "26.707", "rpc");
+  });
+
+  it("keeps the 26.715 lazy setting-storage adapter", async () => {
+    const page = await renderer({
+      "index-715.js": 'const deps = ["./setting-storage-abc.js"];',
+      "setting-storage-abc.js": moduleSource(wrappers.legacy),
+    }, { loaded: ["index-715.js"], adapters: ["26.715", "26.707", "26.831.21537+", "26.901.20858+"] });
+    await assertRoundTrip(page, "26.715", "rpc");
+  });
+
+  it("keeps 26.831.21537 dollar identifiers and export aliases", async () => {
+    const page = await renderer({ "app-initial-old.js": moduleSource(wrappers["26.831.21537"].replace("as ezt", "as $ezt")) }, {
+      adapters: ["26.831.21537+", "26.715", "26.707", "26.901.20858+"],
+    });
+    await assertRoundTrip(page, "26.831.21537+", "rpc");
+  });
+
+  for (const version of ["26.901.20858", "26.901.22334"]) {
+    for (const native of [true, false]) {
+      it(`${version} reads, switches and restores with native bridge ${native ? "present" : "absent"}`, async () => {
+        const page = await renderer({ "app-initial-new.js": moduleSource(wrappers[version], native) });
+        await assertRoundTrip(page, "26.901.20858+", native ? "native" : "rpc");
+        if (!native) expect(await page.window.__camThemeSettingsV1.read({ key: "unset", default: "fallback" })).toBe("fallback");
+      });
+    }
+  }
+
+  it("falls back to the native adapter with a stale old version hint", async () => {
+    const page = await renderer({ "app-initial-new.js": moduleSource(wrappers["26.901.22334"]) }, {
+      adapters: ["26.831.21537+", "26.715", "26.707", "26.901.20858+"],
+    });
+    await assertRoundTrip(page, "26.901.20858+", "native");
+  });
+
+  it("accepts old wrappers when the version is unknown", async () => {
+    const page = await renderer({ "app-initial-old.js": moduleSource(wrappers["26.831.21537"]) });
+    await assertRoundTrip(page, "26.901.20858+", "rpc");
+  });
+
+  it("also follows lazy manifests for the native bridge", async () => {
+    const page = await renderer({
+      "index-new.js": 'const deps = ["setting-storage-new.js"];',
+      "setting-storage-new.js": moduleSource(wrappers["26.901.22334"]),
+    }, { loaded: ["index-new.js"] });
+    await assertRoundTrip(page, "26.901.20858+", "native");
+  });
+
+  it("tolerates renamed parameters, formatting, guards and duplicate export aliases", async () => {
+    const page = await renderer({ "app-initial-formatted.js": moduleSource(`
+async function $read ( $setting ) {
+  if (bX?.settings) return (await bX.settings.read($setting.key)).effective;
+  return ( await $rpc ( 'get-setting', { params: { key: $setting.key } } ) ).value ?? $setting.default;
+}
+async function $write ( $setting, $value ) {
+  if (bX?.settings) { await bX.settings.write($setting.key, $value); return; }
+  await $rpc ( "set-setting", { params: { key: $setting.key, value: $value } } );
+}
+export { $read as $r, $write as $w, $read as duplicateRead, $write as duplicateWrite };
+`) });
+    await assertRoundTrip(page, "26.901.20858+", "native");
+  });
+
+  for (const [name, change] of [
+    ["wrong key parameter", (source) => source.replace("key:e.key,value:t", "key:other.key,value:t")],
+    ["wrong value parameter", (source) => source.replace("key:e.key,value:t", "key:e.key,value:other")],
+    ["different RPC dispatchers", (source) => source.replace("await ED(`set-setting`", "await DD(`set-setting`")],
+    ["unexported wrappers", (source) => source.replace("export {bO as fUt,xO as vUt};", "")],
+    ["ambiguous readers", (source) => source + '\nexport async function extra(e){if(bX) return null;return(await ED(`get-setting`,{params:{key:e.key}})).value??e.default}'],
+    ["ambiguous writers", (source) => source + '\nexport async function extra(e,t){if(bX) return;await ED(`set-setting`,{params:{key:e.key,value:t}})}'],
+  ]) {
+    it(`rejects ${name} without calling candidates`, async () => {
+      const page = await renderer({ "app-initial-invalid.js": moduleSource(change(wrappers["26.901.22334"])) });
+      expect(await page.run()).toMatchObject({ ok: false, error: expect.stringContaining("settings module not found") });
+      expect(page.window.__camThemeSettingsV1).toBeUndefined();
+      expect((await page.module("app-initial-invalid.js")).calls).toEqual([]);
+    });
+  }
+
+  it("continues after failed fetches and imports without caching failures", async () => {
+    const page = await renderer({
+      "unreadable.js": "export {};",
+      "bad-import.js": moduleSource(wrappers["26.901.22334"]) + '\nthrow new Error("failed import");',
+      "app-initial-good.js": moduleSource(wrappers["26.901.22334"]),
+    }, { failures: ["unreadable.js"] });
+    await assertRoundTrip(page, "26.901.20858+", "native");
+  });
+
+  it("skips unrelated exports whose instrumented Function#toString throws", async () => {
+    const page = await renderer({
+      "app-initial-instrumented.js": moduleSource(wrappers["26.901.22334"]) + '\nexport function opaque() {}',
+    }, {
+      inspection: { prototype: { toString() {
+        if (this.name === "opaque") throw new TypeError("Function.prototype.toString requires that 'this' be a Function");
+        return Function.prototype.toString.call(this);
+      } } },
+    });
+    await assertRoundTrip(page, "26.901.20858+", "native");
+  });
+});

--- a/docs/native-settings-compatibility.md
+++ b/docs/native-settings-compatibility.md
@@ -1,0 +1,44 @@
+# Codex 热切换设置接口兼容性
+
+## 26.901 原生桥接边界
+
+2026-09-04 对镜像中的相邻 macOS 正式包与本机安装包进行了对比：
+
+| Codex 版本 | 设置包装函数 | 调用结构 |
+| --- | --- | --- |
+| [26.831.21537](https://github.com/Wangnov/codex-app-mirror/releases/tag/codex-app-26.831.21537) | `QD` / `$D` | 直接调用 `get-setting` / `set-setting` RPC |
+| [26.901.20858](https://github.com/Wangnov/codex-app-mirror/releases/tag/codex-app-26.901.20858)（build 7658） | `xO` / `SO` | 优先使用 app-host 的 `settings.read` / `settings.write`，缺席时回退 RPC |
+| [26.901.22334](https://github.com/Wangnov/codex-app-mirror/releases/tag/codex-app-26.901.22334)（build 7746） | `bO` / `xO` | 同上；本机真实读写验证版本 |
+
+镜像中首次出现该结构的 macOS 正式版本是 **26.901.20858**，不是 26.901.22334。
+从该版本起优先使用新适配器。版本只决定探测顺序；旧版本提示或未知版本仍会探测其他适配器，并验证实际函数结构。
+本次未运行历史 Windows 安装包，不将 macOS 包的证据写成 Windows 实机验证。
+
+26.901.20858 的 Sparkle ZIP 中 `ChatGPT.app/Contents/Resources/app.asar` 经 ZIP 大小和 CRC32 校验：
+
+- 大小：296097431 字节。
+- SHA-256：`3dee62fa9bfabc58d1c96d9de1b04ab2a09597e78b9f39f14403e26d627f8b73`。
+- 设置所在 chunk：`webview/assets/app-initial-7a6c8787453d.js`。
+- 本机 26.901.22334 对应 chunk：`webview/assets/app-initial-f1c3ba37268a.js`。
+
+## 根因与修复约束
+
+Manager 0.5.3 的正则要求读写函数的整个函数体都是旧 RPC 形状。新版本增加原生桥接分支后，CDP 仍正常连通，但三个旧适配器均无法定位设置模块。
+
+新适配器导入候选 chunk 后检查实际导出函数，按参数与 RPC 回退载荷识别读写契约，不依赖压缩函数名、导出别名或完整函数体形状。读写必须唯一且使用同一个 RPC 调用入口；同一函数的重复导出别名会去重；无法检查的无关导出会跳过。Codex 的函数监测包装可能使 `Function.prototype.toString` 抛错，这一情况已在本机实测并纳入回归测试。
+
+定位期间不调用设置读写函数。调用时仍执行 Codex 自己的包装函数，保留原生桥接选择、RPC 回退、默认值与副作用。旧版 26.707、26.715、26.831.21537 适配器继续保留；未知新结构若无法证明匹配，仍会明确报错，不声称兼容所有未来版本。
+
+## 验证
+
+- `src/runtime/native-hot-discovery.test.mjs`（相对 `crates/codex-theme-engine/`）执行 Rust 中嵌入的生产脚本与真实 ESM 导入，覆盖新旧包装函数、原生/RPC 两条路径、切换及恢复、缓存、懒加载、过期版本提示、歧义/错误参数拒绝与无法检查的导出。
+- Rust 单元测试固定 `26.901.20858` 边界与完整探测顺序。
+- 本机 26.901.22334：旧版定位脚本仍复现 `settings module not found`；修复后的 `live_hot_settings_same_value_round_trip` 完成五项外观设置读取、原值写回和复读一致性验证，不改变当前视觉设置。
+
+```sh
+npm test -- crates/codex-theme-engine/src/runtime/native-hot-discovery.test.mjs
+cargo test --manifest-path crates/codex-theme-engine/Cargo.toml native_hot --lib
+# 仅在开发机已运行启用 9345 CDP 端口的 Codex 时执行；会写回现有外观设置。
+cargo test --manifest-path crates/codex-theme-engine/Cargo.toml \
+  --test real_packages live_hot_settings_same_value_round_trip -- --ignored --nocapture
+```

--- a/docs/releases/v0.5.4.md
+++ b/docs/releases/v0.5.4.md
@@ -1,0 +1,47 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 修复 Codex 26.901 系列的皮肤试穿与切换，保留旧版本兼容，并恢复 winget 自动提交。
+> Restores skin try-on and switching on Codex 26.901 builds, retains older-version support, and repairs automated winget submissions.
+
+## 🐛 修复 · Fixes
+
+- **新版 Codex 可再次试穿和切换皮肤**：Codex `26.901.20858` 起新增原生设置桥接，导致旧版管理器报 `settings module not found`。现在从该版本起优先使用新版适配器，并已在 `26.901.22334` 上完成真实设置读写验证。
+  Skin try-on and switching work on newer Codex builds again: the native settings bridge introduced in Codex `26.901.20858` caused older Manager releases to report `settings module not found`. A new adapter is preferred from that version onward and has passed live settings read/write verification on `26.901.22334`.
+
+- **设置接口识别更稳健**：不再依赖新版读写函数的完整压缩形状；会跳过无法检查的无关导出，并保留 Codex 自身的原生接口、旧接口回退和既有旧版本适配。
+  More resilient settings discovery: the new adapter no longer depends on exact minified function bodies, skips unrelated exports that cannot be inspected, and preserves Codex's native/legacy dispatch along with existing older-version adapters.
+
+- **恢复 winget 版本提交**：修复发布后自动向 `winget-pkgs` 提交更新的流程；具体版本仍需上游审核合并后才会在 winget 中可用。
+  Restored winget submissions: releases can once again submit updates to `winget-pkgs` automatically. Each version becomes available through winget after upstream review and merge.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "base64 0.23.1",
  "codex-mac-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.5.3"
+version = "0.5.4"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## 变更

- 修复 Codex 26.901 新增原生设置桥接后皮肤试穿/切换失败的问题；以镜像中首次出现新结构的 26.901.20858 为优先适配边界，保留三个旧适配器与过期版本提示回退。
- 按实际导出函数的参数和 RPC 回退载荷定位原始读写包装函数，保留 Codex 自身原生/旧接口调度；跳过被函数监测包装影响的无关导出。
- 新增 19 项实际 JavaScript/ESM 执行回归测试、Rust 版本边界测试和包级证据文档。
- 按规范更新 5 个文件中的 6 处应用版本声明至 0.5.4，并添加双语发布说明（包含上次 tag 后已合并的 winget 提交流程修复）。

## 验证

- npm run check / lint / test / build：全部通过，358 tests。
- cargo clippy（src-tauri workspace，deny warnings）与 src-tauri、mac/win/theme 三引擎全部测试：通过，331 tests，4 项环境依赖测试默认忽略。
- 本机 Codex 26.901.22334：旧版 0.5.3 定位脚本复现 settings module not found；新引擎完成五项外观设置读取、原值写回和复读一致性验证。
- codex review --uncommitted：全部变更及新文件已审查，无待修复意见。
- node scripts/check-release-version.mjs source v0.5.4 .：6 处版本一致。

等待所有 CI（含非必需 nsis 安装包检查）通过后 squash 合并，再于 main HEAD 打 annotated tag v0.5.4 发版。