### PR TITLE
chore(release): bump version to 0.5.6

### DIFF
--- a/crates/codex-theme-engine/src/cdp.rs
+++ b/crates/codex-theme-engine/src/cdp.rs
@@ -381,7 +381,7 @@ pub const PROBE_EXPRESSION: &str = r#"(() => {
     const markers = {
       shell: Boolean(document.querySelector('main[data-app-shell-main-surface], main.main-surface')),
       sidebar: Boolean(document.querySelector('.app-shell-left-panel')),
-      composer: Boolean(document.querySelector('.composer-surface-chrome')),
+      composer: Boolean(document.querySelector('.composer-surface-chrome, [data-codex-composer-root] [data-composer-surface-variant][data-composer-layout]')),
       main: Boolean(document.querySelector('[role="main"]')),
     };
     const shellMatch = markers.shell && markers.sidebar && (markers.composer || markers.main);

--- a/crates/codex-theme-engine/src/payload.rs
+++ b/crates/codex-theme-engine/src/payload.rs
@@ -11,10 +11,10 @@ use crate::theme::{
 };
 use crate::{Result, ENGINE_VERSION};
 
-/// The injected renderer runtime — codex-theme-studio's file verbatim. It
+/// The injected renderer runtime — maintained from codex-theme-studio. It
 /// encodes the flicker discipline (compare-before-write), sticky route
-/// detection, icon annotation and cleanup contract; edit it in the studio,
-/// not here.
+/// detection, icon annotation and cleanup contract, plus Manager's host
+/// compatibility shims for existing skin packages.
 const RUNTIME_TEMPLATE: &str = include_str!("runtime/theme-runtime.js");
 const COMPOSER_OVERFLOW_MODULE: &str = include_str!("runtime/composer-overflow.mjs");
 
@@ -119,7 +119,7 @@ pub fn build_payload_from(theme: LoadedTheme) -> Result<BuiltPayload> {
 fn composer_overflow_helpers_expression() -> String {
     let module = COMPOSER_OVERFLOW_MODULE.replace("export function ", "function ");
     format!(
-        "(() => {{\n{module}\nreturn {{ createComposerOverflowAnnotator, selectComposerSurfaces }};\n}})()"
+        "(() => {{\n{module}\nreturn {{ clearComposerSurfaceCompat, createComposerOverflowAnnotator, reconcileComposerSurfaces, selectComposerSurfaces }};\n}})()"
     )
 }
 
@@ -159,6 +159,10 @@ pub const REMOVE_EXPRESSION: &str = r#"(() => {
   document.querySelectorAll('[data-cts-menu-region]').forEach((node) => node.removeAttribute('data-cts-menu-region'));
   document.querySelectorAll('[data-cts-composer-overflow]').forEach((node) => node.removeAttribute('data-cts-composer-overflow'));
   document.querySelectorAll('[data-cts-composer-mode]').forEach((node) => node.removeAttribute('data-cts-composer-mode'));
+  document.querySelectorAll('[data-cts-composer-surface-compat]').forEach((node) => {
+    node.classList.remove('composer-surface-chrome');
+    node.removeAttribute('data-cts-composer-surface-compat');
+  });
   document.documentElement?.style.removeProperty('--cts-windows-menu-height');
   document.documentElement?.style.removeProperty('--cts-windows-sidebar-padding-top');
   document.documentElement?.style.removeProperty('--cts-windows-main-padding-top');
@@ -178,6 +182,7 @@ pub const VERIFY_REMOVED_EXPRESSION: &str = r#"(() =>
   !document.querySelector('[data-cts-menu-region]') &&
   !document.querySelector('[data-cts-composer-overflow]') &&
   !document.querySelector('[data-cts-composer-mode]') &&
+  !document.querySelector('[data-cts-composer-surface-compat]') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-menu-height') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-sidebar-padding-top') &&
   !document.documentElement.style.getPropertyValue('--cts-windows-main-padding-top') &&
@@ -281,6 +286,8 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
       mainSurfaceCompatible: Boolean(mainSurfaceNode?.classList.contains('main-surface')),
       stageAttachedToMainSurface: !stage || stage.parentElement === mainSurfaceNode,
       composer,
+      composerSurfaceMode: composerNode?.hasAttribute('data-composer-surface-variant') ? 'current' : (composerNode ? 'legacy' : null),
+      composerSurfaceCompatible: Boolean(composerNode?.classList.contains('composer-surface-chrome')),
       composerOverflow,
       sidebar,
       viewport: {{ width: innerWidth, height: innerHeight }},
