### PR TITLE
chore(release): bump version to 0.5.5

### DIFF
--- a/docs/releases/v0.5.5.md
+++ b/docs/releases/v0.5.5.md
@@ -1,0 +1,47 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 管理器长期打开时也能发现自身更新，首页手动检查同时检查 Codex 与管理器。
+> Manager updates are now detected while the app stays open, and the home screen's manual check covers both Codex and Manager.
+
+## 🐛 修复 · Fixes
+
+- **不重启也能收到管理器更新横幅**：管理器自身更新接入现有周期检查，沿用设置中的开关与时间间隔；修改设置后立即调整检查计划，不再只在启动时检查一次。
+  Manager update banners no longer require a restart: self-update checks now follow the existing periodic-check toggle and interval, with schedule changes taking effect as soon as settings are saved.
+
+- **首页“重新检查”同时检查两种更新**：macOS 和 Windows 首页都会并行检查 Codex 与管理器，即使关闭自动检查也可手动发现管理器新版；其中一项检查失败不会遮蔽另一项的结果。
+  The home screen's manual check now checks Codex and Manager in parallel on both macOS and Windows, even when automatic checks are disabled. A failure in one check does not hide the other's result.
+
+- **更新提示更稳定**：重复检查会合并请求，临时断网不会清掉已发现的更新；确认或安装管理器更新期间，后台检查不会替换正在确认的版本。
+  More stable update prompts: overlapping checks share one request, temporary connection failures preserve known updates, and background checks cannot replace a version being confirmed or installed.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "base64 0.23.1",
  "codex-mac-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.5.4"
+version = "0.5.5"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/app/ManagerUpdatePrompt.test.tsx
+++ b/src/app/ManagerUpdatePrompt.test.tsx
@@ -1,9 +1,10 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   managerApi,
+  SETTINGS_CHANGED_EVENT,
   type ManagerUpdateAvailable,
   type ManagerUpdateCheck,
 } from "../services/managerApi";
@@ -41,24 +42,31 @@ function available(
   };
 }
 
-function PromptHost({ visible = true }: { visible?: boolean }) {
+function PromptHost({ visible = true, manual = false }: { visible?: boolean; manual?: boolean }) {
   const controller = useManagerUpdatePrompt();
-  return visible ? <ManagerUpdatePrompt {...controller} /> : null;
+  return (
+    <>
+      {manual ? <button onClick={controller.check}>手动刷新</button> : null}
+      {visible ? <ManagerUpdatePrompt {...controller} /> : null}
+    </>
+  );
 }
 
-function promptTree(visible = true) {
+function promptTree(visible = true, manual = false) {
   return (
     <I18nProvider>
-      <PromptHost visible={visible} />
+      <PromptHost visible={visible} manual={manual} />
     </I18nProvider>
   );
 }
 
-function renderPrompt() {
-  return render(promptTree());
+function renderPrompt(manual = false) {
+  return render(promptTree(true, manual));
 }
 
 describe("ManagerUpdatePrompt", () => {
+  afterEach(() => vi.useRealTimers());
+
   beforeEach(() => {
     localStorage.setItem("cam.lang", "zh-CN");
     api.getSettingsStrict.mockReset();
@@ -264,5 +272,211 @@ describe("ManagerUpdatePrompt", () => {
 
     await screen.findByRole("alert");
     expect(within(dialog).getByRole("button", { name: "更新" })).toBeEnabled();
+  });
+
+  it("finds a release published after startup at the configured interval", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    api.getSettingsStrict.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      periodicCheckIntervalSeconds: 120,
+    });
+    api.checkManagerUpdate.mockResolvedValueOnce({ kind: "none" }).mockResolvedValue(available());
+    renderPrompt();
+    await act(async () => {});
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+
+    await act(() => vi.advanceTimersByTimeAsync(119_999));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    expect(await screen.findByText("发现管理器新版本 0.5.3")).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs periodic checks independently of startup checks and clamps the interval", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    api.getSettingsStrict.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      checkOnStartup: false,
+      periodicCheckIntervalSeconds: 1,
+    });
+    api.checkManagerUpdate.mockResolvedValue(available());
+    renderPrompt();
+    await act(async () => {});
+
+    await act(() => vi.advanceTimersByTimeAsync(59_999));
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    expect(await screen.findByText("发现管理器新版本 0.5.3")).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows an explicit manual check when both automatic settings are disabled", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    api.getSettingsStrict.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      checkOnStartup: false,
+      periodicCheck: false,
+    });
+    api.checkManagerUpdate.mockResolvedValue(available());
+    renderPrompt(true);
+    await act(async () => {});
+    await act(() => vi.advanceTimersByTimeAsync(3_600_000));
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "手动刷新" }));
+    expect(await screen.findByText("发现管理器新版本 0.5.3")).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies saved interval and toggle changes without restarting", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const initial = { ...DEFAULT_SETTINGS, checkOnStartup: false, periodicCheck: false };
+    api.getSettingsStrict.mockResolvedValue(initial);
+    api.checkManagerUpdate.mockResolvedValue({ kind: "none" });
+    renderPrompt();
+    await act(async () => {});
+
+    const save = (periodicCheck: boolean, periodicCheckIntervalSeconds: number) =>
+      act(() => {
+        window.dispatchEvent(new CustomEvent(SETTINGS_CHANGED_EVENT, {
+          detail: { ...initial, periodicCheck, periodicCheckIntervalSeconds },
+        }));
+      });
+    save(true, 120);
+    await act(() => vi.advanceTimersByTimeAsync(120_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    save(true, 180);
+    await act(() => vi.advanceTimersByTimeAsync(120_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    await act(() => vi.advanceTimersByTimeAsync(60_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    save(false, 180);
+    await act(() => vi.advanceTimersByTimeAsync(3_600_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a late settings read re-enable checks after they were disabled", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    let resolveSettings!: (value: typeof DEFAULT_SETTINGS) => void;
+    api.getSettingsStrict.mockReturnValue(new Promise((resolve) => { resolveSettings = resolve; }));
+    api.checkManagerUpdate.mockResolvedValue({ kind: "none" });
+    renderPrompt();
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(SETTINGS_CHANGED_EVENT, {
+        detail: { ...DEFAULT_SETTINGS, checkOnStartup: false, periodicCheck: false },
+      }));
+      resolveSettings(DEFAULT_SETTINGS);
+    });
+    await act(() => vi.advanceTimersByTimeAsync(3_600_000));
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+  });
+
+  it("never schedules automatic checks after a settings failure but permits manual checks", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    api.getSettingsStrict.mockRejectedValue(new Error("settings unavailable"));
+    api.checkManagerUpdate.mockResolvedValue(available());
+    renderPrompt(true);
+    await act(async () => {});
+    await act(() => vi.advanceTimersByTimeAsync(3_600_000));
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "手动刷新" }));
+    expect(await screen.findByText("发现管理器新版本 0.5.3")).toBeInTheDocument();
+  });
+
+  it("coalesces startup, periodic and manual requests while the feed is pending", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    let resolveCheck!: (value: ManagerUpdateCheck) => void;
+    api.checkManagerUpdate.mockReturnValue(new Promise((resolve) => { resolveCheck = resolve; }));
+    renderPrompt(true);
+    await act(async () => {});
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    await act(() => vi.advanceTimersByTimeAsync(3_600_000));
+    await user.click(screen.getByRole("button", { name: "手动刷新" }));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    await act(async () => resolveCheck(available()));
+    expect(await screen.findByText("发现管理器新版本 0.5.3")).toBeInTheDocument();
+  });
+
+  it("keeps a known update during transient feed failures but clears it after a successful empty result", async () => {
+    const user = userEvent.setup();
+    api.checkManagerUpdate.mockResolvedValueOnce(available())
+      .mockResolvedValueOnce({ kind: "unavailable" })
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({ kind: "none" });
+    renderPrompt(true);
+    await screen.findByText("发现管理器新版本 0.5.3");
+    const manual = screen.getByRole("button", { name: "手动刷新" });
+    await user.click(manual);
+    expect(screen.getByText("发现管理器新版本 0.5.3")).toBeInTheDocument();
+    await user.click(manual);
+    expect(screen.getByText("发现管理器新版本 0.5.3")).toBeInTheDocument();
+    await user.click(manual);
+    expect(screen.queryByText("发现管理器新版本 0.5.3")).not.toBeInTheDocument();
+  });
+
+  it("does not replace the confirmed version with an earlier in-flight result and resumes after cancel", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const old = available();
+    const next = available({ version: "0.5.4" });
+    let resolveCheck!: (value: ManagerUpdateCheck) => void;
+    api.checkManagerUpdate.mockResolvedValueOnce(old)
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveCheck = resolve; }))
+      .mockResolvedValue(next);
+    renderPrompt(true);
+    await screen.findByText("发现管理器新版本 0.5.3");
+    await user.click(screen.getByRole("button", { name: "手动刷新" }));
+    await user.click(screen.getByRole("button", { name: "更新" }));
+    await act(async () => resolveCheck(next));
+    expect(screen.getByRole("dialog", { name: "更新到 0.5.3?" })).toBeInTheDocument();
+    expect(old.discard).not.toHaveBeenCalled();
+    expect(next.discard).toHaveBeenCalledTimes(1);
+    await act(() => vi.advanceTimersByTimeAsync(3_600_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    await user.click(screen.getByRole("button", { name: "取消" }));
+    await act(() => vi.advanceTimersByTimeAsync(900_000));
+    expect(await screen.findByText("发现管理器新版本 0.5.4")).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps checks paused until a failed installation is dismissed", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    let rejectInstall!: (reason: Error) => void;
+    const update = available({ installAndRelaunch: vi.fn(() => new Promise<void>((_, reject) => { rejectInstall = reject; })) });
+    api.checkManagerUpdate.mockResolvedValue(update);
+    renderPrompt();
+    await user.click(await screen.findByRole("button", { name: "更新" }));
+    await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "更新" }));
+    await act(() => vi.advanceTimersByTimeAsync(900_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    await act(async () => rejectInstall(new Error("offline")));
+    await act(() => vi.advanceTimersByTimeAsync(900_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button", { name: "取消" }));
+    await act(() => vi.advanceTimersByTimeAsync(900_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("cleans up the timer and settings listener and discards late results on unmount", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    let resolveCheck!: (value: ManagerUpdateCheck) => void;
+    api.checkManagerUpdate.mockReturnValue(new Promise((resolve) => { resolveCheck = resolve; }));
+    const { unmount } = renderPrompt();
+    await act(async () => {});
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    unmount();
+    const update = available();
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(SETTINGS_CHANGED_EVENT, { detail: DEFAULT_SETTINGS }));
+      resolveCheck(update);
+    });
+    await act(() => vi.advanceTimersByTimeAsync(3_600_000));
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+    expect(update.discard).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/app/ManagerUpdatePrompt.tsx
+++ b/src/app/ManagerUpdatePrompt.tsx
@@ -10,8 +10,10 @@ import {
 import {
   errorCode,
   managerApi,
+  SETTINGS_CHANGED_EVENT,
   type ManagerUpdateAvailable,
 } from "../services/managerApi";
+import type { AppSettings } from "../shared/types";
 import { StatusBanner, Ring } from "./components";
 import { userErrorMessage } from "./errorCopy";
 import { useI18n } from "./i18n";
@@ -19,19 +21,28 @@ import { Sheet } from "./Sheet";
 
 export interface ManagerUpdatePromptController {
   update: ManagerUpdateAvailable | null;
+  check: () => Promise<void>;
   refresh: () => Promise<void>;
+  setChecksPaused: (paused: boolean) => void;
 }
 
 /**
- * Owns the one-per-session startup check. Home calls this hook at its stable
+ * Owns startup and periodic checks. Home calls this hook at its stable
  * platform-dispatch layer, so Codex progress/finished screens can hide the
- * prompt without remounting the checker and contacting the feed again.
+ * prompt without restarting the schedule. Manual home checks share the same
+ * in-flight request; returning from settings does not remount the checker.
  */
 export function useManagerUpdatePrompt(): ManagerUpdatePromptController {
   const [update, setUpdate] = useState<ManagerUpdateAvailable | null>(null);
   const updateRef = useRef<ManagerUpdateAvailable | null>(null);
   const mountedRef = useRef(false);
   const checkingRef = useRef<Promise<void> | null>(null);
+  const checksPausedRef = useRef(false);
+  const [settings, setSettings] = useState<AppSettings | null>(null);
+
+  const setChecksPaused = useCallback((paused: boolean) => {
+    checksPausedRef.current = paused;
+  }, []);
 
   const replaceUpdate = useCallback((next: ManagerUpdateAvailable | null) => {
     const previous = updateRef.current;
@@ -41,17 +52,24 @@ export function useManagerUpdatePrompt(): ManagerUpdatePromptController {
   }, []);
 
   const check = useCallback((): Promise<void> => {
+    if (checksPausedRef.current) return Promise.resolve();
     if (checkingRef.current) return checkingRef.current;
 
     const pending = managerApi
       .checkManagerUpdate()
       .then((result) => {
-        if (result.kind === "available") {
-          if (mountedRef.current) replaceUpdate(result);
-          else void result.discard();
+        // A background result must not replace/discard the version the user
+        // is confirming or installing, even if its request started earlier.
+        if (!mountedRef.current || checksPausedRef.current) {
+          if (result.kind === "available") void result.discard();
           return;
         }
-        if (mountedRef.current) replaceUpdate(null);
+        if (result.kind === "available") {
+          replaceUpdate(result);
+          return;
+        }
+        // An offline/feed failure is not evidence that a known update vanished.
+        if (result.kind === "none") replaceUpdate(null);
       })
       .catch(() => {
         // Startup checks are deliberately quiet. About keeps the explicit
@@ -67,24 +85,45 @@ export function useManagerUpdatePrompt(): ManagerUpdatePromptController {
   useEffect(() => {
     mountedRef.current = true;
     let active = true;
+    let settingsChanged = false;
+    const onSettingsChanged = (event: Event) => {
+      settingsChanged = true;
+      setSettings((event as CustomEvent<AppSettings>).detail);
+    };
+    window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged);
 
     // Fail closed when local settings cannot be read: an uncertain preference
     // must not become an unsolicited network request.
     void managerApi
       .getSettingsStrict()
       .then((settings) => {
-        if (active && settings.checkOnStartup) void check();
+        // A slow startup read must not overwrite a newer saved preference.
+        if (!active || settingsChanged) return;
+        setSettings(settings);
+        if (settings.checkOnStartup) void check();
       })
       .catch(() => undefined);
 
     return () => {
       active = false;
       mountedRef.current = false;
+      window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged);
       const retained = updateRef.current;
       updateRef.current = null;
       void retained?.discard();
     };
   }, [check]);
+
+  const periodicCheck = settings?.periodicCheck ?? false;
+  const intervalSeconds = settings?.periodicCheckIntervalSeconds ?? 900;
+  useEffect(() => {
+    if (!periodicCheck) return;
+    const id = window.setInterval(
+      () => void check(),
+      Math.max(60_000, intervalSeconds * 1000),
+    );
+    return () => window.clearInterval(id);
+  }, [check, periodicCheck, intervalSeconds]);
 
   const refresh = useCallback(async () => {
     // A stale expectation can never succeed on retry. Remove it before asking
@@ -93,7 +132,10 @@ export function useManagerUpdatePrompt(): ManagerUpdatePromptController {
     await check();
   }, [check, replaceUpdate]);
 
-  return useMemo(() => ({ update, refresh }), [refresh, update]);
+  return useMemo(
+    () => ({ update, check, refresh, setChecksPaused }),
+    [check, refresh, setChecksPaused, update],
+  );
 }
 
 /**
@@ -104,6 +146,7 @@ export function useManagerUpdatePrompt(): ManagerUpdatePromptController {
 export function ManagerUpdatePrompt({
   update,
   refresh,
+  setChecksPaused,
 }: ManagerUpdatePromptController) {
   const { t } = useI18n();
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -112,11 +155,14 @@ export function ManagerUpdatePrompt({
   const titleId = useId();
   const bodyId = useId();
 
+  useEffect(() => () => setChecksPaused(false), [setChecksPaused]);
+
   const closeConfirm = useCallback(() => {
     if (installing) return;
+    setChecksPaused(false);
     setConfirmOpen(false);
     setFailure(null);
-  }, [installing]);
+  }, [installing, setChecksPaused]);
 
   const installUpdate = useCallback(async () => {
     if (!update || installing) return;
@@ -126,6 +172,7 @@ export function ManagerUpdatePrompt({
       await update.installAndRelaunch();
     } catch (cause) {
       if (errorCode(cause) === "stale_expectation") {
+        setChecksPaused(false);
         setConfirmOpen(false);
         await refresh();
       } else {
@@ -134,7 +181,7 @@ export function ManagerUpdatePrompt({
     } finally {
       setInstalling(false);
     }
-  }, [installing, refresh, t, update]);
+  }, [installing, refresh, setChecksPaused, t, update]);
 
   if (!update) return null;
 
@@ -149,6 +196,7 @@ export function ManagerUpdatePrompt({
               type="button"
               className="btn primary sm"
               onClick={() => {
+                setChecksPaused(true);
                 setFailure(null);
                 setConfirmOpen(true);
               }}

--- a/src/app/views/Home.test.tsx
+++ b/src/app/views/Home.test.tsx
@@ -210,6 +210,53 @@ describe("MacHome state machine", () => {
     expect(screen.getByRole("button", { name: /立即更新/ })).toBeEnabled();
   });
 
+  it("manually checks Codex and Manager with automatic checks disabled", async () => {
+    const user = userEvent.setup();
+    const manualOnly = settings({ checkOnStartup: false, periodicCheck: false });
+    api.getSettings.mockResolvedValue(manualOnly);
+    api.getSettingsStrict.mockResolvedValue(manualOnly);
+    api.macPlanUpdate.mockResolvedValue(REPORT_UPTODATE);
+    api.checkManagerUpdate.mockResolvedValue({
+      kind: "available", version: "0.5.5", currentVersion: "0.5.4",
+      installAndRelaunch: vi.fn(), discard: vi.fn(),
+    });
+    renderHome();
+    const recheck = await screen.findByRole("button", { name: "重新检查" });
+    expect(api.macPlanUpdate).not.toHaveBeenCalled();
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+    await user.click(recheck);
+    expect(await screen.findByText("发现管理器新版本 0.5.5")).toBeInTheDocument();
+    expect(await screen.findByText("已是最新", { selector: ".headline" })).toBeInTheDocument();
+    expect(api.macPlanUpdate).toHaveBeenCalledTimes(1);
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("finds a Manager update even when the parallel Codex check fails", async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await screen.findByRole("button", { name: "重新检查" });
+    api.macPlanUpdate.mockRejectedValue(new Error("Codex feed offline"));
+    api.checkManagerUpdate.mockResolvedValue({
+      kind: "available", version: "0.5.5", currentVersion: "0.5.4",
+      installAndRelaunch: vi.fn(), discard: vi.fn(),
+    });
+    await user.click(screen.getByRole("button", { name: "重新检查" }));
+    expect(await screen.findByText("发现管理器新版本 0.5.5")).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    expect(api.macPlanUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a failed Manager check hide a successful Codex check", async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await screen.findByRole("button", { name: "重新检查" });
+    api.macPlanUpdate.mockResolvedValue(REPORT_UPTODATE);
+    api.checkManagerUpdate.mockResolvedValue({ kind: "unavailable" });
+    await user.click(screen.getByRole("button", { name: "重新检查" }));
+    expect(await screen.findByText("已是最新", { selector: ".headline" })).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+  });
+
   it("routes the update CTA through the confirm sheet when askBefore is on", async () => {
     const user = userEvent.setup();
     renderHome();

--- a/src/app/views/Home.tsx
+++ b/src/app/views/Home.tsx
@@ -253,6 +253,9 @@ function MacHome({
     }
   }, [refreshStatus, t]);
 
+  const checkAllUpdates = () =>
+    Promise.all([check(), managerUpdatePrompt.check()]);
+
   useEffect(() => {
     void (async () => {
       const s = await managerApi.getSettings().catch(() => DEFAULT_SETTINGS);
@@ -1225,7 +1228,7 @@ function MacHome({
             <>
               <button
                 className="btn ghost big"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />
@@ -1255,7 +1258,7 @@ function MacHome({
               </button>
               <button
                 className="btn ghost"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />
@@ -1319,7 +1322,7 @@ function MacHome({
               </button>
               <button
                 className="btn ghost"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />
@@ -1342,7 +1345,7 @@ function MacHome({
                 </button>
                 <button
                   className="btn ghost"
-                  onClick={check}
+                  onClick={checkAllUpdates}
                   disabled={busy !== null}
                 >
                   <Icon name="refresh" />
@@ -1352,7 +1355,7 @@ function MacHome({
             ) : (
               <button
                 className="btn primary big"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />

--- a/src/app/views/WinHome.test.tsx
+++ b/src/app/views/WinHome.test.tsx
@@ -21,6 +21,7 @@ import type {
 import { DEFAULT_SETTINGS, emptyOperationOutcome } from "../../shared/types";
 import { I18nProvider } from "../i18n";
 import { ThemeProvider } from "../theme";
+import { useManagerUpdatePrompt } from "../ManagerUpdatePrompt";
 import { WinHome } from "./WinHome";
 
 vi.mock("../motion", () => ({ useHomeMotion: () => {} }));
@@ -179,11 +180,16 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
   return { ...DEFAULT_SETTINGS, ...overrides };
 }
 
-function renderWinHome() {
+function WinHomeWithManagerPrompt() {
+  const managerUpdatePrompt = useManagerUpdatePrompt();
+  return <WinHome onOpenSettings={vi.fn()} managerUpdatePrompt={managerUpdatePrompt} />;
+}
+
+function renderWinHome(withManagerPrompt = false) {
   return render(
     <ThemeProvider>
       <I18nProvider>
-        <WinHome onOpenSettings={vi.fn()} />
+        {withManagerPrompt ? <WinHomeWithManagerPrompt /> : <WinHome onOpenSettings={vi.fn()} />}
       </I18nProvider>
     </ThemeProvider>,
   );
@@ -208,6 +214,7 @@ describe("WinHome state machine", () => {
     api.checkManagerUpdate.mockResolvedValue({ kind: "none" });
     api.getOperationCompletion.mockResolvedValue(null);
     api.getSettings.mockResolvedValue(settings());
+    api.getSettingsStrict.mockResolvedValue(settings());
     api.winDefaultInstallRoot.mockResolvedValue(DEFAULT_SETTINGS.installRoot);
     api.winStatus.mockResolvedValue(STATUS_MANAGED);
     api.winPlanUpdate.mockResolvedValue(report());
@@ -238,6 +245,52 @@ describe("WinHome state machine", () => {
     expect(
       screen.getByRole("button", { name: /选择安装版本/ }),
     ).toBeInTheDocument();
+  });
+
+  it("manually checks Codex and Manager with automatic checks disabled", async () => {
+    const user = userEvent.setup();
+    const manualOnly = settings({ checkOnStartup: false, periodicCheck: false });
+    api.getSettings.mockResolvedValue(manualOnly);
+    api.getSettingsStrict.mockResolvedValue(manualOnly);
+    api.checkManagerUpdate.mockResolvedValue({
+      kind: "available", version: "0.5.5", currentVersion: "0.5.4",
+      installAndRelaunch: vi.fn(), discard: vi.fn(),
+    });
+    renderWinHome(true);
+    const recheck = await screen.findByRole("button", { name: "重新检查" });
+    expect(api.winPlanUpdate).not.toHaveBeenCalled();
+    expect(api.checkManagerUpdate).not.toHaveBeenCalled();
+    await user.click(recheck);
+    expect(await screen.findByText("发现管理器新版本 0.5.5")).toBeInTheDocument();
+    expect(await screen.findByText("有新版本", { selector: ".headline" })).toBeInTheDocument();
+    expect(api.winPlanUpdate).toHaveBeenCalledTimes(1);
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("finds a Manager update even when the parallel Codex check fails", async () => {
+    const user = userEvent.setup();
+    renderWinHome(true);
+    await screen.findByRole("button", { name: "重新检查" });
+    api.winPlanUpdate.mockRejectedValue(new Error("Codex feed offline"));
+    api.checkManagerUpdate.mockResolvedValue({
+      kind: "available", version: "0.5.5", currentVersion: "0.5.4",
+      installAndRelaunch: vi.fn(), discard: vi.fn(),
+    });
+    await user.click(screen.getByRole("button", { name: "重新检查" }));
+    expect(await screen.findByText("发现管理器新版本 0.5.5")).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    expect(api.winPlanUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a failed Manager check hide a successful Codex check", async () => {
+    const user = userEvent.setup();
+    renderWinHome(true);
+    await screen.findByRole("button", { name: "重新检查" });
+    api.checkManagerUpdate.mockResolvedValue({ kind: "unavailable" });
+    await user.click(screen.getByRole("button", { name: "重新检查" }));
+    expect(await screen.findByText("有新版本", { selector: ".headline" })).toBeInTheDocument();
+    expect(api.checkManagerUpdate).toHaveBeenCalledTimes(2);
+    expect(api.winPlanUpdate).toHaveBeenCalledTimes(2);
   });
 
   it("signs the perform expectation from the SAME report snapshot it shows", async () => {

--- a/src/app/views/WinHome.tsx
+++ b/src/app/views/WinHome.tsx
@@ -282,6 +282,9 @@ export function WinHome({
     }
   }, [beginOperation, finishOperation, runCheck]);
 
+  const checkAllUpdates = () =>
+    Promise.all([check(), managerUpdatePrompt?.check()]);
+
   const refreshStatus = useCallback(
     async (generation?: number) => {
       const canApply = () =>
@@ -1608,7 +1611,12 @@ export function WinHome({
           {!rechecking && provenanceRecoveryPending && kind !== "external" ? (
             <button
               className="btn primary big"
-              onClick={() => void recheckProvenanceRecovery()}
+              onClick={() =>
+                void Promise.all([
+                  recheckProvenanceRecovery(),
+                  managerUpdatePrompt?.check(),
+                ])
+              }
               disabled={busy !== null}
             >
               <Icon name="refresh" />
@@ -1619,7 +1627,7 @@ export function WinHome({
             <>
               <button
                 className="btn ghost big"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />
@@ -1644,7 +1652,7 @@ export function WinHome({
               {launchButton("primary")}
               <button
                 className="btn ghost"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />
@@ -1680,7 +1688,7 @@ export function WinHome({
               {launchButton("primary")}
               <button
                 className="btn ghost"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />
@@ -1696,7 +1704,7 @@ export function WinHome({
                 {launchButton("primary")}
                 <button
                   className="btn ghost"
-                  onClick={check}
+                  onClick={checkAllUpdates}
                   disabled={busy !== null}
                 >
                   <Icon name="refresh" />
@@ -1706,7 +1714,7 @@ export function WinHome({
             ) : (
               <button
                 className="btn primary big"
-                onClick={check}
+                onClick={checkAllUpdates}
                 disabled={busy !== null}
               >
                 <Icon name="refresh" />


### PR DESCRIPTION
## 变更

- 修复管理器常驻运行时无法发现自身新版本：复用 `periodicCheck` 与现有间隔，设置修改立即生效，读取设置失败时不擅自开启网络检查。
- macOS / Windows 首页的“重新检查”并行检查 Codex 与管理器；关闭自动检查不影响用户手动检查。
- 请求去重、临时失败保留已知更新；更新确认和安装期间暂停后台刷新，并丢弃此前未完成的后台结果，保持确认版本稳定。
- 按项目发版约定同步 5 个文件的 6 处版本号至 0.5.5，并加入双语发布说明。

## 验证

- `codex review --uncommitted`：已审查全部变更及发布说明，无需修复的明确缺陷。
- `npm run check` / `npm run lint` / `npm test` / `npm run build`：通过，375 项测试；新增 17 项回归。
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`：通过。
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace`：168 项通过。
- `node scripts/check-release-version.mjs source v0.5.5 .`：6 处版本一致。
- Playwright / Chromium 实际渲染验证：macOS 和 Windows 首页手动检查 → 更新横幅 → 确认按钮；macOS 模拟时钟推进 15 分钟自动发现新版；400×700 与 1024×800 视口；无页面或控制台错误。
- 浏览器验证模拟原生 API 返回值，不执行真实安装；原生打包与安装流程由 PR macOS packaged smoke / Windows NSIS 检查覆盖。

## 发布

待所有必需检查及 NSIS、macOS packaged smoke 通过后 squash 合并，在合并后的 main HEAD 打 annotated tag `v0.5.5`，由现有 Release 流程发布四平台工件并验证双镜像和签名。