@@ -298,6 +305,7 @@ pub fn verify_expression(expected_version: &str) -> Result<String> {
       result.mainSurfaceCompatible &&
       result.stageAttachedToMainSurface &&
       Boolean(result.composer?.visible) &&
+      result.composerSurfaceCompatible &&
       result.composerOverflow?.shellRole === 'shell' &&
       result.composerOverflow?.shellOverflowY === 'clip' &&
       result.composerOverflow?.lanesValid === true &&
@@ -459,6 +467,7 @@ mod tests {
             "data-cts-menu-region",
             "data-cts-composer-overflow",
             "data-cts-composer-mode",
+            "data-cts-composer-surface-compat",
             "--cts-windows-menu-height",
             "--cts-windows-sidebar-padding-top",
             "--cts-windows-main-padding-top",
@@ -491,6 +500,18 @@ mod tests {
     }
 
     #[test]
+    fn payload_supports_current_and_legacy_composer_surfaces() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = build_payload(&fixture_theme(tmp.path())).unwrap();
+        assert!(built.payload.contains("[data-composer-surface-variant][data-composer-layout]"));
+        assert!(built.payload.contains("data-cts-composer-surface-compat"));
+        assert!(built.payload.contains("reconcileComposerSurfaces(document)"));
+        assert!(built.payload.contains("clearComposerSurfaceCompat(document)"));
+        assert!(built.payload.contains(".composer-surface-chrome"));
+        assert!(!built.payload.contains("_ComposerLayoutRoot_"));
+    }
+
+    #[test]
     fn verify_expression_embeds_version() {
         let expr = verify_expression("9.9.9").unwrap();
         assert!(expr.contains("\"9.9.9\""));
@@ -499,6 +520,8 @@ mod tests {
         assert!(expr.contains("mainSurfaceCompatible"));
         assert!(expr.contains("stageAttachedToMainSurface"));
         assert!(expr.contains("composerOverflow"));
+        assert!(expr.contains("composerSurfaceMode"));
+        assert!(expr.contains("composerSurfaceCompatible"));
         assert!(expr.contains("modeValid"));
         assert!(expr.contains("editorValid"));
         assert!(expr.contains("26.727.51351"));

--- a/crates/codex-theme-engine/src/runtime/composer-overflow.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-overflow.mjs
@@ -2,23 +2,68 @@
 // the renderer payload, so keep them self-contained (no module-scope reads).
 
 export function selectComposerSurfaces(root) {
+  // Codex 26.730.61309 introduced the CSS-module surface; the adjacent
+  // 26.727.51351 still used the legacy class (see docs/composer-compatibility.md).
+  // Detect capabilities rather than trusting a version hint or module hash.
+  const current = "[data-composer-surface-variant][data-composer-layout]";
+  const surfaceSelector = `${current}, .composer-surface-chrome`;
+  const editorSelector = '[data-codex-composer], .ProseMirror[contenteditable="true"], ' +
+    '[contenteditable="true"], textarea';
   const unique = (nodes) => [...new Set(nodes.filter(Boolean))];
+  const ownsEditor = (surface) => {
+    if (surface.hasAttribute?.("data-cts-composer-surface-compat") && !surface.matches(current)) {
+      return false;
+    }
+    const editor = surface.querySelector(editorSelector);
+    // Nested surfaces and static utility/review cards must not get a second
+    // frame. Prefer the surface immediately enclosing the actual editor.
+    return Boolean(editor && (!editor.closest || editor.closest(surfaceSelector) === surface));
+  };
   const marked = unique(
     [...root.querySelectorAll("[data-codex-composer]")]
-      .map((node) => node.closest?.(".composer-surface-chrome")),
+      .map((node) => node.closest?.(surfaceSelector)),
   );
   const rooted = unique([
+    ...root.querySelectorAll(`[data-codex-composer-root] ${current}`),
     ...root.querySelectorAll("[data-codex-composer-root] .composer-surface-chrome"),
   ]);
-  const preferred = unique([...marked, ...rooted]);
+  const preferred = unique([...marked, ...rooted]).filter(ownsEditor);
   if (preferred.length) return preferred;
 
   // Older renderers may not expose the stable Composer markers. Retain a
   // capability fallback, but exclude static surfaces that contain no editor.
-  return [...root.querySelectorAll(".composer-surface-chrome")].filter((surface) =>
-    surface.querySelector(
-      '.ProseMirror[contenteditable="true"], [contenteditable="true"], textarea',
-    ));
+  return unique([
+    ...root.querySelectorAll(current),
+    ...root.querySelectorAll(".composer-surface-chrome"),
+  ]).filter(ownsEditor);
+}
+
+export function clearComposerSurfaceCompat(root) {
+  for (const node of root.querySelectorAll("[data-cts-composer-surface-compat]")) {
+    node.classList.remove("composer-surface-chrome");
+    node.removeAttribute("data-cts-composer-surface-compat");
+  }
+}
+
+export function reconcileComposerSurfaces(root) {
+  const surfaces = selectComposerSurfaces(root);
+  const desired = new Set(surfaces.filter((node) =>
+    node.matches("[data-composer-surface-variant][data-composer-layout]")));
+  // Own only aliases we add, so cleanup never removes a native legacy class.
+  // Reconcile on route changes and when React reuses or replaces the surface.
+  for (const node of root.querySelectorAll("[data-cts-composer-surface-compat]")) {
+    if (!desired.has(node)) {
+      node.classList.remove("composer-surface-chrome");
+      node.removeAttribute("data-cts-composer-surface-compat");
+    }
+  }
+  for (const node of desired) {
+    if (!node.classList.contains("composer-surface-chrome")) {
+      node.classList.add("composer-surface-chrome");
+      node.setAttribute("data-cts-composer-surface-compat", "true");
+    }
+  }
+  return surfaces;
 }
 
 export function createComposerOverflowAnnotator({
@@ -46,7 +91,10 @@ export function createComposerOverflowAnnotator({
 
   const nodeSignature = (node) => {
     const className = typeof node.className === "string" ? node.className : "";
-    return `${node.tagName || ""}\u0000${className}\u0000${node.getAttribute("style") || ""}`;
+    const layout = node.getAttribute("data-composer-layout") || "";
+    const overflow = node.getAttribute("data-composer-surface-overflow") || "";
+    return `${node.tagName || ""}\u0000${className}\u0000${node.getAttribute("style") || ""}` +
+      `\u0000${layout}\u0000${overflow}`;
   };
 
   const classify = (composer, path, signature) => {

--- a/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
@@ -255,3 +255,29 @@ test("external style invalidation remeasures an unchanged Composer path", () => 
   assert.equal(shell.getAttribute(MODE_ATTR), "scrolling");
   assert.equal(editor.getAttribute(OVERFLOW_ATTR), "editor");
 });
+
+test("attribute-only Composer layout changes invalidate the cached scroll roles", () => {
+  const shell = new FakeNode("div", {
+    className: "_ComposerLayoutRoot_build_2 composer-surface-chrome",
+    attributes: { "data-composer-layout": "multiline", "data-composer-surface-overflow": "auto" },
+  });
+  const editor = shell.append(new FakeNode("div", {
+    nativeStyle: { overflowY: "auto", maxHeight: "160px" },
+  }));
+  editor.append(new FakeNode("div", { attributes: { "data-codex-composer": "true" } }));
+  const annotate = createComposerOverflowAnnotator({
+    overflowAttribute: OVERFLOW_ATTR,
+    modeAttribute: MODE_ATTR,
+    readStyle: (node) => node.nativeStyle,
+    viewportSignature: () => "1280x800",
+  });
+  annotate([shell]);
+  assert.equal(shell.getAttribute(MODE_ATTR), "scrolling");
+  // Codex reuses the CSS-module classes and changes only its data attributes.
+  shell.setAttribute("data-composer-layout", "singleline");
+  shell.setAttribute("data-composer-surface-overflow", "visible");
+  editor.nativeStyle = { overflowY: "hidden", maxHeight: "none" };
+  annotate([shell]);
+  assert.equal(shell.getAttribute(MODE_ATTR), "single-line");
+  assert.equal(editor.getAttribute(OVERFLOW_ATTR), null);
+});

--- a/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-overflow.test.mjs
@@ -274,7 +274,7 @@ test("attribute-only Composer layout changes invalidate the cached scroll roles"
   annotate([shell]);
   assert.equal(shell.getAttribute(MODE_ATTR), "scrolling");
   // Codex reuses the CSS-module classes and changes only its data attributes.
-  shell.setAttribute("data-composer-layout", "singleline");
+  shell.setAttribute("data-composer-layout", "single-line");
   shell.setAttribute("data-composer-surface-overflow", "visible");
   editor.nativeStyle = { overflowY: "hidden", maxHeight: "none" };
   annotate([shell]);

--- a/crates/codex-theme-engine/src/runtime/composer-surface-compat.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/composer-surface-compat.test.mjs
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { JSDOM } from "jsdom";
+import { test } from "vitest";
+
+import {
+  clearComposerSurfaceCompat,
+  reconcileComposerSurfaces,
+  selectComposerSurfaces,
+} from "./composer-overflow.mjs";
+
+const ATTR = "data-cts-composer-surface-compat";
+const LEGACY = "composer-surface-chrome";
+const runtimeDir = path.join(process.cwd(), "crates/codex-theme-engine/src/runtime");
+const editor = '<div class="ProseMirror" data-codex-composer contenteditable="true"></div>';
+// Surface attribute contract first found in the real 26.730.61309 package,
+// with the editor ancestry captured from the installed 26.901.31953 build.
+// The CSS-module hash deliberately differs from either audited build.
+const current = `
+  <div data-codex-composer-root data-composer-placement="thread">
+    <div class="relative">
+      <div id="surface" class="_ComposerLayoutRoot_future_9"
+        data-composer-layout="multiline" data-composer-surface-variant="default"
+        data-composer-surface-overflow="auto">
+        <div data-composer-layout="multiline"><div class="contents">
+          <div data-composer-layout="multiline" class="flex-grow overflow-y-auto">
+            <div class="rich-input" style="overflow-y:auto;max-height:180px">${editor}</div>
+          </div>
+        </div></div>
+        <button class="size-token-button-composer"><svg></svg></button>
+      </div>
+    </div>
+  </div>`;
+
+function domFor(html = current) {
+  const dom = new JSDOM(
+    `<!doctype html><html><head></head><body>
+      <aside class="app-shell-left-panel"></aside>
+      <main data-app-shell-main-surface>${html}</main>
+    </body></html>`,
+    { pretendToBeVisual: true, runScripts: "outside-only" },
+  );
+  dom.window.matchMedia = () => ({ matches: false, addEventListener() {}, removeEventListener() {} });
+  return dom;
+}
+
+function runtimeExpression(stamp = "test:one") {
+  const helpers = fs.readFileSync(path.join(runtimeDir, "composer-overflow.mjs"), "utf8")
+    .replaceAll("export function ", "function ");
+  return fs.readFileSync(path.join(runtimeDir, "theme-runtime.js"), "utf8")
+    .replace("__CTS_COMPOSER_OVERFLOW_HELPERS__", `(() => { ${helpers}; return {
+      clearComposerSurfaceCompat, createComposerOverflowAnnotator,
+      reconcileComposerSurfaces, selectComposerSurfaces,
+    }; })()`)
+    .replace("__CTS_CSS_JSON__", JSON.stringify(`
+      html.codex-theme-studio .composer-surface-chrome { background: rgb(14,18,14); }
+      html.codex-theme-studio div:has(> .composer-surface-chrome)::before { content: ""; }
+    `))
+    .replace("__CTS_THEME_JSON__", JSON.stringify({ id: "fixture", colors: {}, strings: {} }))
+    .replace("__CTS_CHROME_JSON__", "null")
+    .replace("__CTS_MOTION_JSON__", "{}")
+    .replace("__CTS_VERSION_JSON__", '"test"')
+    .replace("__CTS_STAMP_JSON__", JSON.stringify(stamp));
+}
+
+test("current Composer restores legacy skin selectors without depending on a module hash", () => {
+  const dom = domFor(`<div class="${LEGACY}">static review card</div>${current}`);
+  try {
+    const document = dom.window.document;
+    const surface = document.getElementById("surface");
+    assert.deepEqual(selectComposerSurfaces(document), [surface]);
+    assert.equal(document.querySelector("div:has(> #surface)").matches(`div:has(> .${LEGACY})`), false);
+    assert.deepEqual(reconcileComposerSurfaces(document), [surface]);
+    assert.equal(surface.getAttribute(ATTR), "true");
+    assert.equal(surface.parentElement.matches(`div:has(> .${LEGACY})`), true);
+    assert.equal(document.querySelector(`.${LEGACY} button[class*="size-token-button-composer"]`)?.tagName, "BUTTON");
+  } finally { dom.window.close(); }
+});
+
+test("native legacy surfaces survive reconciliation and cleanup unchanged", () => {
+  const dom = domFor(`<div data-codex-composer-root><div id="legacy" class="${LEGACY}">${editor}</div></div>`);
+  try {
+    const document = dom.window.document;
+    const before = document.body.innerHTML;
+    assert.deepEqual(reconcileComposerSurfaces(document), [document.getElementById("legacy")]);
+    clearComposerSurfaceCompat(document);
+    assert.equal(document.body.innerHTML, before);
+  } finally { dom.window.close(); }
+});
+
+test("a native legacy class on a current surface is not owned or removed", () => {
+  const dom = domFor(current);
+  try {
+    const document = dom.window.document;
+    const surface = document.getElementById("surface");
+    surface.classList.add(LEGACY);
+    reconcileComposerSurfaces(document);
+    assert.equal(surface.hasAttribute(ATTR), false);
+    clearComposerSurfaceCompat(document);
+    assert.equal(surface.classList.contains(LEGACY), true);
+  } finally { dom.window.close(); }
+});
+
+test("static current surfaces, misleading hashes, and nested wrappers get no duplicate frame", () => {
+  const dom = domFor(`
+    <div class="_ComposerLayoutRoot_fake">${editor}</div>
+    <div data-composer-layout="multiline" data-composer-surface-variant="default">utility bar</div>
+    <div id="outer" data-composer-layout="multiline" data-composer-surface-variant="default">${current}</div>
+  `);
+  try {
+    const document = dom.window.document;
+    assert.deepEqual(reconcileComposerSurfaces(document), [document.getElementById("surface")]);
+    assert.equal(document.querySelectorAll(`[${ATTR}]`).length, 1);
+    assert.equal(document.getElementById("outer").classList.contains(LEGACY), false);
+  } finally { dom.window.close(); }
+});
+
+test("unmarked older editors still use the capability fallback", () => {
+  const dom = domFor(`<div class="${LEGACY}">card</div><div id="legacy" class="${LEGACY}"><textarea></textarea></div>`);
+  try {
+    assert.deepEqual(selectComposerSurfaces(dom.window.document), [dom.window.document.getElementById("legacy")]);
+  } finally { dom.window.close(); }
+});
+
+test("reconciliation is write-free when unchanged and repairs React class replacement", () => {
+  const dom = domFor(current);
+  try {
+    const document = dom.window.document;
+    const surface = document.getElementById("surface");
+    reconcileComposerSurfaces(document);
+    const observer = new dom.window.MutationObserver(() => {});
+    observer.observe(document.body, { attributes: true, childList: true, subtree: true });
+    reconcileComposerSurfaces(document);
+    assert.deepEqual(observer.takeRecords(), []);
+    surface.className = "_ComposerLayoutRoot_replaced_6";
+    reconcileComposerSurfaces(document);
+    assert.equal(surface.classList.contains(LEGACY), true);
+    observer.disconnect();
+  } finally { dom.window.close(); }
+});
+
+test("aliases are released when React repurposes the node or removes its editor", () => {
+  for (const change of [
+    (surface) => surface.removeAttribute("data-composer-surface-variant"),
+    (surface) => surface.querySelector("[data-codex-composer]").remove(),
+  ]) {
+    const dom = domFor(current);
+    try {
+      const document = dom.window.document;
+      const surface = document.getElementById("surface");
+      reconcileComposerSurfaces(document);
+      change(surface);
+      assert.deepEqual(reconcileComposerSurfaces(document), []);
+      assert.equal(surface.classList.contains(LEGACY), false);
+      assert.equal(surface.hasAttribute(ATTR), false);
+    } finally { dom.window.close(); }
+  }
+});
+
+test("multiple active Composers reconcile independently and cleanup restores original markup", () => {
+  const dom = domFor(current + current.replace('id="surface"', 'id="second"'));
+  try {
+    const document = dom.window.document;
+    const before = document.body.innerHTML;
+    assert.equal(reconcileComposerSurfaces(document).length, 2);
+    assert.equal(document.querySelectorAll(`[${ATTR}]`).length, 2);
+    clearComposerSurfaceCompat(document);
+    assert.equal(document.body.innerHTML, before);
+  } finally { dom.window.close(); }
+});
+
+test("production runtime hot-switch and removal own and release the compatibility aliases", () => {
+  const dom = domFor(current);
+  try {
+    const document = dom.window.document;
+    const surface = document.getElementById("surface");
+    dom.window.eval(runtimeExpression());
+    assert.equal(surface.classList.contains(LEGACY), true);
+    assert.equal(surface.getAttribute("data-cts-composer-overflow"), "shell");
+    assert.equal(surface.getAttribute("data-cts-composer-mode"), "scrolling");
+    assert.equal(surface.querySelectorAll('[data-cts-composer-overflow="editor"]').length, 1);
+    dom.window.eval(runtimeExpression("test:two"));
+    assert.equal(surface.classList.contains(LEGACY), true);
+    dom.window.__CODEX_THEME_STUDIO__.cleanup();
+    assert.equal(surface.className, "_ComposerLayoutRoot_future_9");
+    assert.equal(document.querySelector(`[${ATTR}], [data-cts-composer-overflow]`), null);
+    assert.equal(document.getElementById("cts-style"), null);
+  } finally { dom.window.close(); }
+});
+
+test("fallback removal expression clears only runtime-owned surface aliases", () => {
+  const dom = domFor(current + `<div class="${LEGACY}" id="native">${editor}</div>`);
+  try {
+    reconcileComposerSurfaces(dom.window.document);
+    const source = fs.readFileSync(path.join(runtimeDir, "../payload.rs"), "utf8");
+    const expression = source.match(/pub const REMOVE_EXPRESSION: &str = r#"([\s\S]*?)"#;/)?.[1];
+    assert.ok(expression);
+    assert.equal(dom.window.eval(expression), true);
+    assert.equal(dom.window.document.getElementById("surface").classList.contains(LEGACY), false);
+    assert.equal(dom.window.document.getElementById("native").classList.contains(LEGACY), true);
+  } finally { dom.window.close(); }
+});
+
+test("production observer reconciles a Composer mounted after a settings route", async () => {
+  const dom = domFor("");
+  try {
+    dom.window.eval(runtimeExpression());
+    dom.window.document.querySelector("main").innerHTML = current;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    assert.equal(dom.window.document.getElementById("surface").classList.contains(LEGACY), true);
+    dom.window.__CODEX_THEME_STUDIO__.cleanup();
+  } finally { dom.window.close(); }
+});

--- a/crates/codex-theme-engine/src/runtime/theme-runtime-motion.test.mjs
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime-motion.test.mjs
@@ -10,12 +10,14 @@ const TEMPLATE_PATH = path.join(
   "crates/codex-theme-engine/src/runtime/theme-runtime.js",
 );
 const HELPERS = `({
+  clearComposerSurfaceCompat: () => {},
   createComposerOverflowAnnotator: () => {
     const annotate = () => {};
     annotate.invalidate = () => {};
     return annotate;
   },
   selectComposerSurfaces: () => [],
+  reconcileComposerSurfaces: () => [],
 })`;
 const CSS = `
 html.codex-theme-studio {

--- a/crates/codex-theme-engine/src/runtime/theme-runtime.js
+++ b/crates/codex-theme-engine/src/runtime/theme-runtime.js
@@ -22,7 +22,9 @@
   const COMPOSER_OVERFLOW_ATTR = "data-cts-composer-overflow";
   const COMPOSER_MODE_ATTR = "data-cts-composer-mode";
   const {
+    clearComposerSurfaceCompat,
     createComposerOverflowAnnotator,
+    reconcileComposerSurfaces,
     selectComposerSurfaces,
   } = __CTS_COMPOSER_OVERFLOW_HELPERS__;
   const RUNTIME_CSS = `
@@ -86,6 +88,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     .forEach((node) => node.removeAttribute(COMPOSER_OVERFLOW_ATTR));
   document.querySelectorAll(`[${COMPOSER_MODE_ATTR}]`)
     .forEach((node) => node.removeAttribute(COMPOSER_MODE_ATTR));
+  clearComposerSurfaceCompat(document);
 
   // Split the chrome fragment into its layers: "overlay" floats above the UI
   // (fixed, z31), "stage" is scenery mounted inside main UNDER the content.
@@ -379,8 +382,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
         if (button.dataset.ctsLogo !== want) button.dataset.ctsLogo = want;
       }
     }
-    const composer = document.querySelector(".composer-surface-chrome");
-    if (composer) {
+    for (const composer of selectComposerSurfaces(document)) {
       for (const button of composer.querySelectorAll("button:not([data-cts-icon])")) {
         const aria = button.getAttribute("aria-label") || "";
         const text = button.textContent || "";
@@ -478,8 +480,9 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     if (home) setClass(home, "cts-home", true);
     if (shellMain) setClass(shellMain, "cts-home-shell", Boolean(home));
 
+    const composers = reconcileComposerSurfaces(document);
     annotateIcons();
-    annotateComposerOverflow(selectComposerSurfaces(document));
+    annotateComposerOverflow(composers);
 
     const fillTexts = (rootNode) => {
       for (const node of rootNode.querySelectorAll("[data-cts-text]")) {
@@ -582,6 +585,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
       .forEach((node) => node.removeAttribute(COMPOSER_OVERFLOW_ATTR));
     document.querySelectorAll(`[${COMPOSER_MODE_ATTR}]`)
       .forEach((node) => node.removeAttribute(COMPOSER_MODE_ATTR));
+    clearComposerSurfaceCompat(document);
     document.getElementById(STYLE_ID)?.remove();
     document.getElementById(CHROME_ID)?.remove();
     document.getElementById(STAGE_ID)?.remove();
@@ -617,7 +621,7 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
       document.documentElement.style.getPropertyPriority(name)}`)
     .join(";");
   const styleMutationTouchesComposer = (target) => Boolean(
-    target.closest?.(".composer-surface-chrome") ||
+    target.closest?.(".composer-surface-chrome, [data-composer-surface-variant][data-composer-layout]") ||
     target.querySelector?.(
       '[data-codex-composer], .ProseMirror[contenteditable="true"], ' +
       '[contenteditable="true"], textarea',
@@ -649,7 +653,12 @@ html.codex-theme-studio .cts-windows-menu-bar [data-cts-menu-region="main"] {
     childList: true,
     subtree: true,
     attributes: true,
-    attributeFilter: ["class", "style", "data-theme", "data-appearance", "data-color-mode"],
+    attributeFilter: [
+      "class", "style", "data-theme", "data-appearance", "data-color-mode",
+      "data-composer-layout", "data-composer-surface-overflow",
+      "data-composer-surface-variant", "data-composer-radius-variant",
+      "data-composer-utility-bar-variant",
+    ],
   });
   const timer = setInterval(() => {
     annotateComposerOverflow.invalidate();

--- a/docs/composer-compatibility.md
+++ b/docs/composer-compatibility.md
@@ -1,0 +1,57 @@
+# Codex 输入框素材兼容性
+
+## 26.730.61309 结构边界
+
+2026-09-04 对 Codex App Mirror 保存的相邻 macOS 正式版 Sparkle ZIP 进行只读提取，核对 `Info.plist`、ASAR 内的 `package.json` 和实际创建输入框表层的函数：
+
+| Codex 版本 | build | 输入框表层 |
+| --- | --- | --- |
+| [26.727.51351](https://github.com/Wangnov/codex-app-mirror/releases/tag/codex-app-26.727.51351) | 6119 | 直接构造 `composer-surface-chrome`；首页通过 utility bar context 传递该类 |
+| [26.730.61309](https://github.com/Wangnov/codex-app-mirror/releases/tag/codex-app-26.730.61309) | 6223 | 改用 `_ComposerLayoutRoot_uo8w3_2`，并输出 `data-composer-layout`、`data-composer-surface-variant` 等语义属性；输入框表层不再附带旧类 |
+| 本机 26.901.31953 | 7868 | 同一语义属性契约，CSS-module 类为 `_ComposerLayoutRoot_kbwao_2`；已完成真实界面注入、检查和恢复 |
+
+镜像中首次采用新结构的 macOS 正式版本是 **26.730.61309**，不是本次刚更新的 26.901 系列。
+同时抽检的 26.730.61639、26.803.41515、26.810.52044、26.818.61809、26.820.80927、26.825.51511 包也已使用新结构。
+这里的首次版本依据是相邻 macOS 正式包；未运行历史 Windows 安装包，不将该证据表述为 Windows 实机验证。
+
+边界包中仍能搜索到 `composer-surface-chrome`，但它出现在静态 review card、utility bar 或浮动输入框把手中。仅统计字符串是否存在会误判，必须检查实际输入框组件的 `className` 和属性构造。
+
+### 包校验与复核位置
+
+按 ZIP 中央目录定位 `ChatGPT.app/Contents/Resources/app.asar` 和 `Info.plist`，范围下载压缩条目后，验证解压大小与中央目录 CRC32；再核对包内版本并计算 SHA-256。没有安装或运行历史包，也没有修改本机 Codex 安装文件。
+
+| 版本 | ASAR 大小（字节） | ASAR CRC32（十进制） | 组件所在 chunk |
+| --- | --- | --- | --- |
+| 26.727.51351 | 218370611 | 2910382013 | `webview/assets/app-initial-iBPGfcXU.js` |
+| 26.730.61309 | 219943419 | 1633413362 | `webview/assets/app-initial-YjNFxVhk.js` |
+
+- 26.727.51351 ASAR SHA-256：`a529edd72e10b08931c0d695b5e3e6a0be7f51874610dafc04f578436ab7d74d`。
+- 26.730.61309 ASAR SHA-256：`9de942a9a058fca20b78d171032e0fe65ccb1063868f175ff7eb4e159efc2c38`。
+- 本机 26.901.31953 ASAR SHA-256：`4b385ffce845bb319a1769a3cb59751e1a8f157bab79f5018ba51d83f9e6df4e`；输入框组件位于 `webview/assets/app-primary-37ff25fd4643.js`。
+
+## 根因与适配约束
+
+Elon Mars Protocol 皮肤包含完整的 `composer-deck.webp`、`deck-slim.webp` 和 `send-starship.webp`。本机注入的图片数据与原始素材一致；问题不在素材缺失或 CDP 断连，而在皮肤的边框、发送按钮和图标选择器依赖旧的 `.composer-surface-chrome`。
+
+Manager 0.5.6 从上述已确认边界的新 DOM 契约补充适配，并保留旧类路径：
+
+- 以 `[data-composer-surface-variant][data-composer-layout]` 和实际编辑区能力定位新输入框，优先使用 Codex 的 composer 标记与根节点，不依赖每次构建都会变化的 CSS-module hash。
+- 仅向有效的新输入框补上旧样式类，并标记 `data-cts-composer-surface-compat` 归属。静态 review card、无编辑区表层及嵌套外框不误加第二层装饰。
+- 重复检查在 DOM 未变时不写属性；React 重建 class、任务切换或输入框重挂载后重新协调。节点失去输入框能力时撤销归属。
+- 沿用编辑区、滚动通道、外壳的分层处理；仅布局/overflow 属性变化也会重新分类，避免多行输入滚动到外壳。
+- 关闭皮肤或切换时清理自身新增的类与标记；旧版自带的类不占有、不删除。Rust 回退卸载路径也执行相同清理。
+
+版本边界用于说明和回归证据，运行时仍按实际 DOM 能力判定：旧版本提示、未知新版本和不同平台不会因版本字符串而被错误拒绝；这不等于承诺兼容未来任意结构变化。
+此问题与 [26.901 设置桥接接口变化](native-settings-compatibility.md) 是两个独立的兼容点。
+
+## 验证
+
+- 单元测试执行生产 runtime 和 Rust 卸载表达式，覆盖新旧表层、hash 变化、静态/嵌套节点排除、多输入框、重挂载、热切换、幂等与完整清理。
+- 本机 Codex 26.901.31953 + Elon Mars Protocol：使用 Rust 实际打包的 payload 短暂注入后，输入框材质边框、发送按钮图片和 `LAUNCH` 装饰恢复；结构验证通过，输入框可聚焦，外壳 `overflow: clip`，编辑区 `overflow-y: auto`。随后恢复原运行时，没有发送消息或写入应用安装文件；这不是已安装新版 Manager 的端到端测试。
+- 将真实当前输入框 DOM 与原生 CSS 放入隔离 Chromium，清空编辑内容后执行相同生产 payload：1100×800 深色、640×700 深色、1100×800 浅色均通过。输入测试文本、增加至 28 行、滚动、切换布局属性、重复应用和卸载均符合预期；没有相关 console 错误、框架错误遮罩或页面横向溢出。
+- 历史包用于静态结构对比；未执行旧版完整应用，也未在真实 Windows Codex 中试穿皮肤。
+
+```sh
+npm test -- crates/codex-theme-engine/src/runtime
+cargo test --manifest-path crates/codex-theme-engine/Cargo.toml --locked --all-targets
+```

--- a/docs/releases/v0.5.6.md
+++ b/docs/releases/v0.5.6.md
@@ -1,0 +1,44 @@
+<p align="center">
+  <a href="https://codexapp.agentsmirror.com">
+    <img src="https://raw.githubusercontent.com/Wangnov/Codex-App-Manager/main/assets/banner.svg" alt="Codex App Manager" width="100%">
+  </a>
+</p>
+
+> 恢复新版 Codex 中皮肤的输入框材质边框、发送按钮和相关图标，同时保留旧版兼容。
+> Restore skinned Composer frames, send buttons, and related icons in newer Codex builds while preserving compatibility with older versions.
+
+## 🐛 修复 · Fixes
+
+- **输入框装饰不再消失**：修复 Codex 输入框结构变化后，背景已生效但输入框仍是原生样式的问题；经相邻 macOS 正式包对比，变化始于 **26.730.61309**。包括 Elon Mars Protocol 在内的现有皮肤可重新显示材质边框和发送按钮素材，无需重新下载或制作皮肤。
+  Fix a Composer structure change that left the background themed but the input box unskinned, first observed in **26.730.61309** by comparing adjacent official macOS packages. Existing skins, including Elon Mars Protocol, regain their material frames and send-button artwork without needing to be recreated or downloaded again.
+
+- **切换与输入保持稳定**：兼容层支持任务页面切换和输入框重建，保留多行编辑区独立滚动；关闭皮肤时清理新增的适配标记，不改写 Codex 安装文件，也不移除旧版本自带的样式类。
+  The compatibility layer follows navigation and Composer remounts while keeping multiline scrolling inside the editor. Disabling a skin removes only runtime-owned compatibility markers, without modifying Codex app files or stripping native classes from older builds.
+
+## 📦 安装与升级 · Install & Upgrade
+
+**已经安装?** 打开应用即可收到本次更新——macOS 只下载版本间的增量,校验失败自动回滚。
+**Already installed?** The app offers this update in-app — macOS pulls only the delta, with automatic rollback.
+
+| 平台 · Platform | 下载 · Download(国内直连 · China-reachable) |
+| --- | --- |
+| macOS · Apple Silicon | [CodexAppManager_aarch64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_aarch64.dmg) |
+| macOS · Intel | [CodexAppManager_x86_64.dmg](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x86_64.dmg) |
+| Windows · x64 | [CodexAppManager_x64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_x64-setup.exe) |
+| Windows · ARM64 | [CodexAppManager_arm64-setup.exe](https://codexapp.agentsmirror.com/manager/latest/CodexAppManager_arm64-setup.exe) |
+
+**Windows 签名状态:** 本版 `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` 没有 Authenticode 代码签名,首次运行可能出现 SmartScreen 提示;`.sig` / `latest.json` 的 Tauri updater 签名只校验更新字节,不代表 Windows 发行者身份。SignPath Foundation 申请仍在审核。参见 [代码签名政策](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md)与 [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md)。
+**Windows signing status:** This release's `CodexAppManager_x64-setup.exe` / `CodexAppManager_arm64-setup.exe` are not Authenticode-signed, so SmartScreen may warn on first run. The Tauri updater signature in `.sig` / `latest.json` verifies update bytes only and is not Windows publisher identity. The SignPath Foundation application is pending. See the [code signing policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/code-signing-policy.md) and [Windows signing and verification](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/windows-signing.md).
+
+**隐私 · Privacy:** [隐私政策 · Privacy policy](https://github.com/Wangnov/Codex-App-Manager/blob/main/docs/privacy.md)
+
+**核验下载:** 本页 Assets 带有 `SHA256SUMS`;Windows 用 `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` 或替换为 ARM64 文件名,macOS 用 `shasum -a 256 CodexAppManager_aarch64.dmg`,再与 `SHA256SUMS` 比对。
+**Verify downloads:** This release includes `SHA256SUMS` in Assets; on Windows run `Get-FileHash .\CodexAppManager_x64-setup.exe -Algorithm SHA256` or swap in the ARM64 filename, and on macOS run `shasum -a 256 CodexAppManager_aarch64.dmg`, then compare with `SHA256SUMS`.
+
+```bash
+# macOS · Homebrew
+brew install --cask wangnov/tap/codex-app-manager
+```
+
+> 镜像直链恒指向**最新**版本;如需本页对应的历史版本,请使用下方 Assets。`.app.tar.gz` / `.sig` / `latest.json` 是自动更新器的工件,手动安装请选 `.dmg` / `.exe`。
+> Mirror permalinks always resolve to the **latest** release — for this exact version use the assets below. `.app.tar.gz` / `.sig` / `latest.json` belong to the auto-updater; pick the `.dmg` / `.exe` for manual installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-app-manager",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tauri-apps/api": "2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-app-manager",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-manager"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "base64 0.23.1",
  "codex-mac-engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ name = "codex-app-manager"
 # would otherwise ride along in the production app. default-run is kept
 # defensively to pin `cargo run` to the app should another src/bin/* be added.
 default-run = "codex-app-manager"
-version = "0.5.5"
+version = "0.5.6"
 description = "A cross-platform manager for installing and updating mirrored official Codex desktop app packages."
 authors = ["Wangnov"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex App Manager",
   "mainBinaryName": "codex-app-manager",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "identifier": "io.github.wangnov.codexappmanager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## 变更

- 修复新版 Codex 输入框缺少旧样式类后，Elon Mars Protocol 等皮肤的材质边框、发送按钮和相关图标不生效的问题。
- 以真实相邻 macOS Sparkle 包确认结构边界：26.727.51351 / build 6119 仍使用旧类，26.730.61309 / build 6223 首次改用 CSS-module + 语义属性。详情及包校验值见 `docs/composer-compatibility.md`。
- 运行时按实际 DOM 能力适配，保留旧版路径；支持 React 重挂载、多输入框、幂等协调及完全清理，不修改 Codex 安装文件。
- 版本号六处同步至 0.5.6，并添加双语发行说明。

## 验证

- `npm run check`、`npm run lint`、`npm test`（387 项）及 `npm run build` 通过。
- Rust Clippy（warnings-as-errors）通过；Manager 与三个引擎合计 332 项单元测试通过。
- `codex review --uncommitted` 多轮审查无明确缺陷；最终测试夹具与真实 `single-line` 布局值一致。
- 本机 Codex 26.901.31953 使用 Rust 实际构建的 payload，确认材质边框、发送按钮、LAUNCH 装饰与编辑区独立滚动恢复；验证后恢复原运行时，未发送消息或替换已安装 Manager。
- 隔离 Chromium 使用真实输入框 DOM / 原生 CSS，验证 1100×800 深色、640×700 深色、1100×800 浅色；覆盖输入、28 行滚动、布局切换、重复应用、卸载及无相关控制台错误。
- 4 项需外部环境的 Rust 集成测试未作为默认测试运行；历史包仅做静态结构对比，未执行历史 Windows Codex 实机试穿。

## 发布

等待所有 CI、macOS packaged smoke 和 Windows NSIS 门禁通过后 squash 合并；在合并后的 main HEAD 创建 annotated tag `v0.5.6`，由现有四平台发布工作流构建、签名、公证及同步镜像。
